### PR TITLE
FOLIO-3117 - Folio integration tests for mod-quick-marc fails

### DIFF
--- a/quick-marc/src/main/resources/domain/mod-quick-marc/features/setup/setup.feature
+++ b/quick-marc/src/main/resources/domain/mod-quick-marc/features/setup/setup.feature
@@ -65,7 +65,7 @@ Feature: Test quickMARC
       "jobProfileInfo": {
         "id": "6409dcff-71fa-433a-bc6a-e70ad38a9604",
         "name": "CLI Create MARC Bibs and Instances",
-        "dataType": "MARC"
+        "dataType": "MARC_BIB"
       }
     }
     """

--- a/quick-marc/src/test/java/org/folio/QuickMarcApiTest.java
+++ b/quick-marc/src/test/java/org/folio/QuickMarcApiTest.java
@@ -4,7 +4,6 @@ import org.folio.test.TestBase;
 import org.folio.test.config.TestModuleConfiguration;
 import org.folio.test.services.TestIntegrationService;
 import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 


### PR DESCRIPTION
## Purpose 
Fix tests failure https://issues.folio.org/browse/FOLIO-3117

## Approach

* updated record type from MARC to MARC_BIB