### PR TITLE
MODPWD-72 Added tests for 400 errors

### DIFF
--- a/mod-password-validator/src/test/resources/domain/passwordvalidator/features/validate.feature
+++ b/mod-password-validator/src/test/resources/domain/passwordvalidator/features/validate.feature
@@ -18,6 +18,20 @@ Feature: Test POST password validate
     Then status 200
     And match response.result == "valid"
 
+  Scenario: Should return 404 if user with given id not found
+    Given path 'password/validate'
+    And request password
+    And set password.userId = "WrongId"
+    When method POST
+    Then status 404
+
+  Scenario: Should return 422 if required fields not provided
+    Given path 'password/validate'
+    And request {}
+    When method POST
+    Then status 422
+    And match response.total_records == 2
+
   Scenario: Should return invalid result if password contains consecutive whitespaces
     Given call read(testRuleFailure) { rule: 'no_consecutive_whitespaces' }
 


### PR DESCRIPTION
## Purpose
After this merged [pull request](https://github.com/folio-org/mod-password-validator/pull/84) 
mod-password-validator started giving correct responses to invalid requests.

## Approach
Added tests for new errors

## Learning
[MODPWD-72](https://issues.folio.org/browse/MODPWD-72)
[Password Api Documentation](https://s3.amazonaws.com/foliodocs/api/mod-password-validator/s/password-validator.html#operation/validatePassword)
