### PR TITLE
MODOAIPMH-70: Integration tests

### DIFF
--- a/gulfstream/src/test/java/org/folio/GulfstreamTests.java
+++ b/gulfstream/src/test/java/org/folio/GulfstreamTests.java
@@ -39,6 +39,15 @@ class GulfstreamTests {
     }
 
     @Test
+    void oaiPmhMarWithHoldingsTests() throws IOException {
+        Results results = Runner.path("classpath:domain/oaipmh/oaipmh-q3-marc_withholdings.feature")
+                .tags("~@Ignore")
+                .parallel(1);
+        generateReport(results.getReportDir());
+        assert results.getFailCount() == 0;
+    }
+
+    @Test
     void loadDefaultConfigurationTests() throws IOException {
         Results results = Runner.path("classpath:domain/mod-configuration/load-default-pmh-configuration.feature.feature")
                 .tags("~@Ignore")

--- a/gulfstream/src/test/resources/domain/oaipmh/oaipmh-q3-marc_withholdings.feature
+++ b/gulfstream/src/test/resources/domain/oaipmh/oaipmh-q3-marc_withholdings.feature
@@ -1,0 +1,46 @@
+Feature: Test enhancements to oai-pmh
+
+  Background:
+    * table modules
+      | name                              |
+      | 'mod-permissions'                 |
+      | 'mod-oai-pmh'                     |
+      | 'mod-login'                       |
+      | 'mod-configuration'               |
+      | 'mod-source-record-storage'       |
+
+    * table userPermissions
+      | name                              |
+      | 'oai-pmh.all'                     |
+      | 'configuration.all'               |
+      | 'inventory-storage.all'           |
+      | 'source-storage.all'              |
+
+    * def pmhUrl = baseUrl + '/oai/records'
+    * url pmhUrl
+#    * call destroyData {tenant: 'oaipmh_test_tenant1482'}
+        * configure afterFeature =  function(){ karate.call(destroyData, {tenant: testUser.tenant})}
+    #=========================SETUP================================================
+    * callonce read('classpath:common/tenant.feature@create')
+    * callonce read('classpath:common/tenant.feature@install') { modules: '#(modules)', tenant: '#(testUser.tenant)'}
+    * callonce read('classpath:common/setup-users.feature')
+    * callonce read('classpath:common/login.feature') testUser
+    * def testUserToken = responseHeaders['x-okapi-token'][0]
+    * callonce read('classpath:global/init_data/mod_configuration_init_data.feature')
+    * callonce read('classpath:global/init_data/mod_inventory_init_data.feature')
+    #=========================SETUP=================================================
+    * callonce resetConfiguration
+    * configure headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(testUserToken)', 'x-okapi-tenant': '#(testUser.tenant)' }
+
+  Scenario Outline: [Q3] request instance records identifiers should query inventory for <prefix>
+    And param verb = 'ListIdentifiers'
+    And param metadataPrefix = <prefix>
+    And header Accept = 'text/xml'
+    When method GET
+    Then status 200
+    * match response count(//identifier) == 10
+
+    Examples:
+      | prefix                |
+      | 'marc21'              |
+      | 'oai_dc'              |

--- a/gulfstream/src/test/resources/karate-config.js
+++ b/gulfstream/src/test/resources/karate-config.js
@@ -59,6 +59,8 @@ function fn() {
   config.runId = karate.properties['runId'] ? karate.properties['runId'] : config.random(10000);
   config.testTenant = 'oaipmh_test_tenant' +  config.runId
   karate.log('===RUNNING TESTS IN ENVIRONMENT===' + env);
+  karate.log('===TENANT===' + config.testTenant);
+
 
   config.testUser = {tenant: config.testTenant, name: 'test-user', password: 'test', id: '00000000-1111-5555-9999-999999999991'}
 


### PR DESCRIPTION
1. Scenario – request instance records identifiers

    Given instance record source=FOLIO or MARC
    And instance create/update/delete date fits OAI-PMH request parameters (from/until)
    And instance record can be exposed according to suppressed and deleted records support rules
    When OAI-PMH request verb=ListIdentifiers
    And metadataPrefix = marc21 or oai_dc
    Then the record’s identifier is present in ListIdentifiers response

2. Scenario – request identifiers of instance records with holdings and items

    Given instance record source= FOLIO or MARC
    And instance create/update/delete date or its holdings/items create/update/delete date fits OAI-PMH request parameters (from/until)
    And instance record can be exposed according to suppressed and deleted records support rules
    When OAI-PMH request verb=ListIdentifiers
    And metadataPrefix = marc21_withholdings
    Then the record’s identifier is present in ListIdentifiers response

