### PR TITLE
MODQM-127 MARC record does NOT open after saving an invalid field

### DIFF
--- a/quick-marc/src/main/resources/domain/mod-quick-marc/features/quick-marc-record-status.feature
+++ b/quick-marc/src/main/resources/domain/mod-quick-marc/features/quick-marc-record-status.feature
@@ -49,7 +49,7 @@ Feature: Test quickMARC for record status
     And headers headersUser
     When method GET
     Then status 400
-    And match response.message == "Parameter 'qmRecordId' should be not null"
+    And match response.message == "Parameter getRecordCreationStatus.qmRecordId: must not be null"
 
   Scenario: Record was not found with invalid id
     Given path 'records-editor/records/status'


### PR DESCRIPTION
## Purpose
Changed message for exception if qmRecordId is null

## Approach
Modified message in test data

## Learning
https://issues.folio.org/browse/MODQM-127