### PR TITLE
FAT-1009 Loans: Item with Restricted status should change status to Available after it is checked in

### DIFF
--- a/mod-circulation/src/main/resources/domain/mod-circulation/circulation-junit.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/circulation-junit.feature
@@ -18,51 +18,51 @@ Feature: mod-circulation integration tests
       | name                                                           |
       | 'accounts.collection.get'                                      |
       | 'automated-patron-blocks.collection.get'                       |
-      | 'circulation.loans.collection.get'                             |
-      | 'circulation.loans.declare-item-lost.post'                     |
-      | 'circulation.requests.collection.get'
-      | 'circulation.requests.item.get'
-      | 'circulation.check-out-by-barcode.post'                        |
-      | 'circulation.check-in-by-barcode.post'                         |
+      | 'automated-patron-blocks.collection.get'                       |
+      | 'check-in-storage.check-ins.collection.get'                    |
       | 'check-in-storage.check-ins.item.get'                          |
-      | 'circulation-storage.request-policies.item.post'               |
       | 'circulation-storage.circulation-rules.put'                    |
       | 'circulation-storage.loan-policies.item.post'                  |
       | 'circulation-storage.loans.item.get'                           |
       | 'circulation-storage.patron-notice-policies.item.post'         |
+      | 'circulation-storage.request-policies.item.post'               |
+      | 'circulation.check-in-by-barcode.post'                         |
+      | 'circulation.check-out-by-barcode.post'                        |
+      | 'circulation.loans.collection.get'                             |
+      | 'circulation.loans.declare-item-lost.post'                     |
+      | 'circulation.requests.collection.get'                          |
+      | 'circulation.requests.item.get'                                |
       | 'circulation.requests.item.post'                               |
-      | 'overdue-fines-policies.item.post'                             |
-      | 'lost-item-fees-policies.item.post'                            |
-      | 'manualblocks.collection.get'                                  |
-      | 'automated-patron-blocks.collection.get'                       |
-      | 'check-in-storage.check-ins.collection.get'                    |
-      | 'inventory.instances.item.post'                                |
-      | 'inventory-storage.instances.item.post'                        |
-      | 'inventory-storage.instances.item.get'                         |
-      | 'inventory-storage.preceding-succeeding-titles.collection.get' |
-      | 'inventory-storage.preceding-succeeding-titles.item.post'      |
-      | 'inventory-storage.preceding-succeeding-titles.item.put'       |
-      | 'inventory-storage.preceding-succeeding-titles.item.delete'    |
+      | 'inventory-storage.contributor-name-types.item.post'           |
+      | 'inventory-storage.holdings.item.post'                         |
       | 'inventory-storage.instance-relationships.collection.get'      |
+      | 'inventory-storage.instance-relationships.item.delete'         |
       | 'inventory-storage.instance-relationships.item.post'           |
       | 'inventory-storage.instance-relationships.item.put'            |
-      | 'inventory-storage.instance-relationships.item.delete'         |
       | 'inventory-storage.instance-types.item.post'                   |
+      | 'inventory-storage.instances.item.get'                         |
+      | 'inventory-storage.instances.item.post'                        |
       | 'inventory-storage.items.item.get'                             |
-      | 'inventory-storage.holdings.item.post'                         |
-      | 'inventory-storage.locations.item.post'                        |
-      | 'inventory-storage.location-units.institutions.item.post'      |
-      | 'inventory-storage.location-units.campuses.item.post'          |
-      | 'inventory-storage.location-units.libraries.item.post'         |
       | 'inventory-storage.loan-types.item.post'                       |
+      | 'inventory-storage.location-units.campuses.item.post'          |
+      | 'inventory-storage.location-units.institutions.item.post'      |
+      | 'inventory-storage.location-units.libraries.item.post'         |
+      | 'inventory-storage.locations.item.post'                        |
       | 'inventory-storage.material-types.item.post'                   |
-      | 'inventory-storage.contributor-name-types.item.post'           |
+      | 'inventory-storage.preceding-succeeding-titles.collection.get' |
+      | 'inventory-storage.preceding-succeeding-titles.item.delete'    |
+      | 'inventory-storage.preceding-succeeding-titles.item.post'      |
+      | 'inventory-storage.preceding-succeeding-titles.item.put'       |
       | 'inventory-storage.service-points.item.post'                   |
-      | 'inventory.items.item.post'                                    |
-      | 'owners.item.post'                                             |
-      | 'users.item.post'                                              |
-      | 'usergroups.item.post'                                         |
+      | 'inventory.instances.item.post'                                |
       | 'inventory.items.item.mark-restricted.post'                    |
+      | 'inventory.items.item.post'                                    |
+      | 'lost-item-fees-policies.item.post'                            |
+      | 'manualblocks.collection.get'                                  |
+      | 'overdue-fines-policies.item.post'                             |
+      | 'owners.item.post'                                             |
+      | 'usergroups.item.post'                                         |
+      | 'users.item.post'                                              |
 
   Scenario: create tenant and users for testing
     Given call read('classpath:common/setup-users.feature')

--- a/mod-circulation/src/main/resources/domain/mod-circulation/circulation-junit.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/circulation-junit.feature
@@ -62,6 +62,7 @@ Feature: mod-circulation integration tests
       | 'owners.item.post'                                             |
       | 'users.item.post'                                              |
       | 'usergroups.item.post'                                         |
+      | 'inventory.items.item.mark-restricted.post'                    |
 
   Scenario: create tenant and users for testing
     Given call read('classpath:common/setup-users.feature')

--- a/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
@@ -381,11 +381,11 @@ Feature: Loans tests
   Scenario: When an item that had the status of restricted that was checked out is checked in, set the item status to Available
 
     * def itemBarcode = '88888'
+    * def userBarcode = random(100000)
 
     # post associated entities and item
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostInstance')
-    * def postServicePointResult = call read('classpath:domain/mod-circulation/features/util/initData.feature@PostServicePoint')
-    * def servicePointId = postServicePointResult.response.id
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostServicePoint')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostOwner')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostLocation')
     * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostHoldings')

--- a/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
@@ -377,3 +377,38 @@ Feature: Loans tests
     And match error.message == '#string'
     And match error.message == 'Long Way to a Small Angry Planet (' + materialTypeName + ') (Barcode: ' + extItemBarcode + ') has the item status Intellectual item and cannot be checked out'
     And match error.parameters[0].value == extItemBarcode
+
+  Scenario: When an item that had the status of restricted that was checked out is checked in, set the item status to Available
+
+    * def itemBarcode = '88888'
+
+    # post associated entities and item
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostInstance')
+    * def postServicePointResult = call read('classpath:domain/mod-circulation/features/util/initData.feature@PostServicePoint')
+    * def servicePointId = postServicePointResult.response.id
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostOwner')
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostLocation')
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostHoldings')
+    * def postItemResult = call read('classpath:domain/mod-circulation/features/util/initData.feature@PostItem') { extItemBarcode: #(itemBarcode), extMaterialTypeId: #(materialTypeId) }
+    * def itemId = postItemResult.response.id
+
+    # post group and patron
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostGroup')
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostUser') { extUserBarcode: #(userBarcode) }
+
+    # declare item with restricted status
+    Given path 'inventory/items/' + itemId + '/mark-restricted'
+    When method POST
+    Then status 200
+    And match response.status.name == 'Restricted'
+
+    # checkOut an item with certain itemBarcode to created patron
+    * def checkOutResult = call read('classpath:domain/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(userBarcode), extCheckOutItemBarcode: #(itemBarcode) }
+    * def loanId = checkOutResult.response.id
+
+    # checkIn an item with certain itemBarcode, assert loan as Closed and item status as Available
+    * def postCheckInResult = call read('classpath:domain/mod-circulation/features/util/initData.feature@CheckInItem') { itemBarcode: #(itemBarcode) }
+    And match postCheckInResult.response.loan.id == loanId
+    And match postCheckInResult.response.loan.status.name == 'Closed'
+    And match postCheckInResult.response.item.id == itemId
+    And match postCheckInResult.response.item.status.name == 'Available'


### PR DESCRIPTION
### Purpose
Increase mod-circulation coverage by integration tests
### Approach
Created karate test for Loans: When an item that had the status of restricted that was checked out is checked in, set the item status to Available
### Learning
https://issues.folio.org/browse/FAT-1009
