### PR TITLE
MODSOURMAN-536 Delete instance type before creating new

### DIFF
--- a/quick-marc/src/main/resources/domain/mod-quick-marc/features/setup/create-instance-type.feature
+++ b/quick-marc/src/main/resources/domain/mod-quick-marc/features/setup/create-instance-type.feature
@@ -1,0 +1,34 @@
+Feature: Create instance type
+
+  Background:
+    * url baseUrl
+    * callonce login testAdmin
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json'  }
+    * def headersDelete = { 'Content-Type': 'text/plain', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'text/plain'  }
+    * def instanceType = read('classpath:domain/mod-quick-marc/features/setup/samples/instance-type.json');
+
+  @CreateInstanceType
+  Scenario: create instance type
+    Given path 'instance-types'
+    And headers headersUser
+    And request instanceType
+    When method post
+    Then assert responseStatus == 201 || responseStatus == 400
+    And eval if (responseStatus == 400) karate.call('create-instance-type.feature@DeleteInstanceType')
+
+  @DeleteInstanceType
+  Scenario: delete instance type
+    Given path 'instance-types'
+    And param query = "name=" + instanceType.name + " or code=" + instanceType.code
+    And headers headersUser
+    When method get
+    Then status 200
+    * def idToDelete = response.instanceTypes[0].id
+
+    Given path 'instance-types', idToDelete
+    And headers headersDelete
+    When method delete
+    Then status 204
+    And call read('create-instance-type.feature@CreateInstanceType')

--- a/quick-marc/src/main/resources/domain/mod-quick-marc/features/setup/samples/instance-type.json
+++ b/quick-marc/src/main/resources/domain/mod-quick-marc/features/setup/samples/instance-type.json
@@ -1,0 +1,5 @@
+{
+  "name" : "proceedings",
+  "code" : "zzz",
+  "source" : "rdacontent"
+}

--- a/quick-marc/src/main/resources/domain/mod-quick-marc/features/setup/setup.feature
+++ b/quick-marc/src/main/resources/domain/mod-quick-marc/features/setup/setup.feature
@@ -7,6 +7,7 @@ Feature: Test quickMARC
 
     * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json'  }
     * def headersUserOctetStream = { 'Content-Type': 'application/octet-stream', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json'  }
+    * def createInstancePath = "classpath:domain/mod-quick-marc/features/setup/create-instance-type.feature@CreateInstanceType"
 
     #waiting for all modules to be launched, this sleep allows to avoid creating a phantom instance in the mod-inventory
     * def sleep = function(millis){ java.lang.Thread.sleep(millis) }
@@ -14,18 +15,7 @@ Feature: Test quickMARC
 
   Scenario: import MARC record
     ## Create instance type
-    Given path 'instance-types',
-    And headers headersUser
-    And request
-    """
-    {
-      "name" : "proceedings",
-      "code" : "zzz",
-      "source" : "rdacontent"
-    }
-    """
-    When method post
-    Then status 201
+    * karate.call(createInstancePath)
 
     ## Upload marc file
     Given path 'data-import/uploadDefinitions'

--- a/quick-marc/src/main/resources/domain/mod-quick-marc/quick-marc-junit.feature
+++ b/quick-marc/src/main/resources/domain/mod-quick-marc/quick-marc-junit.feature
@@ -19,15 +19,15 @@ Feature: mod-quick-marc integration tests
       | name |
 
     * table userPermissions
-      | name                                       |
-      | 'configuration.all'                        |
-      | 'inventory.all'                            |
-      | 'inventory-storage.all'                    |
-      | 'source-storage.all'                       |
-      | 'records-editor.all'                       |
-      | 'metadata-provider.logs.get'               |
-      | 'change-manager.jobexecutions.get'         |
-      | 'data-import.fileExtensions.put'           |
+      | name                               |
+      | 'configuration.all'                |
+      | 'inventory.all'                    |
+      | 'inventory-storage.all'            |
+      | 'source-storage.all'               |
+      | 'records-editor.all'               |
+      | 'metadata-provider.logs.get'       |
+      | 'change-manager.jobexecutions.get' |
+      | 'data-import.fileExtensions.put'   |
 
 
   Scenario: create tenant and users for testing


### PR DESCRIPTION
## Description
On this cucumber [REPORT](https://jenkins-aws.indexdata.com/job/FOLIO_Reference_Builds/job/folio-api-tests-karate/536/cucumber-html-reports/report-feature_134_436510751.html) in first attempt you can see
 that request passed with 201 status code and instance-type was created, but for some reasons server does not respond in time, and request falls
I the second attempt, server responds in time but instance type is already exist and we got duplicate error

## Purpose
Delete event-type before creating new
  
## Learning
  [MODSOURMAN-536](https://issues.folio.org/browse/MODSOURMAN-536)
  [Cucumber  Report](https://jenkins-aws.indexdata.com/job/FOLIO_Reference_Builds/job/folio-api-tests-karate/536/cucumber-html-reports/report-feature_134_436510751.html)
 [Jenkins Builds](https://jenkins-aws.indexdata.com/job/FOLIO_Reference_Builds/job/folio-api-tests-karate/)

