### PR TITLE
MODORDERS-443 Update logic for supporting manually exchange rate for …

### DIFF
--- a/acquisitions/src/main/resources/domain/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/domain/mod-orders/orders.feature
@@ -56,5 +56,8 @@ Feature: mod-orders integration tests
   Scenario: Check needReEncumber flag populated correctly
     Given call read('features/check-re-encumber-property.feature')
 
+  Scenario: Open order with manual exchange rate
+    Given call read('features/open-order-with-manual-exchange-rate.feature')
+
   Scenario: wipe data
     Given call read('classpath:common/destroy-data.feature')

--- a/acquisitions/src/test/java/org/folio/OrdersApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersApiTest.java
@@ -70,6 +70,12 @@ public class OrdersApiTest extends AbstractTestRailIntegrationTest {
     runFeatureTest("check-re-encumber-property");
   }
 
+  @Test
+  void openOrderWithManualExchangeRate() {
+    runFeatureTest("open-order-with-manual-exchange-rate");
+  }
+
+
   @BeforeAll
   public void ordersApiTestBeforeAll() {
     runFeature("classpath:domain/mod-orders/orders-junit.feature");


### PR DESCRIPTION
[MODORDERS-443](https://issues.folio.org/browse/MODORDERS-443)
Update logic for supporting manually exchange rate for purchase order line