### PR TITLE
FAT-148 - API Tests for edge-dematic

### DIFF
--- a/edge-dematic/src/main/resources/domain/edge-dematic/edge-dematic-junit.feature
+++ b/edge-dematic/src/main/resources/domain/edge-dematic/edge-dematic-junit.feature
@@ -12,5 +12,5 @@ Feature: edge-dematic integration tests
       | name  |
 
   Scenario: init data
-    * call login admin
+    * call login { tenant: 'diku', name: 'diku_admin', password: 'admin' }
     * callonce read('classpath:global/prepare-test-data.feature')

--- a/edge-dematic/src/main/resources/domain/edge-dematic/edge-dematic-junit.feature
+++ b/edge-dematic/src/main/resources/domain/edge-dematic/edge-dematic-junit.feature
@@ -12,5 +12,5 @@ Feature: edge-dematic integration tests
       | name  |
 
   Scenario: init data
-    * call login { tenant: 'diku', name: 'diku_admin', password: 'admin' }
+    * call login admin
     * callonce read('classpath:global/prepare-test-data.feature')

--- a/edge-dematic/src/main/resources/domain/edge-dematic/features/lookup-asr-requests.feature
+++ b/edge-dematic/src/main/resources/domain/edge-dematic/features/lookup-asr-requests.feature
@@ -2,7 +2,7 @@ Feature: test asrService/asr/lookupAsrRequests request
 
   Background:
     * url baseUrl
-    * callonce login admin
+    * callonce login { tenant: 'diku', name: 'diku_admin', password: 'admin' }
 
     * def headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json'  }
 

--- a/edge-dematic/src/main/resources/domain/edge-dematic/features/lookup-asr-requests.feature
+++ b/edge-dematic/src/main/resources/domain/edge-dematic/features/lookup-asr-requests.feature
@@ -2,7 +2,7 @@ Feature: test asrService/asr/lookupAsrRequests request
 
   Background:
     * url baseUrl
-    * callonce login { tenant: 'diku', name: 'diku_admin', password: 'admin' }
+    * callonce login admin
 
     * def headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json'  }
 

--- a/edge-dematic/src/main/resources/domain/edge-dematic/features/lookup-new-asr-items.feature
+++ b/edge-dematic/src/main/resources/domain/edge-dematic/features/lookup-new-asr-items.feature
@@ -2,7 +2,7 @@ Feature: test asrService/asr/lookupNewAsrItems request
 
   Background:
     * url baseUrl
-    * callonce login { tenant: 'diku', name: 'diku_admin', password: 'admin' }
+    * callonce login admin
 
     * def headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json'  }
 

--- a/edge-dematic/src/main/resources/domain/edge-dematic/features/lookup-new-asr-items.feature
+++ b/edge-dematic/src/main/resources/domain/edge-dematic/features/lookup-new-asr-items.feature
@@ -2,7 +2,7 @@ Feature: test asrService/asr/lookupNewAsrItems request
 
   Background:
     * url baseUrl
-    * callonce login admin
+    * callonce login { tenant: 'diku', name: 'diku_admin', password: 'admin' }
 
     * def headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json'  }
 

--- a/edge-dematic/src/main/resources/domain/edge-dematic/features/update-asr-item-being-retrieved.feature
+++ b/edge-dematic/src/main/resources/domain/edge-dematic/features/update-asr-item-being-retrieved.feature
@@ -1,7 +1,7 @@
 Feature: test asrService/asr/updateASRItemStatusBeingRetrieved request
   Background:
     * url baseUrl
-    * callonce login { tenant: 'diku', name: 'diku_admin', password: 'admin' }
+    * callonce login admin
 
     * def headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json'  }
 

--- a/edge-dematic/src/main/resources/domain/edge-dematic/features/update-asr-item-being-retrieved.feature
+++ b/edge-dematic/src/main/resources/domain/edge-dematic/features/update-asr-item-being-retrieved.feature
@@ -1,7 +1,7 @@
 Feature: test asrService/asr/updateASRItemStatusBeingRetrieved request
   Background:
     * url baseUrl
-    * callonce login admin
+    * callonce login { tenant: 'diku', name: 'diku_admin', password: 'admin' }
 
     * def headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json'  }
 

--- a/edge-dematic/src/main/resources/domain/edge-dematic/features/update-asr-item-status-available.feature
+++ b/edge-dematic/src/main/resources/domain/edge-dematic/features/update-asr-item-status-available.feature
@@ -2,7 +2,7 @@ Feature: test asrService/asr/updateASRItemStatusAvailable request
 
   Background:
     * url baseUrl
-    * callonce login { tenant: 'diku', name: 'diku_admin', password: 'admin' }
+    * callonce login admin
 
     * def headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json'  }
 

--- a/edge-dematic/src/main/resources/domain/edge-dematic/features/update-asr-item-status-available.feature
+++ b/edge-dematic/src/main/resources/domain/edge-dematic/features/update-asr-item-status-available.feature
@@ -2,7 +2,7 @@ Feature: test asrService/asr/updateASRItemStatusAvailable request
 
   Background:
     * url baseUrl
-    * callonce login admin
+    * callonce login { tenant: 'diku', name: 'diku_admin', password: 'admin' }
 
     * def headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json'  }
 

--- a/edge-dematic/src/main/resources/global/prepare-test-data.feature
+++ b/edge-dematic/src/main/resources/global/prepare-test-data.feature
@@ -2,7 +2,7 @@ Feature: edge-dematic sample data
 
   Background:
     * url baseUrl
-    * call login admin
+    * call login { tenant: 'diku', name: 'diku_admin', password: 'admin' }
 
     * configure headers = { 'Content-Type': 'application/json', 'Accept': 'application/json', 'x-okapi-token': '#(okapitoken)' }
 

--- a/edge-dematic/src/main/resources/global/prepare-test-data.feature
+++ b/edge-dematic/src/main/resources/global/prepare-test-data.feature
@@ -2,7 +2,7 @@ Feature: edge-dematic sample data
 
   Background:
     * url baseUrl
-    * call login { tenant: 'diku', name: 'diku_admin', password: 'admin' }
+    * call login admin
 
     * configure headers = { 'Content-Type': 'application/json', 'Accept': 'application/json', 'x-okapi-token': '#(okapitoken)' }
 

--- a/edge-dematic/src/main/resources/karate-config.js
+++ b/edge-dematic/src/main/resources/karate-config.js
@@ -90,8 +90,6 @@ function fn() {
   } else if (env != null && env.match(/^ec2-\d+/)) {
     // Config for FOLIO CI "folio-integration" public ec2- dns name
     config.baseUrl = 'http://' + env + ':9130';
-    config.edgeUrl = 'http://' + env + ':8000';
-    config.apikey = 'eyJzIjoiZGlrdSIsInQiOiJkaWt1IiwidSI6ImRpa3UifQ';
     config.admin = {
       tenant: 'supertenant',
       name: 'admin',

--- a/edge-dematic/src/main/resources/karate-config.js
+++ b/edge-dematic/src/main/resources/karate-config.js
@@ -90,6 +90,8 @@ function fn() {
   } else if (env != null && env.match(/^ec2-\d+/)) {
     // Config for FOLIO CI "folio-integration" public ec2- dns name
     config.baseUrl = 'http://' + env + ':9130';
+    config.edgeUrl = 'http://' + env + ':8000';
+    config.apikey = 'eyJzIjoiZGlrdSIsInQiOiJkaWt1IiwidSI6ImRpa3UifQ';
     config.admin = {
       tenant: 'supertenant',
       name: 'admin',


### PR DESCRIPTION
[FAT-148](https://issues.folio.org/browse/FAT-148) - API Tests for edge-dematic

Verified on [folio-testing](https://folio-testing.dev.folio.org)

1. lookup asr requests
<img width="907" alt="Screenshot 2021-03-25 at 15 39 51" src="https://user-images.githubusercontent.com/60380420/112474202-5b2df180-8d80-11eb-8b6a-0b01bad49e18.png">

2. lookup new asr items
<img width="901" alt="Screenshot 2021-03-25 at 15 40 40" src="https://user-images.githubusercontent.com/60380420/112474283-78fb5680-8d80-11eb-96b0-6686216e4680.png">

3. update asr item being retrieved
<img width="907" alt="Screenshot 2021-03-25 at 15 41 32" src="https://user-images.githubusercontent.com/60380420/112474376-992b1580-8d80-11eb-8979-fef51f0a67c1.png">

4. update asr item status available
<img width="901" alt="Screenshot 2021-03-25 at 15 42 01" src="https://user-images.githubusercontent.com/60380420/112474450-b1029980-8d80-11eb-89ff-2390488166dd.png">
