### PR TITLE
Mod user bl karate tests permission issue

### DIFF
--- a/mod-users-bl/src/main/resources/domain/mod-users-bl/features/configurePermissions.feature
+++ b/mod-users-bl/src/main/resources/domain/mod-users-bl/features/configurePermissions.feature
@@ -9,7 +9,7 @@ Feature: Configure permissions for admin
       | 'users-bl.item.get'                 |
     * def testAdminUserId = "00000000-1111-5555-9999-999999999991"
 
-  Scenario: Add login-saml permissions to admin user
+  Scenario: Add mod-users-bl permissions to admin user
     Given path 'perms/users'
     And param query = 'userId=="' + testAdminUserId + '"'
     When method GET

--- a/mod-users-bl/src/main/resources/domain/mod-users-bl/features/configurePermissions.feature
+++ b/mod-users-bl/src/main/resources/domain/mod-users-bl/features/configurePermissions.feature
@@ -1,0 +1,32 @@
+Feature: Configure permissions for admin
+
+  Background:
+    * url baseUrl
+    * call login testAdmin
+    * configure headers = { 'Content-Type': 'application/json', 'x-okapi-tenant': #(testTenant), 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json, text/plain' }
+    * table blUserPermissions
+      | name                                |
+      | 'users-bl.item.get'                 |
+    * def testAdminUserId = "00000000-1111-5555-9999-999999999991"
+
+  Scenario: Add login-saml permissions to admin user
+    Given path 'perms/users'
+    And param query = 'userId=="' + testAdminUserId + '"'
+    When method GET
+    Then status 200
+    # Get the permissions user id.
+    * def adminPermissionsUserId = response.permissionUsers[0].id
+    * def currentPerms = response.permissionUsers[0].permissions
+    * def newPerms = $blUserPermissions[*].name
+    * def permissions = karate.append(currentPerms, newPerms)
+    Given path 'perms/users/', adminPermissionsUserId
+    And request
+    """
+    {
+      "userId": #(testAdminUserId),
+      "permissions": #(permissions)
+    }
+    """
+    When method PUT
+    Then status 200
+    And match response.permissions contains $blUserPermissions[*].name

--- a/mod-users-bl/src/main/resources/domain/mod-users-bl/features/users-bl.feature
+++ b/mod-users-bl/src/main/resources/domain/mod-users-bl/features/users-bl.feature
@@ -94,7 +94,7 @@ Feature: Test user business logic
     When method GET
     Then status 200
 
-  Scenario: Return a composite object for the currently logged in user
+  Scenario: Return a composite object for the currently logged in user by username
     * call login testAdmin
     * configure headers =
     """

--- a/mod-users-bl/src/main/resources/domain/mod-users-bl/features/users-bl.feature
+++ b/mod-users-bl/src/main/resources/domain/mod-users-bl/features/users-bl.feature
@@ -4,6 +4,8 @@ Feature: Test user business logic
     * url baseUrl
     * configure lowerCaseResponseHeaders = true
     * def newPassword = "Passw0rd1;"
+  Scenario: Set the right permissions for the admin user to allow for SAML configuration
+    Given call read("configurePermissions.feature")
 
   Scenario: Login, validate the response, change password, login with new
     * call login testAdmin
@@ -77,3 +79,31 @@ Feature: Test user business logic
     When method POST
     Then status 201
     And match responseHeaders contains { 'x-okapi-token': '#present' }
+
+  Scenario: Return a composite object for the currently logged in user
+    * call login testAdmin
+    * configure headers =
+    """
+    {
+      "X-Okapi-Tenant": "#(testTenant)",
+      "Accept": "application/json",
+      'x-okapi-token': '#(okapitoken)'
+    }
+    """
+    Given path 'bl-users/_self'
+    When method GET
+    Then status 200
+
+  Scenario: Return a composite object for the currently logged in user
+    * call login testAdmin
+    * configure headers =
+    """
+    {
+      "X-Okapi-Tenant": "#(testTenant)",
+      "Accept": "application/json",
+      'x-okapi-token': '#(okapitoken)'
+    }
+    """
+    Given path 'bl-users/by-username/' + 'test-admin'
+    When method GET
+    Then status 200

--- a/mod-users-bl/src/main/resources/domain/mod-users-bl/users-bl-junit.feature
+++ b/mod-users-bl/src/main/resources/domain/mod-users-bl/users-bl-junit.feature
@@ -18,12 +18,18 @@ Feature: mod-login integration tests
 
     * table userPermissions
       | name                                |
+      | 'perms.users.get'                   |
+      | 'perms.users.item.put'              |
+
 
   Scenario: create tenant and users for testing
     Given call read('classpath:common/setup-users.feature')
 
   # It would seem that mod-users-bl cannot be enabled before mod-authtoken, otherwise permissions problems will happen.
   # mod-authtoken is enabled as the last step of setup-users.feature.
+
   Scenario: install mod-users-bl
     Given call read('classpath:common/tenant.feature@install') { modules: [{name: 'mod-users-bl'}], tenant: '#(testTenant)'}
+
+
 


### PR DESCRIPTION
@adamdickmeiss 
It would seem that mod-users-bl cannot be enabled before mod-authtoken, otherwise permissions problems will happen.
So i have added 1 extra feature file (configurepermission.feature) to set permissions for admin. 

The permission issue is occurring at test:- Scenario: Return a composite object for the currently logged in user by username(Line no:-97) in users-bl.feature file.
