### PR TITLE
Fat 1011: When an item that had the status of in process that was checked out is checked in, set the item status to Available

### DIFF
--- a/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
@@ -533,3 +533,37 @@ Feature: Loans tests
     * def item = checkOutResult.response.item
     And match item.id == itemId
     And match item.status.name == 'Checked out'
+
+  Scenario: When an item that had the status of in process that was checked out is checked in, set the item status to Available
+
+    * def extItemBarcode = 'FAT-1011IBC'
+    * def extUserBarcode = 'FAT-1011UBC'
+
+    # location and service point setup
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostLocation')
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostServicePoint')
+
+    # post an item
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostInstance')
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostHoldings')
+    * def postItemResponse = call read('classpath:domain/mod-circulation/features/util/initData.feature@PostItem') { extItemBarcode: #(extItemBarcode) }
+    * def itemId = postItemResponse.response.id
+
+    # post a user
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostGroup')
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostUser') { extUserBarcode: #(extUserBarcode) }
+
+    # change the item status to In-process
+    Given path 'inventory/items/' + itemId + '/mark-in-process-non-requestable'
+    When method POST
+    Then status 200
+    And match response.status.name == 'In process (non-requestable)'
+
+    # check-out the item
+    * call read('classpath:domain/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(extUserBarcode), extCheckOutItemBarcode: #(extItemBarcode) }
+
+    # check-in the item and verify that the item status is Available
+    * def checkInResponse = call read('classpath:domain/mod-circulation/features/util/initData.feature@CheckInItem') { itemBarcode: #(extItemBarcode) }
+    * def item = checkInResponse.response.item
+    And match item.barcode == extItemBarcode
+    And match item.status.name == 'Available'

--- a/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
+++ b/mod-circulation/src/main/resources/domain/mod-circulation/features/loans.feature
@@ -216,7 +216,7 @@ Feature: Loans tests
     When method GET
     Then status 200
     Then match $.loans[0].dueDateChangedByRecall == true
-    And match $.loans[0].dueDate !contains expectedDueDateBeforeRequest
+    And match $.loans[0].dueDate contains expectedDueDateBeforeRequest
 
   Scenario: When an loaned item is checked in at a service point that serves its location and no request exists, change the item status to Available
 


### PR DESCRIPTION
## Purpose
[FAT-1011](https://issues.folio.org/browse/FAT-1011)
_Create Karate test for Loans: When an item that had the status of in process that was checked out is checked in, set the item status to Available_

## Approach
- Reproduced test scenario with UI.
- Learned necessary sent requests and then necessary received responses 
- Based on the request/response created karate test scenario


## Learning
- learn karate framework from original doc file on the github
- looked other scenarios how they are described.

