### PR TITLE
FAT-1032: Given an item Id, a user Id, and a pickup location, attempt to create a recall request when the applicable request policy disallows recalls

### DIFF
--- a/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
@@ -38,6 +38,8 @@ Feature: mod-circulation integration tests
       | 'circulation.requests.collection.get'                          |
       | 'circulation.requests.item.get'                                |
       | 'circulation.requests.item.post'                               |
+      | 'circulation.rules.put'                                        |
+      | 'circulation-storage.circulation-rules.get'                    |
       | 'feefineactions.item.post'                                     |
       | 'feefineactions.collection.get'                                |
       | 'feefines.item.post'                                           |

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
@@ -33,7 +33,7 @@ Feature: Requests tests
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(firstUserGroupId)' }
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(userId), extUserBarcode: #(userBarcode), extGroupId: #(firstUserGroupId) }
 
-    # post a request and verify that the user are not allowed to create a page request
+    # post a request and verify that the user is not allowed to create a page request
     * def requestId = call uuid1
     * def requestEntityRequest = read('classpath:vega/mod-circulation/features/samples/request-entity-request.json')
     * requestEntityRequest.requesterId = userId
@@ -69,7 +69,7 @@ Feature: Requests tests
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(secondUserGroupId)' }
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(userId), extUserBarcode: #(userBarcode), extGroupId: #(secondUserGroupId)  }
 
-    # post a request and verify that the user are not allowed to create a page request
+    # post a request and verify that the user is not allowed to create a hold request
     * def requestEntityRequest = read('classpath:vega/mod-circulation/features/samples/request-entity-request.json')
     * requestEntityRequest.requesterId = userId
     * requestEntityRequest.requestType = 'Hold'
@@ -82,32 +82,34 @@ Feature: Requests tests
     And match $.errors[0].message == 'Hold requests are not allowed for this patron and item combination'
 
   Scenario: Given an item Id, a user Id, and a pickup location, attempt to create a recall request when the applicable request policy disallows recalls
+    * def extInstanceTypeId = call uuid1
+    * def extInstanceId = call uuid1
+    * def extHoldingsRecordId = call uuid1
+    * def extMaterialTypeId = call uuid1
+    * def extMaterialTypeName = 'electronic resource 3'
     * def userBarcode = 'FAT-1032UBC'
     * def itemBarcode = 'FAT-1032IBC'
-    * def requestPolicyId = call uuid1
-    * def groupId = call uuid1
-    * def requestId = call uuid1
-    * def extRequestTypes = ["Page", "Hold"]
 
-    # post group, request policy and rule
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostRequestPolicy') { extRequestPolicyId: #(requestPolicyId), requestTypes: #(extRequestTypes) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PutRule') { extPatronGroupId: #(groupId), extMaterialTypeId: #(materialTypeId), extLoanPolicyId: #(loanPolicyId), extOverdueFinePoliciesId: #(overdueFinePoliciesId), extLostItemFeePolicyId: #(lostItemFeePolicyId), extRequestPolicyId: #(requestPolicyId), extPatronPolicyId: #(patronPolicyId)}
+    # post a material type
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(extMaterialTypeId), extMaterialTypeName: #(extMaterialTypeName) }
 
     # post an item
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostInstance')
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostInstance') { extInstanceId: #(extInstanceId) }
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostServicePoint')
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostLocation')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostHoldings')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(itemBarcode) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostHoldings') { extInstanceId: #(extInstanceId), extHoldingsRecordId: #(extHoldingsRecordId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(itemBarcode), extMaterialTypeId: #(extMaterialTypeId), extHoldingsRecordId: #(extHoldingsRecordId) }
 
-    # post an user
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(userId), extUserBarcode: #(userBarcode) }
+    # post a group and an user
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(thirdUserGroupId)' }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(userId), extUserBarcode: #(userBarcode), extGroupId: #(thirdUserGroupId) }
 
     # post a request and verify that the user is not allowed to create a recall request
     * def requestEntityRequest = read('classpath:vega/mod-circulation/features/samples/request-entity-request.json')
     * requestEntityRequest.requesterId = userId
     * requestEntityRequest.requestType = 'Recall'
+    * requestEntityRequest.holdingsRecordId = extHoldingsRecordId
+    * requestEntityRequest.requestLevel = 'Item'
     Given path 'circulation', 'requests'
     And request requestEntityRequest
     When method POST

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
@@ -8,12 +8,15 @@ Feature: Root feature that runs all other mod-circulation features
     * def materialTypeName = 'e-book'
     * def requestPolicyIdForGroup = call uuid1
     * def requestPolicyIdForGroup2 = call uuid1
+    * def requestPolicyIdForGroup3 = call uuid1
     * def extRequestTypesForFirstUserGroupRequestPolicy = ["Hold", "Recall"]
     * def extRequestTypesForSecondUserGroupRequestPolicy = ["Page", "Recall"]
+    * def extRequestTypesForThirdUserGroupRequestPolicy = ["Page", "Hold"]
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(materialTypeId) }
 
     * def firstUserGroupId = '188f025c-6e52-11ec-90d6-0242ac120003'
     * def secondUserGroupId = 'f1a28f58-702d-48fe-b95d-daf7fd55dc27'
+    * def thirdUserGroupId = '0dfcce3e-6fb3-11ec-90d6-0242ac120003'
 
     # policies
     * def loanPolicyId = call uuid1
@@ -27,6 +30,7 @@ Feature: Root feature that runs all other mod-circulation features
     * def extMaterialTypePolicy = { materialTypeId: #(materialTypeId), loanPolicyId: #(loanPolicyMaterialId), overdueFinePoliciesId: #(overdueFinePoliciesId), lostItemFeePolicyId: #(lostItemFeePolicyId), requestPolicyId: #(requestPolicyId), patronPolicyId: #(patronPolicyId) }
     * def extFirstGroupPolicy = { userGroupId: #(firstUserGroupId), loanPolicyId: #(loanPolicyId), overdueFinePoliciesId: #(overdueFinePoliciesId), lostItemFeePolicyId: #(lostItemFeePolicyId), requestPolicyId: #(requestPolicyIdForGroup), patronPolicyId: #(patronPolicyId) }
     * def extSecondGroupPolicy = { userGroupId: #(secondUserGroupId), loanPolicyId: #(loanPolicyId), overdueFinePoliciesId: #(overdueFinePoliciesId), lostItemFeePolicyId: #(lostItemFeePolicyId), requestPolicyId: #(requestPolicyIdForGroup2), patronPolicyId: #(patronPolicyId) }
+    * def extThirdGroupPolicy = { userGroupId: #(thirdUserGroupId), loanPolicyId: #(loanPolicyId), overdueFinePoliciesId: #(overdueFinePoliciesId), lostItemFeePolicyId: #(lostItemFeePolicyId), requestPolicyId: #(requestPolicyIdForGroup3), patronPolicyId: #(patronPolicyId) }
 
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostLoanPolicy') { extLoanPolicyId: #(loanPolicyId) }
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostLoanPolicy') { extLoanPolicyId: #(loanPolicyMaterialId) }
@@ -36,7 +40,8 @@ Feature: Root feature that runs all other mod-circulation features
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRequestPolicy') { extRequestPolicyId: #(requestPolicyId) }
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRequestPolicy') { extRequestPolicyId: #(requestPolicyIdForGroup), extRequestTypes: #(extRequestTypesForFirstUserGroupRequestPolicy) }
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRequestPolicy') { extRequestPolicyId: #(requestPolicyIdForGroup2), extRequestTypes: #(extRequestTypesForSecondUserGroupRequestPolicy) }
-    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRulesWithMaterialTypeAndGroup') extFallbackPolicy, extMaterialTypePolicy, extFirstGroupPolicy, extSecondGroupPolicy
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRequestPolicy') { extRequestPolicyId: #(requestPolicyIdForGroup3), extRequestTypes: #(extRequestTypesForThirdUserGroupRequestPolicy) }
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRulesWithMaterialTypeAndGroup') extFallbackPolicy, extMaterialTypePolicy, extFirstGroupPolicy, extSecondGroupPolicy, extThirdGroupPolicy
 
   Scenario: Run all mod-circulation features
     * call read('classpath:vega/mod-circulation/features/loans.feature')


### PR DESCRIPTION
## Purpose
[FAT-1032](https://issues.folio.org/browse/FAT-1032)
_Given an item Id, a user Id, and a pickup location, attempt to create a recall request when the applicable request policy disallows recalls_

## Approach
- Reproduced test scenario with UI.
- Learned necessary sent requests and then necessary received responses 
- Based on the request/response created karate test scenario


## Learning
- learn karate framework from original doc file on the github
- looked other scenarios how they are described.