### PR TITLE
[MODORDERS-616] Test changing location when receiving a piece

### DIFF
--- a/acquisitions/src/main/resources/domain/mod-orders/features/change-location-when-receiving-piece.feature
+++ b/acquisitions/src/main/resources/domain/mod-orders/features/change-location-when-receiving-piece.feature
@@ -1,0 +1,127 @@
+@parallel=false
+# for https://issues.folio.org/browse/MODORDERS-616
+Feature: Change location when receiving a piece
+
+  Background:
+    * url baseUrl
+    * callonce loginAdmin testAdmin
+    * def okapitokenAdmin = okapitoken
+    * callonce loginRegularUser testUser
+    * def okapitokenUser = okapitoken
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json'  }
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': '*/*'  }
+    * configure headers = headersUser
+
+    * callonce variables
+
+    * def fundId = callonce uuid1
+    * def budgetId = callonce uuid2
+    * def orderId = callonce uuid3
+    * def poLineId = callonce uuid4
+    * def pieceId = callonce uuid5
+
+
+  Scenario: Create finances
+    # this is needed for instance if a previous test does a rollover which changes the global fund
+    * configure headers = headersAdmin
+    * call createFund { 'id': '#(fundId)'}
+    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)'}
+
+
+  Scenario: Create an order
+    * configure headers = headersUser
+    Given path 'orders/composite-orders'
+    And request
+    """
+    {
+      id: '#(orderId)',
+      vendor: '#(globalVendorId)',
+      orderType: 'One-Time'
+    }
+    """
+    When method POST
+    Then status 201
+
+
+  Scenario: Create an order line
+    * def poLine = read('classpath:samples/mod-orders/orderLines/minimal-order-line.json')
+    * set poLine.id = poLineId
+    * set poLine.purchaseOrderId = orderId
+    * set poLine.physical.createInventory = 'Instance, Holding, Item'
+    * set poLine.fundDistribution[0].fundId = fundId
+
+    Given path 'orders/order-lines'
+    And request poLine
+    When method POST
+    Then status 201
+
+
+  Scenario: Open the order
+    Given path 'orders/composite-orders', orderId
+    When method GET
+    Then status 200
+
+    * def orderResponse = $
+    * set orderResponse.workflowStatus = 'Open'
+
+    Given path 'orders/composite-orders', orderId
+    And request orderResponse
+    When method PUT
+    Then status 204
+
+
+  Scenario: Receive the piece with a new location
+    # Get the id of piece created when the order was opened
+    Given path 'orders/pieces'
+    And param query = 'poLineId==' + poLineId
+    When method GET
+    Then status 200
+    And match $.totalRecords == 1
+    * def pieceId = $.pieces[0].id
+
+    # Receive it
+    Given path 'orders/check-in'
+    And request
+    """
+    {
+      toBeCheckedIn: [
+        {
+          checkedIn: 1,
+          checkInPieces: [
+            {
+              id: "#(pieceId)",
+              itemStatus: "In process",
+              locationId: "#(globalLocationsId2)"
+            }
+          ],
+          poLineId: "#(poLineId)"
+        }
+      ],
+      totalRecords: 1
+    }
+    """
+    When method POST
+    Then status 200
+    And match $.receivingResults[0].processedSuccessfully == 1
+
+    # Check piece location and get piece holdingId
+    Given path 'orders/pieces', pieceId
+    When method GET
+    Then status 200
+    And match $.locationId == globalLocationsId2
+    * def pieceHoldingId = $.holdingId
+
+    # Get the instanceId from the po line
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+    * def instanceId = response.instanceId
+
+    # Check the piece holdingId is the same as the id of the holding for the new location
+    * configure headers = headersAdmin
+    Given path 'holdings-storage/holdings'
+    And param query = 'instanceId==' + instanceId + ' and permanentLocationId==' + globalLocationsId2
+    When method GET
+    Then status 200
+    And match $.totalRecords == 1
+    And match $.holdingsRecords[0].id == pieceHoldingId

--- a/acquisitions/src/main/resources/domain/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/domain/mod-orders/orders.feature
@@ -51,6 +51,9 @@ Feature: mod-orders integration tests
     * callonce read('classpath:global/finances.feature')
     * callonce read('classpath:global/organizations.feature')
 
+  Scenario: Change location when receiving a piece
+    Given call read('features/change-location-when-receiving-piece.feature')
+
   Scenario: Delete fund distribution
     Given call read('features/delete-fund-distribution.feature')
 

--- a/acquisitions/src/test/java/org/folio/OrdersApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersApiTest.java
@@ -19,6 +19,11 @@ public class OrdersApiTest extends TestBase {
   }
 
   @Test
+  void changeLocationWhenReceivingPiece() {
+    runFeatureTest("change-location-when-receiving-piece");
+  }
+
+  @Test
   void deleteFundDistribution() {
     runFeatureTest("delete-fund-distribution");
   }


### PR DESCRIPTION
## Purpose
[MODORDERS-616](https://issues.folio.org/browse/MODORDERS-616) - New holdingId is not saved into piece when location is changed during receiving

## Approach
Added a new test for this case, checking the piece's holding id is the one of the holding with the new location.