### PR TITLE
FAT-1181 Quick marc - endless waiting

### DIFF
--- a/mod-kb-ebsco-java/src/main/resources/spitfire/mod-kb-ebsco-java/features/packages.feature
+++ b/mod-kb-ebsco-java/src/main/resources/spitfire/mod-kb-ebsco-java/features/packages.feature
@@ -25,6 +25,9 @@ Feature: Packages
     And match response.data[0].attributes.isCustom == true
 
   Scenario: POST Packages should create a custom package with 200 on success
+    #waiting for package setup
+    * eval sleep(30000)
+
     Given path "/eholdings/packages"
     When method GET
     Then status 200

--- a/mod-kb-ebsco-java/src/main/resources/spitfire/mod-kb-ebsco-java/features/setup/destroy.feature
+++ b/mod-kb-ebsco-java/src/main/resources/spitfire/mod-kb-ebsco-java/features/setup/destroy.feature
@@ -13,14 +13,14 @@ Feature: Destroy test data for kb-ebsco-java
     * if (packageId == null) karate.abort()
     Given path '/eholdings/packages', packageId
     When method DELETE
-    Then status 204
+    Then assert responseStatus == 201 || responseStatus == 404
 
   @DestroyCredentials
   Scenario: Destroy kb-credentials
     * if (credentialId == null) karate.abort()
     Given path '/eholdings/kb-credentials', credentialId
     When method DELETE
-    And status 204
+    Then assert responseStatus == 201 || responseStatus == 404
 
   @Ignore
   @DestroyResources
@@ -28,10 +28,10 @@ Feature: Destroy test data for kb-ebsco-java
     * if (resourceId == null) karate.abort()
     Given path '/eholdings/resources', resourceId
     When method DELETE
-    And status 204
+    Then assert responseStatus == 201 || responseStatus == 404
 
   #Destroy resource package
     * if (packageForResourceId == null) karate.abort()
     Given path '/eholdings/packages', packageForResourceId
     When method DELETE
-    Then status 204
+    Then assert responseStatus == 201 || responseStatus == 404

--- a/mod-quick-marc/src/main/resources/karate-config.js
+++ b/mod-quick-marc/src/main/resources/karate-config.js
@@ -42,6 +42,10 @@ function fn() {
       for (var i = 0; i < 5; i++)
         text += possible.charAt(Math.floor(Math.random() * possible.length));
       return text;
+    },
+
+    sleep: function(millis) {
+      return java.lang.Thread.sleep(millis);
     }
   };
 

--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-records.feature
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-records.feature
@@ -7,8 +7,7 @@ Feature: Test quickMARC
     * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json'  }
     * def headersUserOctetStream = { 'Content-Type': 'application/octet-stream', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json'  }
 
-    * def result = callonce read('classpath:spitfire/mod-quick-marc/features/setup/setup.feature')
-    * def testInstanceId = result.response.sourceRecords[0].externalIdsHolder.instanceId
+    * def testInstanceId = karate.properties['instanceId']
 
   # ================= positive test cases =================
    Scenario: Retrieve existing quickMarcJson by instanceId

--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/setup.feature
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/setup.feature
@@ -11,8 +11,7 @@ Feature: Test quickMARC
     * def samplePath = 'classpath:spitfire/mod-quick-marc/features/setup/samples/'
 
     #waiting for all modules to be launched, this sleep allows to avoid creating a phantom instance in the mod-inventory
-    * def sleep = function(millis){ java.lang.Thread.sleep(millis) }
-    * eval sleep(60000)
+    * callonce sleep 60000
 
   Scenario: import MARC record
     ## Create instance type
@@ -81,3 +80,6 @@ Feature: Test quickMARC
     And retry until response.totalRecords > 0 && karate.sizeOf(response.sourceRecords[0].externalIdsHolder) > 0
     When method get
     Then status 200
+
+    * def testInstanceId = response.sourceRecords[0].externalIdsHolder.externalIdsHolder.instanceId
+    * setSystemProperty('instanceId', testInstanceId)

--- a/mod-quick-marc/src/test/java/org/folio/QuickMarcApiTest.java
+++ b/mod-quick-marc/src/test/java/org/folio/QuickMarcApiTest.java
@@ -29,6 +29,7 @@ class QuickMarcApiTest extends TestBase {
     @BeforeAll
     public void quickMarcApiTestBeforeAll() {
         runFeature("classpath:spitfire/mod-quick-marc/quick-marc-junit.feature");
+        runFeatureTest("setup/setup.feature");
     }
 
     @AfterAll


### PR DESCRIPTION
If quick marc feature falls and attempts are over, it start it again

### Approach
- Fix endless feature calling
- Wait for all modules to be launched JUST once
- kb-ebsco Ignore not found error while deleting

### Learing
https://issues.folio.org/browse/FAT-1181