### PR TITLE
Fat 1006

### DIFF
--- a/mod-circulation/src/main/resources/domain/mod-circulation/circulation-junit.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/circulation-junit.feature
@@ -20,7 +20,8 @@ Feature: mod-circulation integration tests
       | 'automated-patron-blocks.collection.get'                       |
       | 'circulation.loans.collection.get'                             |
       | 'circulation.loans.declare-item-lost.post'                     |
-      | 'circulation.requests.collection.get'                          |
+      | 'circulation.requests.collection.get'
+      | 'circulation.requests.item.get'
       | 'circulation.check-out-by-barcode.post'                        |
       | 'circulation.check-in-by-barcode.post'                         |
       | 'check-in-storage.check-ins.item.get'                          |

--- a/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
@@ -262,10 +262,12 @@ Feature: Loans tests
     * def extUserBarcode2 = '3315669'
     * def extRequestId = call uuid1
 
-    # post an item
-    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostInstance')
+    # location and service point setup
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostServicePoint')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostLocation')
+
+    # post an item
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostInstance')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostHoldings')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(extItemBarcode)}
 

--- a/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
@@ -270,7 +270,6 @@ Feature: Loans tests
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(extItemBarcode)}
 
     # post an user
-    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostPolicies')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostGroup')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostUser') { extUserBarcode: #(extUserBarcode1), extUserId: #(extUserId1) }
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostUser') { extUserBarcode: #(extUserBarcode2), extUserId: #(extUserId2) }

--- a/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
@@ -288,13 +288,9 @@ Feature: Loans tests
     And match response.item.id == itemId
     And match response.item.status.name == 'Awaiting pickup'
 
-<<<<<<< HEAD
-=======
     # check the status of the user request whether changed to 'Open-Awaiting pickup'
     Given path 'circulation', 'requests', extRequestId
     When method GET
     Then status 200
     And match response.status == 'Open - Awaiting pickup'
 
-
->>>>>>> 7a78dba (fixed issues and added a condition to check the status of the user request)

--- a/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
@@ -255,11 +255,11 @@ Feature: Loans tests
 
   Scenario: When an requested loaned item is checked in at a service point designated as the pickup location of the request, change the item status to awaiting-pickup
 
-    * def extItemBarcode = '' + random(100000)
+    * def extItemBarcode = '12123366'
     * def extUserId1 = call uuid1
     * def extUserId2 = call uuid2
-    * def extUserBarcode1 = random(1000000)
-    * def extUserBarcode2 = random(1000000)
+    * def extUserBarcode1 = '3315666'
+    * def extUserBarcode2 = '3315669'
     * def extRequestId = call uuid1
 
     # post an item
@@ -268,6 +268,8 @@ Feature: Loans tests
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostLocation')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostHoldings')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(extItemBarcode)}
+
+    # post an user
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostPolicies')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostGroup')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostUser') { extUserBarcode: #(extUserBarcode1), extUserId: #(extUserId1) }
@@ -285,3 +287,13 @@ Feature: Loans tests
     And match response.item.id == itemId
     And match response.item.status.name == 'Awaiting pickup'
 
+<<<<<<< HEAD
+=======
+    # check the status of the user request whether changed to 'Open-Awaiting pickup'
+    Given path 'circulation', 'requests', extRequestId
+    When method GET
+    Then status 200
+    And match response.status == 'Open - Awaiting pickup'
+
+
+>>>>>>> 7a78dba (fixed issues and added a condition to check the status of the user request)

--- a/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
@@ -264,7 +264,7 @@ Feature: Loans tests
 
     # post an item
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostInstance')
-    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostServicePoint') { id: #(servicePointId) }
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostServicePoint')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostLocation')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostHoldings')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(extItemBarcode)}
@@ -276,13 +276,13 @@ Feature: Loans tests
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostUser') { extUserBarcode: #(extUserBarcode2), extUserId: #(extUserId2) }
 
     # checkOut the item
-    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(extUserBarcode1), extCheckOutItemBarcode: #(extItemBarcode), servicePointId: #(servicePointId) }
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(extUserBarcode1), extCheckOutItemBarcode: #(extItemBarcode) }
 
     # post a request for the checked-out-item
-    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostRequest') { requestId: #(extRequestId), itemId: #(itemId), requesterId: #(extUserId2), servicePointId: #(servicePointId) }
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostRequest') { requestId: #(extRequestId), itemId: #(itemId), requesterId: #(extUserId2) }
 
     # checkIn the item and check if the request status changed to awaiting pickup
-    * def checkInResponse = call read('classpath:domain/mod-circulation/features/util/initData.feature@CheckInItem') { servicePointId: #(servicePointId), itemBarcode: #(extItemBarcode) }
+    * def checkInResponse = call read('classpath:domain/mod-circulation/features/util/initData.feature@CheckInItem') { itemBarcode: #(extItemBarcode) }
     * def response = checkInResponse.response
     And match response.item.id == itemId
     And match response.item.status.name == 'Awaiting pickup'

--- a/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
@@ -262,7 +262,7 @@ Feature: Loans tests
     * def extUserBarcode2 = '3315669'
     * def extRequestId = call uuid1
 
-    # location and service point setup
+    # post a location and service point
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostServicePoint')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostLocation')
 

--- a/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
@@ -127,7 +127,7 @@ Feature: Loans tests
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostInstance')
     * def postServicePointResult = call read('classpath:domain/mod-circulation/features/util/initData.feature@PostServicePoint')
     * def servicePointId = postServicePointResult.response.id
-    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostOwner') { servicePointId: #(servicePointId) }
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostOwner')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostLocation')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostHoldings')
     * def postItemResult = call read('classpath:domain/mod-circulation/features/util/initData.feature@PostItem') { extItemBarcode: #(itemBarcode), extMaterialTypeId: #(materialTypeId) }
@@ -252,3 +252,36 @@ Feature: Loans tests
     * def item = checkInResponse.response.item
     And match item.id == itemId
     And match item.status.name == 'Available'
+
+  Scenario: When an requested loaned item is checked in at a service point designated as the pickup location of the request, change the item status to awaiting-pickup
+
+    * def extItemBarcode = '' + random(100000)
+    * def extUserId1 = call uuid1
+    * def extUserId2 = call uuid2
+    * def extUserBarcode1 = random(1000000)
+    * def extUserBarcode2 = random(1000000)
+    * def extRequestId = call uuid1
+
+    # post an item
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostInstance')
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostServicePoint') { id: #(servicePointId) }
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostLocation')
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostHoldings')
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(extItemBarcode)}
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostPolicies')
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostGroup')
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostUser') { extUserBarcode: #(extUserBarcode1), extUserId: #(extUserId1) }
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostUser') { extUserBarcode: #(extUserBarcode2), extUserId: #(extUserId2) }
+
+    # checkOut the item
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(extUserBarcode1), extCheckOutItemBarcode: #(extItemBarcode), servicePointId: #(servicePointId) }
+
+    # post a request for the checked-out-item
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostRequest') { requestId: #(extRequestId), itemId: #(itemId), requesterId: #(extUserId2), servicePointId: #(servicePointId) }
+
+    # checkIn the item and check if the request status changed to awaiting pickup
+    * def checkInResponse = call read('classpath:domain/mod-circulation/features/util/initData.feature@CheckInItem') { servicePointId: #(servicePointId), itemBarcode: #(extItemBarcode) }
+    * def response = checkInResponse.response
+    And match response.item.id == itemId
+    And match response.item.status.name == 'Awaiting pickup'
+

--- a/mod-circulation/src/main/resources/domain/mod-circulation/features/util/initData.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/features/util/initData.feature
@@ -310,4 +310,16 @@ Feature: init data for mod-circulation
     And request declareItemLostRequest
     When method POST
     Then status 204
-    
+
+  @PostRequest
+  Scenario: create request
+    * def requestEntityRequest = read('classpath:domain/mod-circulation/features/samples/request-entity-request.json')
+    Given path 'circulation', 'requests'
+    And request requestEntityRequest
+    When method POST
+    Then status 201
+    And match response.id == requestId
+    And match response.itemId == itemId
+    And match response.requesterId == requesterId
+    And match response.pickupServicePointId == servicePointId
+    And match response.status == 'Open - Not yet filled'


### PR DESCRIPTION
## Purpose
[FAT-1006](https://issues.folio.org/browse/FAT-1006)
_Create Karate test for Loans: When an requested loaned item is checked in at a service point designated as the pickup location of the request, change the item status to awaiting-pickup_

## Approach
- Reproduced test scenario with UI.
- Learned necessary sent requests and then necessary received responses 
- Based on the request/response created karate test scenario


## Learning
- learn karate framework from original doc file on the github
- looked other scenarios how they are described.

