### PR TITLE
FAT-1035: Attempt to create a recall request when request policy allows it but item status does not (should fail)

### DIFF
--- a/acquisitions/src/main/resources/karate-config.js
+++ b/acquisitions/src/main/resources/karate-config.js
@@ -103,6 +103,14 @@ function fn() {
       name: 'testing_admin',
       password: 'admin'
     }
+  } else if (env == 'rancher') {
+        config.baseUrl = 'https://thunderjet-okapi.ci.folio.org';
+        config.edgeUrl = 'https://folio-snapshot.dev.folio.org:8000';
+        config.admin = {
+          tenant: 'diku',
+          name: 'diku_admin',
+          password: 'admin'
+        }
   } else if (env != null && env.match(/^ec2-\d+/)) {
     // Config for FOLIO CI "folio-integration" public ec2- dns name
     config.baseUrl = 'http://' + env + ':9130';

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules-junit.feature
@@ -25,7 +25,6 @@ Feature: cross-module integration tests
       | 'orders.item.approve'      |
       | 'orders.item.reopen'       |
       | 'orders.item.unopen'       |
-      | 'inventory.items.item.get' |
 
     * table desiredPermissions
       | desiredPermissionName |

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
@@ -33,7 +33,6 @@ Feature: cross-module integration tests
       | 'orders.item.approve'      |
       | 'orders.item.reopen'       |
       | 'orders.item.unopen'       |
-      | 'inventory.items.item.get' |
 
     * table desiredPermissions
       | desiredPermissionName |
@@ -103,6 +102,9 @@ Feature: cross-module integration tests
 
   Scenario: Chek po numbers updates when invoice line deleted
     Given call read('features/chek-po-numbers-updates-when-invoice-line-deleted.feature')
+
+  Scenario: Pay invoice with new expense class
+    Given call read('features/pay-invoice-with-new-expense-class.feature')
 
   Scenario: wipe data
     Given call read('classpath:common/destroy-data.feature')

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/pay-invoice-with-new-expense-class.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/pay-invoice-with-new-expense-class.feature
@@ -1,0 +1,175 @@
+# For https://issues.folio.org/browse/MODORDERS-638
+@parallel=false
+Feature: Pay invoice with new expense class
+
+  Background:
+    * url baseUrl
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json'  }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json'  }
+
+    * configure headers = headersUser
+
+    * callonce variables
+
+    * def orderLineTemplate = read('classpath:samples/mod-orders/orderLines/minimal-order-line.json')
+    * def invoiceTemplate = read('classpath:samples/mod-invoice/invoices/global/invoice.json')
+    * def invoiceLineTemplate = read('classpath:samples/mod-invoice/invoices/global/invoice-line-percentage.json')
+
+    * def fundId = callonce uuid1
+    * def budgetId = callonce uuid2
+    * def orderId = callonce uuid3
+    * def poLineId = callonce uuid4
+    * def invoiceId = callonce uuid5
+    * def invoiceLineId = callonce uuid6
+
+
+  Scenario: Create finances
+    * configure headers = headersAdmin
+    * call createFund { 'id': '#(fundId)'}
+    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)', 'status': 'Active'}]}
+
+
+  Scenario: Create an order
+    * print "Create an order"
+
+    Given path 'orders/composite-orders'
+    And request
+    """
+    {
+      id: '#(orderId)',
+      vendor: '#(globalVendorId)',
+      orderType: 'One-Time'
+    }
+    """
+    When method POST
+    Then status 201
+
+
+  Scenario: Create an order line without using an expense class
+    * print "Create an order line without using an expense class"
+
+    * copy poLine = orderLineTemplate
+    * set poLine.id = poLineId
+    * set poLine.purchaseOrderId = orderId
+    * set poLine.fundDistribution[0].fundId = fundId
+    * set poLine.cost.listUnitPrice = 10
+
+    Given path 'orders/order-lines'
+    And request poLine
+    When method POST
+    Then status 201
+
+
+  Scenario: Open the order
+    * print "Open the order"
+
+    Given path 'orders/composite-orders', orderId
+    When method GET
+    Then status 200
+
+    * def orderResponse = $
+    * set orderResponse.workflowStatus = 'Open'
+
+    Given path 'orders/composite-orders', orderId
+    And request orderResponse
+    When method PUT
+    Then status 204
+
+
+  Scenario: Add an expense class to the budget
+    * print "Add an expense class to the budget"
+
+    Given path 'finance/budgets', budgetId
+    When method GET
+    Then status 200
+    * def budget = $
+
+    * set budget.statusExpenseClasses = [{'expenseClassId': '#(globalElecExpenseClassId)'}]
+
+    Given path 'finance/budgets', budgetId
+    And request budget
+    When method PUT
+    Then status 204
+
+
+  Scenario: Create an invoice
+    * print "Create an invoice"
+
+    * copy invoice = invoiceTemplate
+    * set invoice.id = invoiceId
+
+    Given path 'invoice/invoices'
+    And request invoice
+    When method POST
+    Then status 201
+
+
+  Scenario: Add an invoice line with the expense class
+    * print "Add an invoice line with the expense class"
+
+    * copy invoiceLine = invoiceLineTemplate
+    * set invoiceLine.id = invoiceLineId
+    * set invoiceLine.invoiceId = invoiceId
+    * set invoiceLine.poLineId = poLineId
+    * set invoiceLine.fundDistributions[0].fundId = fundId
+    * set invoiceLine.total = 10
+    * set invoiceLine.subTotal = 10
+
+    Given path 'invoice/invoice-lines'
+    And request invoiceLine
+    When method POST
+    Then status 201
+
+
+  Scenario: Approve the invoice
+    * print "Approve the invoice"
+
+    Given path 'invoice/invoices', invoiceId
+    When method GET
+    Then status 200
+
+    * def invoice = $
+    * set invoice.status = 'Approved'
+
+    Given path 'invoice/invoices', invoiceId
+    And request invoice
+    When method PUT
+    Then status 204
+
+
+  Scenario: Add the expense class to the order line
+    * print "Add the expense class to the order line"
+
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+
+    * def poLine = $
+    * set poLine.fundDistribution[0].expenseClassId = globalElecExpenseClassId
+
+    Given path 'orders/order-lines', poLineId
+    And request poLine
+    When method PUT
+    Then status 204
+
+
+  Scenario: Pay the invoice
+    * print "Pay the invoice"
+
+    Given path 'invoice/invoices', invoiceId
+    When method GET
+    Then status 200
+
+    * def invoice = $
+    * set invoice.status = 'Paid'
+
+    Given path 'invoice/invoices', invoiceId
+    And request invoice
+    When method PUT
+    Then status 204

--- a/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
+++ b/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
@@ -102,6 +102,11 @@ public class CrossModulesApiTest extends TestBase {
     runFeatureTest("MODFISTO-270-delete-planned-budget-without-transactions");
   }
 
+  @Test
+  void payInvoiceWithNewExpenseClass() {
+    runFeatureTest("pay-invoice-with-new-expense-class");
+  }
+
   @BeforeAll
   public void crossModuleApiTestBeforeAll() {
     runFeature("classpath:thunderjet/cross-modules/cross-modules-junit.feature");

--- a/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
@@ -74,6 +74,7 @@ Feature: mod-circulation integration tests
       | 'owners.item.post'                                             |
       | 'payments.item.post'                                           |
       | 'usergroups.item.post'                                         |
+      | 'usergroups.collection.get'                                         |
       | 'users.item.post'                                              |
       | 'users.item.get'                                               |
 

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
@@ -2,43 +2,41 @@ Feature: Requests tests
 
   Background:
     * url baseUrl
-    * def itemId = call uuid1
     * def servicePointId = call uuid1
-    * def userId = call uuid1
     * def groupId = call uuid1
     * def instanceId = call uuid1
     * def locationId = call uuid1
     * def holdingId = call uuid1
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostInstance')
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostServicePoint')
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostLocation')
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostHoldings')
 
   Scenario: Given an item Id, a user Id, and a pickup location, attempt to create a page request when the applicable request policy disallows pages
-    * def extInstanceTypeId = call uuid1
-    * def extInstanceId = call uuid1
-    * def extHoldingsRecordId = call uuid1
     * def extMaterialTypeId = call uuid1
     * def extMaterialTypeName = 'electronic resource'
-    * def userBarcode = 'FAT-1030UBC'
-    * def itemBarcode = 'FAT-1030IBC'
+    * def extUserBarcode = 'FAT-1030UBC'
+    * def extItemBarcode = 'FAT-1030IBC'
+    * def extItemId = call uuid1
+    * def extUserId = call uuid1
 
     # post a material type
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(extMaterialTypeId), extMaterialTypeName: #(extMaterialTypeName) }
 
     # post an item
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostInstance') { extInstanceId: #(extInstanceId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostServicePoint')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostLocation')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostHoldings') { extInstanceTypeId: #(extInstanceTypeId), extHoldingsRecordId: #(extHoldingsRecordId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(itemBarcode), extMaterialTypeId: #(extMaterialTypeId), extHoldingsRecordId: #(extHoldingsRecordId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(extItemId), extItemBarcode: #(extItemBarcode), extMaterialTypeId: #(extMaterialTypeId) }
 
     # post a group and an user
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(firstUserGroupId)' }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(userId), extUserBarcode: #(userBarcode), extGroupId: #(firstUserGroupId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(extUserId), extUserBarcode: #(extUserBarcode), extGroupId: #(firstUserGroupId) }
 
     # post a request and verify that the user is not allowed to create a page request
     * def requestId = call uuid1
     * def requestEntityRequest = read('classpath:vega/mod-circulation/features/samples/request-entity-request.json')
-    * requestEntityRequest.requesterId = userId
+    * requestEntityRequest.requesterId = extUserId
+    * requestEntityRequest.itemId = extItemId
     * requestEntityRequest.requestType = 'Page'
-    * requestEntityRequest.holdingsRecordId = extHoldingsRecordId
+    * requestEntityRequest.holdingsRecordId = holdingId
     * requestEntityRequest.requestLevel = 'Item'
     Given path 'circulation', 'requests'
     And request requestEntityRequest
@@ -47,33 +45,29 @@ Feature: Requests tests
     And match $.errors[0].message == 'Page requests are not allowed for this patron and item combination'
 
   Scenario: Given an item Id, a user Id, and a pickup location, attempt to create a hold request when the applicable request policy disallows holds
-    * def extInstanceTypeId = call uuid1
-    * def extInstanceId = call uuid1
-    * def extHoldingsRecordId = call uuid1
     * def extMaterialTypeId = call uuid1
     * def extMaterialTypeName = 'electronic resource 2'
-    * def userBarcode = 'FAT-1031UBC'
-    * def itemBarcode = 'FAT-1031IBC'
+    * def extUserBarcode = 'FAT-1031UBC'
+    * def extItemBarcode = 'FAT-1031IBC'
+    * def extItemId = call uuid1
+    * def extUserId = call uuid1
 
     # post a material type
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(extMaterialTypeId), extMaterialTypeName: #(extMaterialTypeName) }
 
     # post an item
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostInstance') { extInstanceId: #(extInstanceId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostServicePoint')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostLocation')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostHoldings') { extInstanceId: #(extInstanceId), extHoldingsRecordId: #(extHoldingsRecordId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(itemBarcode), extMaterialTypeId: #(extMaterialTypeId), extHoldingsRecordId: #(extHoldingsRecordId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(extItemId), extItemBarcode: #(extItemBarcode), extMaterialTypeId: #(extMaterialTypeId) }
 
     # post a group and an user
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(secondUserGroupId)' }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(userId), extUserBarcode: #(userBarcode), extGroupId: #(secondUserGroupId)  }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(extUserId), extUserBarcode: #(extUserBarcode), extGroupId: #(secondUserGroupId)  }
 
     # post a request and verify that the user is not allowed to create a hold request
     * def requestEntityRequest = read('classpath:vega/mod-circulation/features/samples/request-entity-request.json')
-    * requestEntityRequest.requesterId = userId
+    * requestEntityRequest.requesterId = extUserId
+    * requestEntityRequest.itemId = extItemId
     * requestEntityRequest.requestType = 'Hold'
-    * requestEntityRequest.holdingsRecordId = extHoldingsRecordId
+    * requestEntityRequest.holdingsRecordId = holdingId
     * requestEntityRequest.requestLevel = 'Item'
     Given path 'circulation', 'requests'
     And request requestEntityRequest
@@ -82,33 +76,29 @@ Feature: Requests tests
     And match $.errors[0].message == 'Hold requests are not allowed for this patron and item combination'
 
   Scenario: Given an item Id, a user Id, and a pickup location, attempt to create a recall request when the applicable request policy disallows recalls
-    * def extInstanceTypeId = call uuid1
-    * def extInstanceId = call uuid1
-    * def extHoldingsRecordId = call uuid1
     * def extMaterialTypeId = call uuid1
     * def extMaterialTypeName = 'electronic resource 3'
-    * def userBarcode = 'FAT-1032UBC'
-    * def itemBarcode = 'FAT-1032IBC'
+    * def extUserBarcode = 'FAT-1032UBC'
+    * def extItemBarcode = 'FAT-1032IBC'
+    * def extItemId = call uuid1
+    * def extUserId = call uuid1
 
     # post a material type
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(extMaterialTypeId), extMaterialTypeName: #(extMaterialTypeName) }
 
     # post an item
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostInstance') { extInstanceId: #(extInstanceId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostServicePoint')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostLocation')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostHoldings') { extInstanceId: #(extInstanceId), extHoldingsRecordId: #(extHoldingsRecordId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(itemBarcode), extMaterialTypeId: #(extMaterialTypeId), extHoldingsRecordId: #(extHoldingsRecordId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(extItemId), extItemBarcode: #(extItemBarcode), extMaterialTypeId: #(extMaterialTypeId) }
 
     # post a group and an user
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(thirdUserGroupId)' }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(userId), extUserBarcode: #(userBarcode), extGroupId: #(thirdUserGroupId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(extUserId), extUserBarcode: #(extUserBarcode), extGroupId: #(thirdUserGroupId) }
 
     # post a request and verify that the user is not allowed to create a recall request
     * def requestEntityRequest = read('classpath:vega/mod-circulation/features/samples/request-entity-request.json')
-    * requestEntityRequest.requesterId = userId
+    * requestEntityRequest.requesterId = extUserId
+    * requestEntityRequest.itemId = extItemId
     * requestEntityRequest.requestType = 'Recall'
-    * requestEntityRequest.holdingsRecordId = extHoldingsRecordId
+    * requestEntityRequest.holdingsRecordId = holdingId
     * requestEntityRequest.requestLevel = 'Item'
     Given path 'circulation', 'requests'
     And request requestEntityRequest
@@ -117,37 +107,76 @@ Feature: Requests tests
     And match $.errors[0].message == 'Recall requests are not allowed for this patron and item combination'
 
   Scenario: Given an item Id, a user Id, and a pickup location, attempt to create a page request when the applicable request policy allows pages, but items is not of status Available or Recently returned
-    * def extInstanceTypeId = call uuid1
-    * def extInstanceId = call uuid1
-    * def extHoldingsRecordId = call uuid1
     * def extMaterialTypeId = call uuid1
     * def extMaterialTypeName = 'electronic resource 4'
-    * def userBarcode = 'FAT-1033UBC'
-    * def itemBarcode = 'FAT-1033IBC'
+    * def extUserBarcode = 'FAT-1033UBC'
+    * def extItemBarcode = 'FAT-1033IBC'
     * def extStatusName = 'Paged'
+    * def extItemId = call uuid1
+    * def extUserId = call uuid1
 
     # post a material type
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(extMaterialTypeId), extMaterialTypeName: #(extMaterialTypeName) }
 
     # post an item
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostInstance') { extInstanceId: #(extInstanceId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostServicePoint')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostLocation')
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostHoldings') { extInstanceId: #(extInstanceId), extHoldingsRecordId: #(extHoldingsRecordId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(itemId), extItemBarcode: #(itemBarcode), extStatusName: #(extStatusName), extMaterialTypeId: #(extMaterialTypeId), extHoldingsRecordId: #(extHoldingsRecordId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(extItemId), extItemBarcode: #(extItemBarcode), extStatusName: #(extStatusName), extMaterialTypeId: #(extMaterialTypeId) }
 
-    # post a group and an user
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(fourthUserGroupId)' }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(userId), extUserBarcode: #(userBarcode), extGroupId: #(fourthUserGroupId) }
+    # post an user
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(extUserId), extUserBarcode: #(extUserBarcode), extGroupId: #(fourthUserGroupId) }
 
     # post a request and verify that the user is not allowed to create a page request
     * def requestEntityRequest = read('classpath:vega/mod-circulation/features/samples/request-entity-request.json')
-    * requestEntityRequest.requesterId = userId
+    * requestEntityRequest.requesterId = extUserId
+    * requestEntityRequest.itemId = extItemId
     * requestEntityRequest.requestType = 'Page'
-    * requestEntityRequest.holdingsRecordId = extHoldingsRecordId
+    * requestEntityRequest.holdingsRecordId = holdingId
     * requestEntityRequest.requestLevel = 'Item'
     Given path 'circulation', 'requests'
     And request requestEntityRequest
     When method POST
     Then status 422
     And match $.errors[0].message == 'Page requests are not allowed for this patron and item combination'
+
+    # This scenario does not cover testing for item with statuses, 'Recently returned', 'Missing from ASR' and 'Retrieving from ASR' due to lack of implementation
+  Scenario Outline: Requests: Given an item Id, a user Id, and a pickup location, attempt to create a hold request when the applicable request policy allows holds, but item is of status "Available", "Recently returned", "In process (not requestable)", "Declared lost", "Lost and paid", "Aged to lost", "Claimed returned", "Missing from ASR", "Long missing", "Retrieving from ASR", "Withdrawn", "Order closed", "Intellectual item", "Unavailable", or "Unknown" (should fail)
+    * def extMaterialTypeId = call uuid1
+    * def extItemId = call uuid1
+    * def extUserId = call uuid1
+
+    # post a material type
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(extMaterialTypeId), extMaterialTypeName:  #(<materialTypeName>) }
+
+    # post an item
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(extItemId), extItemBarcode: #(<itemBarcode>), extMaterialTypeId: #(extMaterialTypeId), extStatusName: #(<status>) }
+
+    # post an user
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(extUserId), extUserBarcode: #(<userBarcode>), extGroupId: #(fourthUserGroupId)  }
+
+    # post a request and verify that the user is not allowed to create a hold request
+    * def requestId = call uuid1
+    * def requestEntityRequest = read('classpath:vega/mod-circulation/features/samples/request-entity-request.json')
+    * requestEntityRequest.requesterId = extUserId
+    * requestEntityRequest.itemId = extItemId
+    * requestEntityRequest.requestType = 'Hold'
+    * requestEntityRequest.holdingsRecordId = holdingId
+    * requestEntityRequest.requestLevel = 'Item'
+    Given path 'circulation', 'requests'
+    And request requestEntityRequest
+    When method POST
+    Then status 422
+    And match $.errors[0].message == 'Hold requests are not allowed for this patron and item combination'
+
+    # 'Recently returned', 'Missing from ASR' and 'Retrieving from ASR' are skipped due to the lack of implementation
+    Examples:
+      | status                         | materialTypeName              | itemBarcode      | userBarcode      |
+      | 'Available'                    | 'electronic resource 1034-1'  | 'FAT-1034IBC-1'  | 'FAT-1034UBC-1'  |
+      | 'In process (non-requestable)' | 'electronic resource 1034-3'  | 'FAT-1034IBC-3'  | 'FAT-1034UBC-3'  |
+      | 'Declared lost'                | 'electronic resource 1034-4'  | 'FAT-1034IBC-4'  | 'FAT-1034UBC-4'  |
+      | 'Lost and paid'                | 'electronic resource 1034-5'  | 'FAT-1034IBC-5'  | 'FAT-1034UBC-5'  |
+      | 'Aged to lost'                 | 'electronic resource 1034-6'  | 'FAT-1034IBC-6'  | 'FAT-1034UBC-6'  |
+      | 'Claimed returned'             | 'electronic resource 1034-7'  | 'FAT-1034IBC-7'  | 'FAT-1034UBC-7'  |
+      | 'Long missing'                 | 'electronic resource 1034-8'  | 'FAT-1034IBC-8'  | 'FAT-1034UBC-8'  |
+      | 'Withdrawn'                    | 'electronic resource 1034-9'  | 'FAT-1034IBC-9'  | 'FAT-1034UBC-9'  |
+      | 'Intellectual item'            | 'electronic resource 1034-11' | 'FAT-1034IBC-11' | 'FAT-1034UBC-11' |
+      | 'Unavailable'                  | 'electronic resource 1034-12' | 'FAT-1034IBC-12' | 'FAT-1034UBC-12' |
+      | 'Unknown'                      | 'electronic resource 1034-13' | 'FAT-1034IBC-13' | 'FAT-1034UBC-13' |

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
@@ -52,5 +52,5 @@ Feature: Root feature that runs all other mod-circulation features
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRulesWithMaterialTypeAndGroup') extFallbackPolicy, extMaterialTypePolicy, extFirstGroupPolicy, extSecondGroupPolicy, extThirdGroupPolicy, extFourthGroupPolicy
 
   Scenario: Run all mod-circulation features
-#    * call read('classpath:vega/mod-circulation/features/loans.feature')
+    * call read('classpath:vega/mod-circulation/features/loans.feature')
     * call read('classpath:vega/mod-circulation/features/requests.feature')

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
@@ -15,10 +15,13 @@ Feature: Root feature that runs all other mod-circulation features
     * def extRequestTypesForThirdUserGroupRequestPolicy = ["Page", "Hold"]
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(materialTypeId) }
 
+    # groups
     * def firstUserGroupId = '188f025c-6e52-11ec-90d6-0242ac120003'
     * def secondUserGroupId = 'f1a28f58-702d-48fe-b95d-daf7fd55dc27'
     * def thirdUserGroupId = '0dfcce3e-6fb3-11ec-90d6-0242ac120003'
     * def fourthUserGroupId = 'a58053e4-6fbc-11ec-90d6-0242ac120003'
+
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(fourthUserGroupId)' }
 
     # policies
     * def loanPolicyId = call uuid1

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
@@ -21,8 +21,11 @@ Feature: Root feature that runs all other mod-circulation features
     * def thirdUserGroupId = '0dfcce3e-6fb3-11ec-90d6-0242ac120003'
     * def fourthUserGroupId = 'a58053e4-6fbc-11ec-90d6-0242ac120003'
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(fourthUserGroupId)' }
+<<<<<<< HEAD
 
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(fourthUserGroupId)' }
+=======
+>>>>>>> 206bfdd0cfc4217189a2304cdf1469bd28c42d9c
 
     # policies
     * def loanPolicyId = call uuid1

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
@@ -21,11 +21,6 @@ Feature: Root feature that runs all other mod-circulation features
     * def thirdUserGroupId = '0dfcce3e-6fb3-11ec-90d6-0242ac120003'
     * def fourthUserGroupId = 'a58053e4-6fbc-11ec-90d6-0242ac120003'
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(fourthUserGroupId)' }
-<<<<<<< HEAD
-
-    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(fourthUserGroupId)' }
-=======
->>>>>>> 206bfdd0cfc4217189a2304cdf1469bd28c42d9c
 
     # policies
     * def loanPolicyId = call uuid1
@@ -55,5 +50,5 @@ Feature: Root feature that runs all other mod-circulation features
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRulesWithMaterialTypeAndGroup') extFallbackPolicy, extMaterialTypePolicy, extFirstGroupPolicy, extSecondGroupPolicy, extThirdGroupPolicy, extFourthGroupPolicy
 
   Scenario: Run all mod-circulation features
-    * call read('classpath:vega/mod-circulation/features/loans.feature')
+#    * call read('classpath:vega/mod-circulation/features/loans.feature')
     * call read('classpath:vega/mod-circulation/features/requests.feature')

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
@@ -20,6 +20,7 @@ Feature: Root feature that runs all other mod-circulation features
     * def secondUserGroupId = 'f1a28f58-702d-48fe-b95d-daf7fd55dc27'
     * def thirdUserGroupId = '0dfcce3e-6fb3-11ec-90d6-0242ac120003'
     * def fourthUserGroupId = 'a58053e4-6fbc-11ec-90d6-0242ac120003'
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(fourthUserGroupId)' }
 
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(fourthUserGroupId)' }
 
@@ -51,5 +52,5 @@ Feature: Root feature that runs all other mod-circulation features
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRulesWithMaterialTypeAndGroup') extFallbackPolicy, extMaterialTypePolicy, extFirstGroupPolicy, extSecondGroupPolicy, extThirdGroupPolicy, extFourthGroupPolicy
 
   Scenario: Run all mod-circulation features
-    * call read('classpath:vega/mod-circulation/features/loans.feature')
+#    * call read('classpath:vega/mod-circulation/features/loans.feature')
     * call read('classpath:vega/mod-circulation/features/requests.feature')

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
@@ -52,5 +52,5 @@ Feature: Root feature that runs all other mod-circulation features
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRulesWithMaterialTypeAndGroup') extFallbackPolicy, extMaterialTypePolicy, extFirstGroupPolicy, extSecondGroupPolicy, extThirdGroupPolicy, extFourthGroupPolicy
 
   Scenario: Run all mod-circulation features
-    * call read('classpath:vega/mod-circulation/features/loans.feature')
+#    * call read('classpath:vega/mod-circulation/features/loans.feature')
     * call read('classpath:vega/mod-circulation/features/requests.feature')

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
@@ -50,5 +50,5 @@ Feature: Root feature that runs all other mod-circulation features
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRulesWithMaterialTypeAndGroup') extFallbackPolicy, extMaterialTypePolicy, extFirstGroupPolicy, extSecondGroupPolicy, extThirdGroupPolicy, extFourthGroupPolicy
 
   Scenario: Run all mod-circulation features
-#    * call read('classpath:vega/mod-circulation/features/loans.feature')
+    * call read('classpath:vega/mod-circulation/features/loans.feature')
     * call read('classpath:vega/mod-circulation/features/requests.feature')

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/util/initData.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/util/initData.feature
@@ -242,7 +242,9 @@ Feature: init data for mod-circulation
     * def materialTypePolicy = 'm ' + extMaterialTypePolicy.materialTypeId + ': l ' + extMaterialTypePolicy.loanPolicyId + ' o ' + extMaterialTypePolicy.overdueFinePoliciesId + ' i ' + extMaterialTypePolicy.lostItemFeePolicyId + ' r ' + extMaterialTypePolicy.requestPolicyId + ' n ' + extMaterialTypePolicy.patronPolicyId
     * def groupPolicy = 'g ' + extFirstGroupPolicy.userGroupId + ': l ' + extFirstGroupPolicy.loanPolicyId + ' o ' + extFirstGroupPolicy.overdueFinePoliciesId + ' i ' + extFirstGroupPolicy.lostItemFeePolicyId + ' r ' + extFirstGroupPolicy.requestPolicyId + ' n ' + extFirstGroupPolicy.patronPolicyId
     * def groupPolicy2 = 'g ' + extSecondGroupPolicy.userGroupId + ': l ' + extSecondGroupPolicy.loanPolicyId + ' o ' + extSecondGroupPolicy.overdueFinePoliciesId + ' i ' + extSecondGroupPolicy.lostItemFeePolicyId + ' r ' + extSecondGroupPolicy.requestPolicyId + ' n ' + extSecondGroupPolicy.patronPolicyId
-    * def rules = 'priority: t, s, c, b, a, m, g ' + fallbackPolicy + '\n' + materialTypePolicy + '\n' + groupPolicy + '\n' + groupPolicy2
+    * def groupPolicy3 = 'g ' + extThirdGroupPolicy.userGroupId + ': l ' + extThirdGroupPolicy.loanPolicyId + ' o ' + extThirdGroupPolicy.overdueFinePoliciesId + ' i ' + extThirdGroupPolicy.lostItemFeePolicyId + ' r ' + extThirdGroupPolicy.requestPolicyId + ' n ' + extThirdGroupPolicy.patronPolicyId
+    * def groupPolicy4 = 'g ' + extFourthGroupPolicy.userGroupId + ': l ' + extFourthGroupPolicy.loanPolicyId + ' o ' + extFourthGroupPolicy.overdueFinePoliciesId + ' i ' + extFourthGroupPolicy.lostItemFeePolicyId + ' r ' + extFourthGroupPolicy.requestPolicyId + ' n ' + extFourthGroupPolicy.patronPolicyId
+    * def rules = 'priority: t, s, c, b, a, m, g ' + fallbackPolicy + '\n' + materialTypePolicy + '\n' + groupPolicy + '\n' + groupPolicy2 + '\n' + groupPolicy3 + '\n' + groupPolicy4
     * def rulesEntityRequest = { "rulesAsText": "#(rules)" }
     Given path 'circulation-rules-storage'
     And request rulesEntityRequest

--- a/mod-notes/src/main/resources/karate-config.js
+++ b/mod-notes/src/main/resources/karate-config.js
@@ -13,6 +13,7 @@ function fn() {
 
   var config = {
     baseUrl: 'http://localhost:9130',
+    featuresPath: 'classpath:spitfire/mod-notes/features/',
     admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
 
     testTenant: testTenant ? testTenant: 'testTenant',

--- a/mod-notes/src/main/resources/spitfire/mod-notes/features/note-links.feature
+++ b/mod-notes/src/main/resources/spitfire/mod-notes/features/note-links.feature
@@ -5,33 +5,10 @@ Feature: Note links
     * callonce login testUser
 
     * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': '*/*'  }
-
-    * def result = call read('classpath:spitfire/mod-notes/features/setup/get-default-note-type.feature')
-    * def defaultNoteTypeId = result.defaultNoteType.id
+    * def postNoteWithLinksPath = featuresPath + 'setup/setup-test-note.feature@PostNoteWithLinks';
 
   Scenario Outline: get notes by specific links
-
-    Given path 'notes'
-    And headers headersUser
-    And request
-    """
-    {
-      type: Low Priority,
-      title: Test note title,
-      content: Test content,
-      typeId: #(defaultNoteTypeId),
-      domain: <domain>,
-      links: [
-	  	{
-	  	  id: <linkId>,
-	  	  type: <typeLink>
-	  	}
-	  ]
-    }
-    """
-    When method POST
-    Then status 201
-
+    And call read(postNoteWithLinksPath) {domain: <domain>, linkId: <linkId>, typeLink: <typeLink>}
 
     Given path '/note-links/domain/<domain>/type/<typeLink>/id/<linkId>'
     And headers headersUser
@@ -47,35 +24,13 @@ Feature: Note links
 
   Scenario Outline: should delete note when no link assigned
 
-  #   create test note
-
-    Given path 'notes'
-    And headers headersUser
-    And request
-    """
-    {
-      type: Low Priority,
-      title: Test note title,
-      content: Test content,
-      typeId: #(defaultNoteTypeId),
-      domain: <domain>,
-      links: [
-	  	{
-	  	  id: <linkId>,
-	  	  type: <typeLink>
-	  	}
-	  ]
-    }
-    """
-    When method POST
-    Then status 201
-    * print response
-    * def noteId = $.id
-
+    #  create test note
+    And call read(postNoteWithLinksPath) {domain: <domain>, linkId: <linkId>, typeLink: <typeLink>}
+    And def noteId = $.id
 
     #  update note link
-
     Given path '/note-links/type/<typeLink>/id/<linkId>'
+    And remove headersUser.Accept
     And headers headersUser
     And request
     """
@@ -95,7 +50,6 @@ Feature: Note links
     And headers headersUser
     When method GET
     Then status 404
-
 
     Examples:
       | domain    | typeLink | linkId            |

--- a/mod-notes/src/main/resources/spitfire/mod-notes/features/note-types.feature
+++ b/mod-notes/src/main/resources/spitfire/mod-notes/features/note-types.feature
@@ -6,10 +6,10 @@ Feature: Note types
 
     * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': '*/*'  }
 
-    * def noteTypePayload =    read('classpath:spitfire/mod-notes/features/samples/note-type.json')
-    * def noteTypePayloadPut = read('classpath:spitfire/mod-notes/features/samples/note-type-put.json')
+    * def noteTypePayload = read(featuresPath + 'samples/note-type.json')
+    * def noteTypePayloadPut = read(featuresPath + 'samples/note-type-put.json')
 
-    * def result = call read('classpath:spitfire/mod-notes/features/setup/get-default-note-type.feature')
+    * def result = call read(featuresPath + 'setup/get-default-note-type.feature')
     * def defaultNoteTypeId = result.defaultNoteType.id
 
     # ================= positive test cases =================
@@ -36,7 +36,6 @@ Feature: Note types
     When method POST
     Then status 201
     And match $.id == '#uuid'
-    And match $.metadata.createdByUsername == '#present'
     And match $.metadata.createdByUserId == '#uuid'
     And match $.metadata.updatedByUserId == '#uuid'
     And match $.metadata.createdDate == '#present'
@@ -91,7 +90,8 @@ Feature: Note types
     And headers headersUser
     When method GET
     Then status 404
-    And match response contains 'NoteType not found'
+    And match response.errors[0].message contains 'Note type with ID'
+    And match response.errors[0].message contains 'was not found'
 
   Scenario: check limit config for note-types
 
@@ -109,7 +109,7 @@ Feature: Note types
     """
      {
         module: NOTES,
-        configName: api_access,
+        configName: note-type-limit,
         code: note.types.number.limit,
         value: #(existingNoteTypeAmount)
       }
@@ -128,9 +128,8 @@ Feature: Note types
     }
     """
     When method POST
-    Then status 400
-    And match response == 'Maximum number of note types allowed is ' + existingNoteTypeAmount
-    * print response
+    Then status 422
+    And match response.errors[0].message == 'Maximum number of note types allowed is ' + existingNoteTypeAmount
 
 #    delete note-type limit
     Given path 'configurations/entries', configId
@@ -144,7 +143,6 @@ Feature: Note types
     And headers headersUser
     When method GET
     Then status 200
-    * print response
 
 #  check note type created after limit deleted
     Given path 'note-types'
@@ -166,35 +164,31 @@ Feature: Note types
     And param <paramName> = <value>
     And headers headersUser
     When method GET
-    Then status 400
+    Then status 422
 
     Examples:
       | paramName | value       |
       | limit     | -1          |
-      | limit     | ''          |
       | limit     | -2147483649 |
       | limit     | 2147483648  |
       | offset    | -1          |
-      | offset    | ''          |
       | offset    | -2147483649 |
       | offset    | 2147483648  |
-      | lang      | ''          |
-      | lang      | 'A1'        |
 
   Scenario: Get note types collection - empty query
     Given path 'note-types'
     And param query = ''
     And headers headersUser
     When method GET
-    Then status 400
+    Then status 200
 
   Scenario: Post already existing note type
     Given path 'note-types'
     And headers headersUser
     And request noteTypePayload
     When method POST
-    Then status 400
-    And match response contains "Note type 'Test note type' already exists"
+    Then status 422
+    And match response.errors[0].message contains 'Key (name)=(Test note type) already exists'
 
   Scenario: Post note type - empty JSON
     Given path 'note-types'
@@ -226,14 +220,14 @@ Feature: Note types
     And headers headersUser
     And request ''
     When method POST
-    Then status 400
+    Then status 422
 
   Scenario: Post note type - invalid body
     Given path 'note-types'
     And headers headersUser
     And request '{"name" : "Bad Json}'
     When method POST
-    Then status 400
+    Then status 422
 
   Scenario: Post note type - wrong content-type
     Given path 'note-types'
@@ -241,16 +235,16 @@ Feature: Note types
     And header Content-Type = 'application/xml'
     And request noteTypePayload
     When method POST
-    Then status 400
-    And match response contains 'Content-type header must be ["application/json"] but it is "application/xml"'
+    Then status 415
+    And match response.error contains 'Unsupported Media Type'
 
   Scenario: Put by id - invalid id format
     Given path 'note-types', 12345
     And headers headersUser
     And request noteTypePayloadPut
     When method PUT
-    Then status 400
-    And match response contains "'typeId' parameter is incorrect"
+    Then status 422
+    And match response.errors[0].message contains "Failed to convert value of type 'java.lang.String' to required type 'java.util.UUID'"
 
   Scenario: Put by id - not existing id
     * def randomId = call uuid
@@ -259,11 +253,12 @@ Feature: Note types
     And request noteTypePayloadPut
     When method PUT
     Then status 404
-    And match response contains "NoteType not found"
+    And match response.errors[0].message contains 'Note type with ID'
+    And match response.errors[0].message contains 'was not found'
 
   Scenario: Delete by id - invalid id type
     Given path 'note-types', 12345
     And headers headersUser
     When method DELETE
-    Then status 400
-    And match response contains "'typeId' parameter is incorrect"
+    Then status 422
+    And match response.errors[0].message contains "Failed to convert value of type 'java.lang.String' to required type 'java.util.UUID'"

--- a/mod-notes/src/main/resources/spitfire/mod-notes/features/notes.feature
+++ b/mod-notes/src/main/resources/spitfire/mod-notes/features/notes.feature
@@ -4,14 +4,12 @@ Feature: Notes
     * url baseUrl
     * callonce login testUser
 
-    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json'  }
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json' }
 
-    * def notePayload = read('classpath:spitfire/mod-notes/features/samples/note.json')
-
-    * def result = call read('classpath:spitfire/mod-notes/features/setup/get-default-note-type.feature')
+    * def result = call read(featuresPath + 'setup/get-default-note-type.feature')
     * def defaultNoteTypeId = result.defaultNoteType.id
 
-    * def note = call read('classpath:spitfire/mod-notes/features/setup/setup-test-note.feature')
+    * def note = call read(featuresPath + 'setup/setup-test-note.feature@PostNote')
 
     # ================= positive test cases =================
 
@@ -27,7 +25,6 @@ Feature: Notes
       | id        | note.testNote.id    |
       | title     | note.testNote.title |
       | limit     | 1                   |
-      | limit     | 0                   |
       | offset    | 1                   |
       | offset    | 0                   |
 
@@ -36,23 +33,9 @@ Feature: Notes
 
   Scenario: Put note by id
     Given path 'notes', note.testNote.id
+    And remove headersUser.Accept
     And headers headersUser
-    And request
-    """
-    {
-      type: Low Priority,
-      title: Updated title,
-      content: Updated content,
-      typeId: #(defaultNoteTypeId),
-      domain: Updated domain,
-      links: [
-	  	{
-	  	  id: 583-2356521,
-	  	  type: package
-	  	}
-	  ]
-    }
-    """
+    And request read(featuresPath + "samples/note-put.json")
     When method PUT
     Then status 204
 
@@ -70,21 +53,18 @@ Feature: Notes
     And param <paramName> = <value>
     And headers headersUser
     When method GET
-    Then status 400
+    Then status 422
+    And match $.errors[0].code == 'VALIDATION_ERROR'
 
     Examples:
       | paramName | value       |
+      | limit     | 0           |
       | limit     | -1          |
-      | limit     | ''          |
       | limit     | -2147483649 |
       | limit     | 2147483648  |
       | offset    | -1          |
-      | offset    | ''          |
       | offset    | -2147483649 |
       | offset    | 2147483648  |
-      | lang      | ''          |
-      | lang      | 'A1'        |
-      | query     | ''          |
       | query     | 'foo*'      |
 
   Scenario: Post create note - empty body
@@ -92,7 +72,9 @@ Feature: Notes
     And headers headersUser
     And request ''
     When method POST
-    Then status 400
+    Then status 422
+    And match $.errors[0].code == 'VALIDATION_ERROR'
+    And match $.errors[0].message contains 'Required request body is missing:'
 
   Scenario: Post create note - empty JSON
     Given path 'notes'
@@ -103,6 +85,8 @@ Feature: Notes
     """
     When method POST
     Then status 422
+    And match $.errors[0].code == 'VALIDATION_ERROR'
+    And match $.errors[0].message contains 'Validation failed for argument [0]'
 
 
 

--- a/mod-notes/src/main/resources/spitfire/mod-notes/features/samples/note-links.json
+++ b/mod-notes/src/main/resources/spitfire/mod-notes/features/samples/note-links.json
@@ -1,0 +1,8 @@
+{
+  "links": [
+    {
+      "id": "#(linkId)",
+      "type": "#(typeLink)"
+    }
+  ]
+}

--- a/mod-notes/src/main/resources/spitfire/mod-notes/features/samples/note-put.json
+++ b/mod-notes/src/main/resources/spitfire/mod-notes/features/samples/note-put.json
@@ -1,0 +1,13 @@
+{
+  "type": "Low Priority",
+  "title": "Updated title",
+  "content": "Updated content",
+  "typeId": "#(defaultNoteTypeId)",
+  "domain": "Updated domain",
+  "links": [
+    {
+      "id": "583-2356521",
+      "type": "package"
+    }
+  ]
+}

--- a/mod-notes/src/main/resources/spitfire/mod-notes/features/setup/get-default-note-type.feature
+++ b/mod-notes/src/main/resources/spitfire/mod-notes/features/setup/get-default-note-type.feature
@@ -16,4 +16,3 @@ Feature: Get Default note type
     And match defaultNoteType.metadata.createdByUserId == '#notpresent'
     And match defaultNoteType.metadata.updatedByUserId == '#notpresent'
     And match defaultNoteType.metadata.createdDate == '#present'
-    And match defaultNoteType.metadata.updatedDate == '#present'

--- a/mod-notes/src/main/resources/spitfire/mod-notes/features/setup/setup-test-note-type.feature
+++ b/mod-notes/src/main/resources/spitfire/mod-notes/features/setup/setup-test-note-type.feature
@@ -5,7 +5,7 @@ Feature: Setup mod-notes
     * callonce login testUser
 
     * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json'  }
-    * def noteTypePayload = read('classpath:spitfire/mod-notes/features/samples/valid/note-type.json')
+    * def noteTypePayload = read(featuresPath + 'samples/note-type.json')
 
   Scenario: Post new note type
     Given path '/note-types'

--- a/mod-notes/src/main/resources/spitfire/mod-notes/features/setup/setup-test-note.feature
+++ b/mod-notes/src/main/resources/spitfire/mod-notes/features/setup/setup-test-note.feature
@@ -6,28 +6,27 @@ Feature: Setup mod-notes
 
     * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json'  }
 
-    * def result = call read('classpath:spitfire/mod-notes/features/setup/get-default-note-type.feature')
+    * def result = call read(featuresPath + 'setup/get-default-note-type.feature')
     * def defaultNoteTypeId = result.defaultNoteType.id
 
+  @PostNote
   Scenario: Post new note
     Given path '/notes'
     And headers headersUser
-    And request
-    """
-    {
-      type: Low Priority,
-      title : BU Campus Access Issues,
-      content: There have been access issues at the BU campus since the weekend,
-      typeId: #(defaultNoteTypeId),
-      domain: eholdings,
-      links: [
-        {
-          id: 583-2356521,
-          type: package
-        }
-      ]
-    }
-    """
+    And request read(featuresPath + "samples/note-put.json")
     When method POST
     Then status 201
     * def testNote = $
+
+  @PostNoteWithLinks
+  Scenario: Post new note with links
+    * def note = read(featuresPath + "samples/note-put.json")
+    * def linksJson = read(featuresPath + "samples/note-links.json")
+    * set note.links = linksJson.links
+    * set note.domain = '#(domain)'
+
+    Given path '/notes'
+    And headers headersUser
+    And request note
+    When method POST
+    Then status 201

--- a/mod-notes/src/test/java/org/folio/ModNotesTest.java
+++ b/mod-notes/src/test/java/org/folio/ModNotesTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-public class ModNotesTest extends TestBase {
+class ModNotesTest extends TestBase {
     private static final String TEST_BASE_PATH = "classpath:spitfire/mod-notes/features/";
 
     public ModNotesTest() {


### PR DESCRIPTION
## Purpose
[FAT-1035](https://issues.folio.org/browse/FAT-1035)
_Given an item Id, a user Id, and a pickup location, attempt to create a recall request when the applicable request policy allows recalls, but item is of status "Available", "Recently returned", "Missing", "In process (not requestable)", "Declared lost", "Lost and paid", "Aged to lost", "Claimed returned", "Missing from ASR", "Long missing", "Retrieving from ASR", "Withdrawn", "Order closed", "Intellectual item", "Unavailable", or "Unknown" (should fail)"_

## Approach
- Reproduced test scenario with UI.
- Learned necessary sent requests and then necessary received responses 
- Based on the request/response created karate test scenario


## Learning
- learn karate framework from original doc file on the github
- looked other scenarios how they are described.