### PR TITLE
FAT-200 Add modules to pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -44,6 +44,11 @@
     <module>mod-feesfines</module>
     <module>mod-patron-blocks</module>
     <module>mod-email</module>
+    <module>mod-calendar</module>
+    <module>mod-event-config</module>
+    <module>mod-notify</module>
+    <module>mod-sender</module>
+    <module>mod-template-engine</module>
   </modules>
 
   <build>


### PR DESCRIPTION
Resolves [FAT-200](https://issues.folio.org/browse/FAT-200)

### Purpose
Make mod-calendar, mod-event-config, mod-notify, mod-sender, mod-template-engine visible in the cucumber report

### Approach
Add modules to the common pom file.