### PR TITLE
FAT-1034 Attempt to create a hold request when request policy allows it but item status does not (should fail)

### DIFF
--- a/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
@@ -74,6 +74,7 @@ Feature: mod-circulation integration tests
       | 'owners.item.post'                                             |
       | 'payments.item.post'                                           |
       | 'usergroups.item.post'                                         |
+      | 'usergroups.collection.get'                                         |
       | 'users.item.post'                                              |
       | 'users.item.get'                                               |
 

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
@@ -2,43 +2,41 @@ Feature: Requests tests
 
   Background:
     * url baseUrl
-    * def itemId = call uuid1
     * def servicePointId = call uuid1
-    * def userId = call uuid1
     * def groupId = call uuid1
     * def instanceId = call uuid1
     * def locationId = call uuid1
     * def holdingId = call uuid1
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostInstance')
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostServicePoint')
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostLocation')
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostHoldings')
 
   Scenario: Given an item Id, a user Id, and a pickup location, attempt to create a page request when the applicable request policy disallows pages
-    * def extInstanceTypeId = call uuid1
-    * def extInstanceId = call uuid1
-    * def extHoldingsRecordId = call uuid1
     * def extMaterialTypeId = call uuid1
     * def extMaterialTypeName = 'electronic resource'
-    * def userBarcode = 'FAT-1030UBC'
-    * def itemBarcode = 'FAT-1030IBC'
+    * def extUserBarcode = 'FAT-1030UBC'
+    * def extItemBarcode = 'FAT-1030IBC'
+    * def extItemId = call uuid1
+    * def extUserId = call uuid1
 
     # post a material type
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(extMaterialTypeId), extMaterialTypeName: #(extMaterialTypeName) }
 
     # post an item
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostInstance') { extInstanceId: #(extInstanceId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostServicePoint')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostLocation')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostHoldings') { extInstanceTypeId: #(extInstanceTypeId), extHoldingsRecordId: #(extHoldingsRecordId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(itemBarcode), extMaterialTypeId: #(extMaterialTypeId), extHoldingsRecordId: #(extHoldingsRecordId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(extItemId), extItemBarcode: #(extItemBarcode), extMaterialTypeId: #(extMaterialTypeId) }
 
     # post a group and an user
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(firstUserGroupId)' }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(userId), extUserBarcode: #(userBarcode), extGroupId: #(firstUserGroupId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(extUserId), extUserBarcode: #(extUserBarcode), extGroupId: #(firstUserGroupId) }
 
     # post a request and verify that the user is not allowed to create a page request
     * def requestId = call uuid1
     * def requestEntityRequest = read('classpath:vega/mod-circulation/features/samples/request-entity-request.json')
-    * requestEntityRequest.requesterId = userId
+    * requestEntityRequest.requesterId = extUserId
+    * requestEntityRequest.itemId = extItemId
     * requestEntityRequest.requestType = 'Page'
-    * requestEntityRequest.holdingsRecordId = extHoldingsRecordId
+    * requestEntityRequest.holdingsRecordId = holdingId
     * requestEntityRequest.requestLevel = 'Item'
     Given path 'circulation', 'requests'
     And request requestEntityRequest
@@ -47,33 +45,29 @@ Feature: Requests tests
     And match $.errors[0].message == 'Page requests are not allowed for this patron and item combination'
 
   Scenario: Given an item Id, a user Id, and a pickup location, attempt to create a hold request when the applicable request policy disallows holds
-    * def extInstanceTypeId = call uuid1
-    * def extInstanceId = call uuid1
-    * def extHoldingsRecordId = call uuid1
     * def extMaterialTypeId = call uuid1
     * def extMaterialTypeName = 'electronic resource 2'
-    * def userBarcode = 'FAT-1031UBC'
-    * def itemBarcode = 'FAT-1031IBC'
+    * def extUserBarcode = 'FAT-1031UBC'
+    * def extItemBarcode = 'FAT-1031IBC'
+    * def extItemId = call uuid1
+    * def extUserId = call uuid1
 
     # post a material type
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(extMaterialTypeId), extMaterialTypeName: #(extMaterialTypeName) }
 
     # post an item
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostInstance') { extInstanceId: #(extInstanceId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostServicePoint')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostLocation')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostHoldings') { extInstanceId: #(extInstanceId), extHoldingsRecordId: #(extHoldingsRecordId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(itemBarcode), extMaterialTypeId: #(extMaterialTypeId), extHoldingsRecordId: #(extHoldingsRecordId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(extItemId), extItemBarcode: #(extItemBarcode), extMaterialTypeId: #(extMaterialTypeId) }
 
     # post a group and an user
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(secondUserGroupId)' }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(userId), extUserBarcode: #(userBarcode), extGroupId: #(secondUserGroupId)  }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(extUserId), extUserBarcode: #(extUserBarcode), extGroupId: #(secondUserGroupId)  }
 
     # post a request and verify that the user is not allowed to create a hold request
     * def requestEntityRequest = read('classpath:vega/mod-circulation/features/samples/request-entity-request.json')
-    * requestEntityRequest.requesterId = userId
+    * requestEntityRequest.requesterId = extUserId
+    * requestEntityRequest.itemId = extItemId
     * requestEntityRequest.requestType = 'Hold'
-    * requestEntityRequest.holdingsRecordId = extHoldingsRecordId
+    * requestEntityRequest.holdingsRecordId = holdingId
     * requestEntityRequest.requestLevel = 'Item'
     Given path 'circulation', 'requests'
     And request requestEntityRequest
@@ -82,33 +76,29 @@ Feature: Requests tests
     And match $.errors[0].message == 'Hold requests are not allowed for this patron and item combination'
 
   Scenario: Given an item Id, a user Id, and a pickup location, attempt to create a recall request when the applicable request policy disallows recalls
-    * def extInstanceTypeId = call uuid1
-    * def extInstanceId = call uuid1
-    * def extHoldingsRecordId = call uuid1
     * def extMaterialTypeId = call uuid1
     * def extMaterialTypeName = 'electronic resource 3'
-    * def userBarcode = 'FAT-1032UBC'
-    * def itemBarcode = 'FAT-1032IBC'
+    * def extUserBarcode = 'FAT-1032UBC'
+    * def extItemBarcode = 'FAT-1032IBC'
+    * def extItemId = call uuid1
+    * def extUserId = call uuid1
 
     # post a material type
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(extMaterialTypeId), extMaterialTypeName: #(extMaterialTypeName) }
 
     # post an item
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostInstance') { extInstanceId: #(extInstanceId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostServicePoint')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostLocation')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostHoldings') { extInstanceId: #(extInstanceId), extHoldingsRecordId: #(extHoldingsRecordId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(itemBarcode), extMaterialTypeId: #(extMaterialTypeId), extHoldingsRecordId: #(extHoldingsRecordId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(extItemId), extItemBarcode: #(extItemBarcode), extMaterialTypeId: #(extMaterialTypeId) }
 
     # post a group and an user
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(thirdUserGroupId)' }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(userId), extUserBarcode: #(userBarcode), extGroupId: #(thirdUserGroupId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(extUserId), extUserBarcode: #(extUserBarcode), extGroupId: #(thirdUserGroupId) }
 
     # post a request and verify that the user is not allowed to create a recall request
     * def requestEntityRequest = read('classpath:vega/mod-circulation/features/samples/request-entity-request.json')
-    * requestEntityRequest.requesterId = userId
+    * requestEntityRequest.requesterId = extUserId
+    * requestEntityRequest.itemId = extItemId
     * requestEntityRequest.requestType = 'Recall'
-    * requestEntityRequest.holdingsRecordId = extHoldingsRecordId
+    * requestEntityRequest.holdingsRecordId = holdingId
     * requestEntityRequest.requestLevel = 'Item'
     Given path 'circulation', 'requests'
     And request requestEntityRequest
@@ -117,33 +107,29 @@ Feature: Requests tests
     And match $.errors[0].message == 'Recall requests are not allowed for this patron and item combination'
 
   Scenario: Given an item Id, a user Id, and a pickup location, attempt to create a page request when the applicable request policy allows pages, but items is not of status Available or Recently returned
-    * def extInstanceTypeId = call uuid1
-    * def extInstanceId = call uuid1
-    * def extHoldingsRecordId = call uuid1
     * def extMaterialTypeId = call uuid1
     * def extMaterialTypeName = 'electronic resource 4'
-    * def userBarcode = 'FAT-1033UBC'
-    * def itemBarcode = 'FAT-1033IBC'
+    * def extUserBarcode = 'FAT-1033UBC'
+    * def extItemBarcode = 'FAT-1033IBC'
     * def extStatusName = 'Paged'
+    * def extItemId = call uuid1
+    * def extUserId = call uuid1
 
     # post a material type
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(extMaterialTypeId), extMaterialTypeName: #(extMaterialTypeName) }
 
     # post an item
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostInstance') { extInstanceId: #(extInstanceId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostServicePoint')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostLocation')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostHoldings') { extInstanceId: #(extInstanceId), extHoldingsRecordId: #(extHoldingsRecordId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(itemBarcode), extStatusName: #(extStatusName), extMaterialTypeId: #(extMaterialTypeId), extHoldingsRecordId: #(extHoldingsRecordId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(extItemId), extItemBarcode: #(extItemBarcode), extStatusName: #(extStatusName), extMaterialTypeId: #(extMaterialTypeId) }
 
     # post an user
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(userId), extUserBarcode: #(userBarcode), extGroupId: #(fourthUserGroupId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(extUserId), extUserBarcode: #(extUserBarcode), extGroupId: #(fourthUserGroupId) }
 
     # post a request and verify that the user is not allowed to create a page request
     * def requestEntityRequest = read('classpath:vega/mod-circulation/features/samples/request-entity-request.json')
-    * requestEntityRequest.requesterId = userId
+    * requestEntityRequest.requesterId = extUserId
+    * requestEntityRequest.itemId = extItemId
     * requestEntityRequest.requestType = 'Page'
-    * requestEntityRequest.holdingsRecordId = extHoldingsRecordId
+    * requestEntityRequest.holdingsRecordId = holdingId
     * requestEntityRequest.requestLevel = 'Item'
     Given path 'circulation', 'requests'
     And request requestEntityRequest
@@ -151,37 +137,46 @@ Feature: Requests tests
     Then status 422
     And match $.errors[0].message == 'Page requests are not allowed for this patron and item combination'
 
-  Scenario: Requests: Given an item Id, a user Id, and a pickup location, attempt to create a hold request when the applicable request policy allows holds, but item is of status "Available", "Recently returned", "In process (not requestable)", "Declared lost", "Lost and paid", "Aged to lost", "Claimed returned", "Missing from ASR", "Long missing", "Retrieving from ASR", "Withdrawn", "Order closed", "Intellectual item", "Unavailable", or "Unknown" (should fail)
-    * def extInstanceTypeId = call uuid1
-    * def extInstanceId = call uuid1
-    * def extHoldingsRecordId = call uuid1
+    # This scenario does not cover testing for item with statuses, 'Recently returned', 'Missing from ASR' and 'Retrieving from ASR' due to lack of implementation
+  Scenario Outline: Requests: Given an item Id, a user Id, and a pickup location, attempt to create a hold request when the applicable request policy allows holds, but item is of status "Available", "Recently returned", "In process (not requestable)", "Declared lost", "Lost and paid", "Aged to lost", "Claimed returned", "Missing from ASR", "Long missing", "Retrieving from ASR", "Withdrawn", "Order closed", "Intellectual item", "Unavailable", or "Unknown" (should fail)
     * def extMaterialTypeId = call uuid1
-    * def extMaterialTypeName = 'electronic resource 5'
-    * def userBarcode = 'FAT-1034UBC'
-    * def itemBarcode = 'FAT-1034IBC'
-    * def extStatusName = 'Declared lost'
+    * def extItemId = call uuid1
+    * def extUserId = call uuid1
 
     # post a material type
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(extMaterialTypeId), extMaterialTypeName: #(extMaterialTypeName) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(extMaterialTypeId), extMaterialTypeName:  #(<materialTypeName>) }
 
     # post an item
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostInstance') { extInstanceId: #(extInstanceId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostServicePoint')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostLocation')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostHoldings') { extInstanceId: #(extInstanceId), extHoldingsRecordId: #(extHoldingsRecordId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(itemBarcode), extMaterialTypeId: #(extMaterialTypeId), extHoldingsRecordId: #(extHoldingsRecordId), extStatusName: #(extStatusName) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(extItemId), extItemBarcode: #(<itemBarcode>), extMaterialTypeId: #(extMaterialTypeId), extStatusName: #(<status>) }
 
     # post an user
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(userId), extUserBarcode: #(userBarcode), extGroupId: #(fourthUserGroupId)  }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(extUserId), extUserBarcode: #(<userBarcode>), extGroupId: #(fourthUserGroupId)  }
 
     # post a request and verify that the user is not allowed to create a hold request
+    * def requestId = call uuid1
     * def requestEntityRequest = read('classpath:vega/mod-circulation/features/samples/request-entity-request.json')
-    * requestEntityRequest.requesterId = userId
+    * requestEntityRequest.requesterId = extUserId
+    * requestEntityRequest.itemId = extItemId
     * requestEntityRequest.requestType = 'Hold'
-    * requestEntityRequest.holdingsRecordId = extHoldingsRecordId
+    * requestEntityRequest.holdingsRecordId = holdingId
     * requestEntityRequest.requestLevel = 'Item'
     Given path 'circulation', 'requests'
     And request requestEntityRequest
     When method POST
     Then status 422
     And match $.errors[0].message == 'Hold requests are not allowed for this patron and item combination'
+
+    # 'Recently returned', 'Missing from ASR' and 'Retrieving from ASR' are skipped due to the lack of implementation
+    Examples:
+      | status                         | materialTypeName              | itemBarcode      | userBarcode      |
+      | 'Available'                    | 'electronic resource 1034-1'  | 'FAT-1034IBC-1'  | 'FAT-1034UBC-1'  |
+      | 'In process (non-requestable)' | 'electronic resource 1034-3'  | 'FAT-1034IBC-3'  | 'FAT-1034UBC-3'  |
+      | 'Declared lost'                | 'electronic resource 1034-4'  | 'FAT-1034IBC-4'  | 'FAT-1034UBC-4'  |
+      | 'Lost and paid'                | 'electronic resource 1034-5'  | 'FAT-1034IBC-5'  | 'FAT-1034UBC-5'  |
+      | 'Aged to lost'                 | 'electronic resource 1034-6'  | 'FAT-1034IBC-6'  | 'FAT-1034UBC-6'  |
+      | 'Claimed returned'             | 'electronic resource 1034-7'  | 'FAT-1034IBC-7'  | 'FAT-1034UBC-7'  |
+      | 'Long missing'                 | 'electronic resource 1034-8'  | 'FAT-1034IBC-8'  | 'FAT-1034UBC-8'  |
+      | 'Withdrawn'                    | 'electronic resource 1034-9'  | 'FAT-1034IBC-9'  | 'FAT-1034UBC-9'  |
+      | 'Intellectual item'            | 'electronic resource 1034-11' | 'FAT-1034IBC-11' | 'FAT-1034UBC-11' |
+      | 'Unavailable'                  | 'electronic resource 1034-12' | 'FAT-1034IBC-12' | 'FAT-1034UBC-12' |
+      | 'Unknown'                      | 'electronic resource 1034-13' | 'FAT-1034IBC-13' | 'FAT-1034UBC-13' |

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
@@ -15,10 +15,13 @@ Feature: Root feature that runs all other mod-circulation features
     * def extRequestTypesForThirdUserGroupRequestPolicy = ["Page", "Hold"]
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(materialTypeId) }
 
+    # groups
     * def firstUserGroupId = '188f025c-6e52-11ec-90d6-0242ac120003'
     * def secondUserGroupId = 'f1a28f58-702d-48fe-b95d-daf7fd55dc27'
     * def thirdUserGroupId = '0dfcce3e-6fb3-11ec-90d6-0242ac120003'
     * def fourthUserGroupId = 'a58053e4-6fbc-11ec-90d6-0242ac120003'
+
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(fourthUserGroupId)' }
 
     # policies
     * def loanPolicyId = call uuid1

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/util/initData.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/util/initData.feature
@@ -242,7 +242,9 @@ Feature: init data for mod-circulation
     * def materialTypePolicy = 'm ' + extMaterialTypePolicy.materialTypeId + ': l ' + extMaterialTypePolicy.loanPolicyId + ' o ' + extMaterialTypePolicy.overdueFinePoliciesId + ' i ' + extMaterialTypePolicy.lostItemFeePolicyId + ' r ' + extMaterialTypePolicy.requestPolicyId + ' n ' + extMaterialTypePolicy.patronPolicyId
     * def groupPolicy = 'g ' + extFirstGroupPolicy.userGroupId + ': l ' + extFirstGroupPolicy.loanPolicyId + ' o ' + extFirstGroupPolicy.overdueFinePoliciesId + ' i ' + extFirstGroupPolicy.lostItemFeePolicyId + ' r ' + extFirstGroupPolicy.requestPolicyId + ' n ' + extFirstGroupPolicy.patronPolicyId
     * def groupPolicy2 = 'g ' + extSecondGroupPolicy.userGroupId + ': l ' + extSecondGroupPolicy.loanPolicyId + ' o ' + extSecondGroupPolicy.overdueFinePoliciesId + ' i ' + extSecondGroupPolicy.lostItemFeePolicyId + ' r ' + extSecondGroupPolicy.requestPolicyId + ' n ' + extSecondGroupPolicy.patronPolicyId
-    * def rules = 'priority: t, s, c, b, a, m, g ' + fallbackPolicy + '\n' + materialTypePolicy + '\n' + groupPolicy + '\n' + groupPolicy2
+    * def groupPolicy3 = 'g ' + extThirdGroupPolicy.userGroupId + ': l ' + extThirdGroupPolicy.loanPolicyId + ' o ' + extThirdGroupPolicy.overdueFinePoliciesId + ' i ' + extThirdGroupPolicy.lostItemFeePolicyId + ' r ' + extThirdGroupPolicy.requestPolicyId + ' n ' + extThirdGroupPolicy.patronPolicyId
+    * def groupPolicy4 = 'g ' + extFourthGroupPolicy.userGroupId + ': l ' + extFourthGroupPolicy.loanPolicyId + ' o ' + extFourthGroupPolicy.overdueFinePoliciesId + ' i ' + extFourthGroupPolicy.lostItemFeePolicyId + ' r ' + extFourthGroupPolicy.requestPolicyId + ' n ' + extFourthGroupPolicy.patronPolicyId
+    * def rules = 'priority: t, s, c, b, a, m, g ' + fallbackPolicy + '\n' + materialTypePolicy + '\n' + groupPolicy + '\n' + groupPolicy2 + '\n' + groupPolicy3 + '\n' + groupPolicy4
     * def rulesEntityRequest = { "rulesAsText": "#(rules)" }
     Given path 'circulation-rules-storage'
     And request rulesEntityRequest


### PR DESCRIPTION
## Purpose
[FAT-1034](https://issues.folio.org/browse/FAT-1034)
_Requests: Given an item Id, a user Id, and a pickup location, attempt to create a hold request when the applicable request policy allows holds, but item is of status "Available", "Recently returned", "In process (not requestable)", "Declared lost", "Lost and paid", "Aged to lost", "Claimed returned", "Missing from ASR", "Long missing", "Retrieving from ASR", "Withdrawn", "Order closed", "Intellectual item", "Unavailable", or "Unknown" (should fail)_

## Approach
- Reproduced test scenario with UI.
- Learned necessary sent requests and then necessary received responses
- Based on the request/response created karate test scenario

## Learning
- learn karate framework from original doc file on the github
- looked other scenarios how they are described.