### PR TITLE
FAT-128 Add API tests for profiles

### DIFF
--- a/mod-data-export/src/test/java/org/folio/ModDataExportApiTest.java
+++ b/mod-data-export/src/test/java/org/folio/ModDataExportApiTest.java
@@ -5,8 +5,12 @@ import org.folio.testrail.config.TestModuleConfiguration;
 import org.folio.testrail.services.TestRailIntegrationService;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
 
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class ModDataExportApiTest extends AbstractTestRailIntegrationTest {
 
     private static final long TEST_SUITE_ID = 114L;
@@ -20,14 +24,29 @@ class ModDataExportApiTest extends AbstractTestRailIntegrationTest {
     }
 
     @Test
+    @Order(1)
     void quickExportTest() {
         runFeatureTest("quick-export");
     }
 
     @Test
+    @Order(2)
     void deleteJobExecutionTest() {
         runFeatureTest("delete-job-execution");
     }
+
+    @Test
+    @Order(3)
+    void mappingProfilesTest() {
+        runFeatureTest("mapping-profiles");
+    }
+
+    @Test
+    @Order(4)
+    void jobProfilesTest() {
+        runFeatureTest("job-profiles");
+    }
+
 
     @BeforeAll
     public void modDataExportTestsBeforeAll() {

--- a/mod-data-export/src/test/resources/domain/dataexport/features/job-profiles.feature
+++ b/mod-data-export/src/test/resources/domain/dataexport/features/job-profiles.feature
@@ -1,0 +1,83 @@
+Feature: Test job profiles
+
+  Background:
+    * url baseUrl
+
+    * callonce login testAdmin
+    * def okapiAdminToken = okapitoken
+
+    * callonce login testUser
+    * def okapiUserToken = okapitoken
+
+    # load variables
+    * callonce variables
+    * json jobProfile = read('classpath:samples/job_profile.json')
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapiUserToken)', 'Accept': 'application/json'  }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapiAdminToken)', 'Accept': 'application/json'  }
+    * configure headers = headersUser
+
+  Scenario: Test creating job profile
+
+    Given path 'data-export/job-profiles'
+    And request jobProfile
+    When method POST
+    Then status 201
+    And match response.id == '#present'
+    And match response.name == '#present'
+    And match response.userInfo == '#present'
+
+  Scenario: Test update job profile
+
+    Given path 'data-export/job-profiles', jobProfile.id
+    * configure headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapiUserToken)', 'Accept': 'text/plain' }
+    And request jobProfile
+    And set jobProfile.name = 'Updated APITest-JobProfile'
+    When method PUT
+    Then status 204
+
+  Scenario: Test get updated job profile
+
+    Given path 'data-export/job-profiles', jobProfile.id
+    When method GET
+    Then status 200
+    And match  response.name contains 'Updated APITest-JobProfile'
+
+  Scenario: Test get job profile by query
+
+    Given path 'data-export/job-profiles'
+    And param query = 'id==' + jobProfile.id
+    When method GET
+    Then status 200
+    And match  response.jobProfiles[0].id contains jobProfile.id
+    And match  response.totalRecords contains 1
+
+  Scenario: Test get default job profile by id
+
+    Given path 'data-export/job-profiles', defaultJobProfileId
+    When method GET
+    Then status 200
+    Then print response
+    And match  response.id contains defaultJobProfileId
+    And match  response.name contains 'Default job profile'
+    And match  response.description contains 'Default job profile'
+    And match  response.mappingProfileId contains defaultMappingProfileId
+
+  Scenario: Test update default job profile
+
+    Given path 'data-export/job-profiles', defaultJobProfileId
+    * configure headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapiUserToken)', 'Accept': 'text/plain' }
+    And request jobProfile
+    And set jobProfile.id = defaultJobProfileId
+    When method PUT
+    Then status 403
+    And match response contains 'Editing of default job profile is forbidden'
+
+  Scenario: Test delete default job profile
+
+    Given path 'data-export/job-profiles', defaultJobProfileId
+    * configure headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapiUserToken)', 'Accept': 'text/plain' }
+    When method DELETE
+    Then status 403
+    And match response contains 'Deletion of default job profile is forbidden'
+

--- a/mod-data-export/src/test/resources/domain/dataexport/features/mapping-profiles.feature
+++ b/mod-data-export/src/test/resources/domain/dataexport/features/mapping-profiles.feature
@@ -1,0 +1,85 @@
+Feature: Test mapping profiles
+
+  Background:
+    * url baseUrl
+
+    * callonce login testAdmin
+    * def okapiAdminToken = okapitoken
+
+    * callonce login testUser
+    * def okapiUserToken = okapitoken
+
+    # load variables
+    * callonce variables
+    * json mappingProfile = read('classpath:samples/mapping_profile.json')
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapiUserToken)', 'Accept': 'application/json'  }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapiAdminToken)', 'Accept': 'application/json'  }
+    * configure headers = headersUser
+
+  Scenario: Test creating mapping profile
+
+    Given path 'data-export/mapping-profiles'
+    And request mappingProfile
+    When method POST
+    Then status 201
+    And match response.id == '#present'
+    And match response.name == '#present'
+    And match response.userInfo == '#present'
+    And match response.transformations == '#present'
+
+  Scenario: Test update mapping profile
+
+    Given path 'data-export/mapping-profiles', mappingProfile.id
+    * configure headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapiUserToken)', 'Accept': 'text/plain' }
+    And request mappingProfile
+    And set mappingProfile.description = 'Updated mapping profile description'
+    When method PUT
+    Then status 204
+
+  Scenario: Test get updated mapping profile
+
+    Given path 'data-export/mapping-profiles', mappingProfile.id
+    When method GET
+    Then status 200
+    And match  response.description contains 'Updated mapping profile description'
+
+  Scenario: Test get mapping profile by query
+
+    Given path 'data-export/mapping-profiles'
+    And param query = 'id==' + mappingProfile.id
+    When method GET
+    Then status 200
+    And match  response.mappingProfiles[0].id contains mappingProfile.id
+    And match  response.totalRecords contains 1
+
+  Scenario: Test get default mapping profile by id
+
+    Given path 'data-export/mapping-profiles', defaultMappingProfileId
+    When method GET
+    Then status 200
+    Then print response
+    And match  response.id contains defaultMappingProfileId
+    And match  response.recordTypes[0] contains 'INSTANCE'
+    And match  response.name contains 'Default instance mapping profile'
+    And match  response.description contains 'Default mapping profile for the inventory instance record'
+    And match  response.outputFormat contains 'MARC'
+
+  Scenario: Test update default mapping profile
+
+    Given path 'data-export/mapping-profiles', defaultMappingProfileId
+    * configure headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapiUserToken)', 'Accept': 'text/plain' }
+    And request mappingProfile
+    And set mappingProfile.id = defaultMappingProfileId
+    When method PUT
+    Then status 403
+    And match response contains 'Editing of default mapping profile is forbidden'
+
+  Scenario: Test delete default mapping profile
+
+    Given path 'data-export/mapping-profiles', defaultMappingProfileId
+    * configure headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapiUserToken)', 'Accept': 'text/plain' }
+    When method DELETE
+    Then status 403
+    And match response contains 'Deletion of default mapping profile is forbidden'
+

--- a/mod-data-export/src/test/resources/global/variables.feature
+++ b/mod-data-export/src/test/resources/global/variables.feature
@@ -1,0 +1,5 @@
+Feature: Global variables
+
+  Scenario: variables
+    * def defaultMappingProfileId = '25d81cbe-9686-11ea-bb37-0242ac130002'
+    * def defaultJobProfileId = '6f7f3cd7-9f24-42eb-ae91-91af1cd54d0a'

--- a/mod-data-export/src/test/resources/karate-config.js
+++ b/mod-data-export/src/test/resources/karate-config.js
@@ -17,6 +17,7 @@ function fn() {
     // define global features
     login: karate.read('classpath:common/login.feature'),
     dev: karate.read('classpath:common/dev.feature'),
+    variables: karate.read('classpath:global/variables.feature'),
 
     getJobExecutions: karate.read('classpath:domain/dataexport/features/get-job-execution.feature'),
 

--- a/mod-data-export/src/test/resources/samples/job_profile.json
+++ b/mod-data-export/src/test/resources/samples/job_profile.json
@@ -1,0 +1,7 @@
+{
+  "id":"cf971c00-54bd-11eb-ae93-0242ac130002",
+  "name":"APITest-JobProfile",
+  "destination": "fileSystem",
+  "description": "Job profile for API tests",
+  "mappingProfileId": "0b648404-54c1-11eb-ae93-0242ac130002"
+}

--- a/mod-data-export/src/test/resources/samples/mapping_profile.json
+++ b/mod-data-export/src/test/resources/samples/mapping_profile.json
@@ -1,0 +1,34 @@
+{
+  "id":"0b648404-54c1-11eb-ae93-0242ac130002",
+  "name":"Mapping profile",
+  "description":"Mapping profile description",
+  "recordTypes":[
+    "INSTANCE",
+    "HOLDINGS",
+    "ITEM"
+  ],
+  "outputFormat":"MARC",
+  "transformations":[
+    {
+      "fieldId":"holdings.callnumber",
+      "path":"$.holdings[*].callNumber",
+      "recordType":"HOLDINGS",
+      "transformation":"900  $a",
+      "enabled":true
+    },
+    {
+      "fieldId":"instance.hrid",
+      "path":"$.instance.hrid",
+      "recordType":"INSTANCE",
+      "transformation":"901  $a",
+      "enabled":true
+    },
+    {
+      "fieldId":"item.copynumber",
+      "path":"$.holdings[*].items[*].copyNumber",
+      "recordType":"ITEM",
+      "transformation":"902 1$a",
+      "enabled":true
+    }
+  ]
+}


### PR DESCRIPTION
**PURPOSE:**
https://issues.folio.org/browse/FAT-128

**APPROACH**
Add CRUD tests for profiles, method order in class, and samples.

Verified on testing, screenshot from testRail.
![Screenshot_4](https://user-images.githubusercontent.com/60778653/104309310-9d15fe00-54da-11eb-9a8a-035b3a4352c6.png)
