### PR TITLE
FAT-1031: Given an item Id, a user Id, and a pickup location, attempt to create a hold request when the applicable request policy disallows holds

### DIFF
--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/util/initData.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/util/initData.feature
@@ -276,7 +276,7 @@ Feature: init data for mod-circulation
 
     * def policyEntityRequest = read('samples/policies/request-policy-entity-request.json')
     * def intRequestTypes = ["Hold", "Page", "Recall"]
-    * policyEntityRequest.requestTypes = karate.get('extRequestTypes', intRequestTypes)
+    * policyEntityRequest.requestTypes = karate.get('extRequestTypesForRequestPolicy', intRequestTypes)
     * policyEntityRequest.name = policyEntityRequest.name + ' ' + random_string()
     Given path 'request-policy-storage/request-policies'
     And request policyEntityRequest


### PR DESCRIPTION
## Purpose
[FAT-1031](https://issues.folio.org/browse/FAT-1031)
_Given an item Id, a user Id, and a pickup location, attempt to create a hold request when the applicable request policy disallows holds_

## Approach
- Reproduced test scenario with UI.
- Learned necessary sent requests and then necessary received responses 
- Based on the request/response created karate test scenario


## Learning
- learn karate framework from original doc file on the github
- looked other scenarios how they are described.

