### PR TITLE
[MODINVOSTO-120] Test the voucher number start

### DIFF
--- a/acquisitions/src/main/resources/domain/mod-invoice/features/voucher-numbers.feature
+++ b/acquisitions/src/main/resources/domain/mod-invoice/features/voucher-numbers.feature
@@ -1,0 +1,28 @@
+# created for MODINVOSTO-120
+Feature: Voucher numbers
+
+  Background:
+    * url baseUrl
+    * callonce loginAdmin testAdmin
+    * def okapitokenAdmin = okapitoken
+
+    * callonce loginRegularUser testUser
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json'  }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json'  }
+    * configure headers = headersUser
+
+
+  Scenario: Set/reset the start value of the voucher-number sequence
+    # Note: an id is passed by the UI in the request, but not used...
+    Given path '/voucher/voucher-number/start/11'
+    And request {}
+    When method POST
+    Then status 204
+
+  Scenario: Try a wrong number as the start value of the voucher-number sequence
+    Given path '/voucher/voucher-number/start/abc'
+    And request {}
+    When method POST
+    Then status 400

--- a/acquisitions/src/main/resources/domain/mod-invoice/invoice.feature
+++ b/acquisitions/src/main/resources/domain/mod-invoice/invoice.feature
@@ -72,5 +72,8 @@ Feature: mod-invoice integration tests
   Scenario: Check that can not approve invoice if organization is not vendor
     Given call read('features/check-that-can-not-approve-invoice-if-organization-is-not-vendor.feature')
 
+  Scenario: Voucher numbers
+    Given call read('features/voucher-numbers.feature')
+
   Scenario: wipe data
     Given call read('classpath:common/destroy-data.feature')

--- a/acquisitions/src/test/java/org/folio/InvoicesApiTest.java
+++ b/acquisitions/src/test/java/org/folio/InvoicesApiTest.java
@@ -102,6 +102,11 @@ public class InvoicesApiTest extends TestBase {
     runFeatureTest("check-that-can-not-approve-invoice-if-organization-is-not-vendor.feature");
   }
 
+  @Test
+  void voucherNumbers() {
+    runFeatureTest("voucher-numbers");
+  }
+
   @BeforeAll
   public void invoicesApiTestBeforeAll() {
     runFeature("classpath:domain/mod-invoice/invoice-junit.feature");


### PR DESCRIPTION
## Purpose
[MODINVOSTO-120](https://issues.folio.org/browse/MODINVOSTO-120) - Cannot set voucher "Starting number" or reset sequence

## Approach
Simply test setting the start number and a syntax error.