### PR TITLE
[MODORDERS-565] All transaction queries should use the fiscal year id. Fix for karate…

### DIFF
--- a/acquisitions/src/main/resources/domain/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/domain/mod-orders/orders.feature
@@ -10,6 +10,7 @@ Feature: mod-orders integration tests
       | 'mod-orders-storage' |
       | 'mod-orders'         |
       | 'mod-tags'           |
+      | 'mod-invoice'        |
 
     * def random = callonce randomMillis
     * def testTenant = 'test_orders' + random


### PR DESCRIPTION
Purpose
Problem related to karate tests that didn't work because invoice-module wasn't added to the table modules