### PR TITLE
[MODORDERS-645] Remove and add order line fund distribution before invoice approval

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
@@ -106,5 +106,8 @@ Feature: cross-module integration tests
   Scenario: Pay invoice with new expense class
     Given call read('features/pay-invoice-with-new-expense-class.feature')
 
+  Scenario: Change poline fund distribution and pay invoice
+    Given call read('features/change-poline-fd-and-pay-invoice.feature.feature')
+
   Scenario: wipe data
     Given call read('classpath:common/destroy-data.feature')

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/change-poline-fd-and-pay-invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/change-poline-fd-and-pay-invoice.feature
@@ -1,0 +1,155 @@
+# For https://issues.folio.org/browse/MODINVOICE-342
+@parallel=false
+Feature: Change poline fund distribution and pay invoice
+
+  Background:
+    * url baseUrl
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json' }
+
+    * configure headers = headersUser
+
+    * callonce variables
+
+    * def fundId = callonce uuid1
+    * def budgetId = callonce uuid2
+    * def orderId = callonce uuid3
+    * def poLineId = callonce uuid4
+    * def invoiceId = callonce uuid5
+    * def invoiceLineId = callonce uuid6
+
+    * def orderLineTemplate = read('classpath:samples/mod-orders/orderLines/minimal-order-line.json')
+    * def invoiceTemplate = read('classpath:samples/mod-invoice/invoices/global/invoice.json')
+    * def invoiceLineTemplate = read('classpath:samples/mod-invoice/invoices/global/invoice-line-percentage.json')
+
+
+  Scenario: Create finances
+    * print "Create finances"
+    * configure headers = headersAdmin
+    * call createFund { 'id': '#(fundId)' }
+    * call createBudget { 'id': '#(budgetId)', 'allocated': 1000, 'fundId': '#(fundId)', 'status': 'Active'}] }
+
+  Scenario: Create an order
+    * print "Create an order"
+    Given path 'orders/composite-orders'
+    And request
+    """
+    {
+      id: '#(orderId)',
+      vendor: '#(globalVendorId)',
+      orderType: 'One-Time'
+    }
+    """
+    When method POST
+    Then status 201
+
+  Scenario: Create an order line
+    * print "Create an order line"
+    * copy poLine = orderLineTemplate
+    * set poLine.id = poLineId
+    * set poLine.purchaseOrderId = orderId
+    * set poLine.fundDistribution[0].fundId = fundId
+    * set poLine.fundDistribution[0].code = fundId
+    * set poLine.cost.listUnitPrice = 10
+    Given path 'orders/order-lines'
+    And request poLine
+    When method POST
+    Then status 201
+
+  Scenario: Open the order
+    * print "Open the order"
+    Given path 'orders/composite-orders', orderId
+    When method GET
+    Then status 200
+    * def orderResponse = $
+    * set orderResponse.workflowStatus = 'Open'
+    Given path 'orders/composite-orders', orderId
+    And request orderResponse
+    When method PUT
+    Then status 204
+
+  Scenario: Create an invoice
+    * print "Create an invoice"
+    * copy invoice = invoiceTemplate
+    * set invoice.id = invoiceId
+    Given path 'invoice/invoices'
+    And request invoice
+    When method POST
+    Then status 201
+
+  Scenario: Add an invoice line linked to the po line
+    * print "Get the encumbrance id"
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+    * def poLine = $
+    * def encumbranceId = poLine.fundDistribution[0].encumbrance
+
+    * print "Add an invoice line linked to the po line"
+    * copy invoiceLine = invoiceLineTemplate
+    * set invoiceLine.id = invoiceLineId
+    * set invoiceLine.invoiceId = invoiceId
+    * set invoiceLine.poLineId = poLineId
+    * set invoiceLine.fundDistributions[0].fundId = fundId
+    * set invoiceLine.fundDistributions[0].encumbrance = encumbranceId
+    * set invoiceLine.total = 10
+    * set invoiceLine.subTotal = 10
+    * remove invoiceLine.fundDistributions[0].expenseClassId
+    Given path 'invoice/invoice-lines'
+    And request invoiceLine
+    When method POST
+    Then status 201
+
+  Scenario: Remove the order line fund distribution
+    * print "Remove the order line fund distribution"
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+    * def poLine = $
+    * remove poLine.fundDistribution
+    Given path 'orders/order-lines', poLineId
+    And request poLine
+    When method PUT
+    Then status 204
+
+  Scenario: Add a new order line fund distribution
+    * print "Add a new order line fund distribution"
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+    * def poLine = $
+    * set poLine.fundDistribution = [ { fundId:'#(fundId)', code:'#(fundId)', distributionType:'percentage', value:100.0 } ]
+    Given path 'orders/order-lines', poLineId
+    And request poLine
+    When method PUT
+    Then status 204
+
+  Scenario: Approve the invoice
+    * print "Approve the invoice"
+    Given path 'invoice/invoices', invoiceId
+    When method GET
+    Then status 200
+    * def invoice = $
+    * set invoice.status = 'Approved'
+    Given path 'invoice/invoices', invoiceId
+    And request invoice
+    When method PUT
+    Then status 204
+
+  Scenario: Pay the invoice
+    * print "Pay the invoice"
+    Given path 'invoice/invoices', invoiceId
+    When method GET
+    Then status 200
+    * def invoice = $
+    * set invoice.status = 'Paid'
+    Given path 'invoice/invoices', invoiceId
+    And request invoice
+    When method PUT
+    Then status 204

--- a/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
+++ b/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
@@ -107,6 +107,11 @@ public class CrossModulesApiTest extends TestBase {
     runFeatureTest("pay-invoice-with-new-expense-class");
   }
 
+  @Test
+  void changePolineFdAndPayInvoice() {
+    runFeatureTest("change-poline-fd-and-pay-invoice");
+  }
+
   @BeforeAll
   public void crossModuleApiTestBeforeAll() {
     runFeature("classpath:thunderjet/cross-modules/cross-modules-junit.feature");


### PR DESCRIPTION
## Purpose
[MODORDERS-645](https://issues.folio.org/browse/MODORDERS-645) - Invoice payment fails if order line fund distribution is changed before invoice approval

## Approach
Added a new cross-module test.