### PR TITLE
FAT-1003 Created Karate test for Loans

### DIFF
--- a/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
@@ -233,11 +233,10 @@ Feature: Loans tests
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(extItemBarcode)}
 
     # post a user
-    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostPolicies')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostGroup')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostUser') { extUserBarcode: #(extUserBarcode), extUserId: #(extUserId) }
 
-    # check-out the created item
+    # check-out the item
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(extUserBarcode), extCheckOutItemBarcode: #(extItemBarcode) }
 
     # verify that no request exist before check-in

--- a/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
@@ -219,13 +219,13 @@ Feature: Loans tests
 
   Scenario: When an loaned item is checked in at a service point that serves its location and no request exists, change the item status to Available
 
-    * def extItemBarcode = '' + random(100000)
+    * def extItemBarcode = 'fat1003-ibc'
     * def extUserId = call uuid1
-    * def extUserBarcode = random(1000000)
+    * def extUserBarcode = 'fat1003-ubc'
 
     # location and service point setup
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostLocation')
-    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostServicePoint') { id: #(servicePointId) }
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostServicePoint')
 
     # post an item
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostInstance')
@@ -238,7 +238,7 @@ Feature: Loans tests
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostUser') { extUserBarcode: #(extUserBarcode), extUserId: #(extUserId) }
 
     # check-out the created item
-    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(extUserBarcode), extCheckOutItemBarcode: #(extItemBarcode), servicePointId: #(servicePointId) }
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(extUserBarcode), extCheckOutItemBarcode: #(extItemBarcode) }
 
     # verify that no request exist before check-in
     Given path 'circulation', 'requests'
@@ -249,7 +249,7 @@ Feature: Loans tests
     And match response.requests == []
 
     # check-in the item and verify that item status is changed to 'Available'
-    * def checkInResponse = call read('classpath:domain/mod-circulation/features/util/initData.feature@CheckInItem') { servicePointId: #(servicePointId), itemBarcode: #(extItemBarcode) }
+    * def checkInResponse = call read('classpath:domain/mod-circulation/features/util/initData.feature@CheckInItem') { itemBarcode: #(extItemBarcode) }
     * def item = checkInResponse.response.item
     And match item.id == itemId
     And match item.status.name == 'Available'

--- a/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
@@ -223,19 +223,21 @@ Feature: Loans tests
     * def extUserId = call uuid1
     * def extUserBarcode = random(1000000)
 
+    # location and service point setup
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostLocation')
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostServicePoint') { id: #(servicePointId) }
+
     # post an item
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostInstance')
-    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostServicePoint') { id: #(servicePointId) }
-    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostLocation')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostHoldings')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(extItemBarcode)}
 
-    # post an user
+    # post a user
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostPolicies')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostGroup')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostUser') { extUserBarcode: #(extUserBarcode), extUserId: #(extUserId) }
 
-    # checkOut the created item
+    # check-out the created item
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(extUserBarcode), extCheckOutItemBarcode: #(extItemBarcode), servicePointId: #(servicePointId) }
 
     # verify that no request exist before check-in
@@ -246,7 +248,7 @@ Feature: Loans tests
     And match response.totalRecords == 0
     And match response.requests == []
 
-    # checkIn the item and verify that item status is changed to 'Available'
+    # check-in the item and verify that item status is changed to 'Available'
     * def checkInResponse = call read('classpath:domain/mod-circulation/features/util/initData.feature@CheckInItem') { servicePointId: #(servicePointId), itemBarcode: #(extItemBarcode) }
     * def item = checkInResponse.response.item
     And match item.id == itemId


### PR DESCRIPTION
## Purpose
[FAT-1003](https://issues.folio.org/browse/FAT-1003)
_Create Karate test for Loans: When an loaned item is checked in at a service point that serves its location and no request exists, change the item status to Available (circ-13)_

## Approach
- Reproduced test scenario with UI.
- Learned necessary sent requests and then necessary received responses 
- Based on the request/response created karate test scenario


## Learning
- learn karate framework from original doc file on the github
- looked other scenarios how they are described.