### PR TITLE
FOLIO-3117 Folio integration tests for mod-quick-marc fails

### DIFF
--- a/quick-marc/src/main/resources/domain/mod-quick-marc/features/setup/samples/record.json
+++ b/quick-marc/src/main/resources/domain/mod-quick-marc/features/setup/samples/record.json
@@ -13,16 +13,27 @@
     "content" : "20141107001016.0",
     "indicators" : [ ]
   }, {
-    "tag" : "006",
-    "content" : {
-      "Audn" : "e",
-      "AccM" : [ "g", "h", "i", "j", "k", "l" ],
-      "FMus" : "c",
-      "Form" : "f",
-      "Part" : "d",
-      "LTxt" : [ "m", "n" ],
-      "TrAr" : "o",
-      "Comp" : " b"
+    "tag": "006",
+    "content": {
+      "Type": "c",
+      "Comp": " b",
+      "FMus": "c",
+      "Part": "d",
+      "Audn": "e",
+      "Form": "f",
+      "AccM": [
+        "g",
+        "h",
+        "i",
+        "j",
+        "k",
+        "l"
+      ],
+      "LTxt": [
+        "m",
+        "n"
+      ],
+      "TrAr": "o"
     },
     "indicators" : [ ]
   }, {

--- a/quick-marc/src/main/resources/domain/mod-quick-marc/features/setup/setup.feature
+++ b/quick-marc/src/main/resources/domain/mod-quick-marc/features/setup/setup.feature
@@ -8,6 +8,10 @@ Feature: Test quickMARC
     * def headersUserOctetStream = { 'Content-Type': 'application/octet-stream', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json'  }
 
   Scenario: import MARC record
+    #waiting for all modules to be launched, this sleep allows to avoid creating a phantom instance in the mod-inventory
+    * def sleep = function(millis){ java.lang.Thread.sleep(millis) }
+    * eval sleep(60000)
+
     Given path 'instance-types',
     And headers headersUser
     And request

--- a/quick-marc/src/main/resources/domain/mod-quick-marc/quick-marc-junit.feature
+++ b/quick-marc/src/main/resources/domain/mod-quick-marc/quick-marc-junit.feature
@@ -15,6 +15,7 @@ Feature: mod-quick-marc integration tests
 
     * table userPermissions
       | name                 |
+      |'inventory-storage.preceding-succeeding-titles.collection.get'|
       | 'records-editor.all' |
 
   Scenario: create tenant and users for testing


### PR DESCRIPTION
## Purpose
Fixed test for mod-quick-marc

## Approach
- fixed test data (006 field) for record.json
- added permission for getting titles (precedingSucceedingTitlesClient) in mod-inventory
- added sleep for waiting while all modules is started

https://issues.folio.org/browse/FOLIO-3117