### PR TITLE
FAT-1480: Prokopovych edge module tests should use testing environment

### DIFF
--- a/edge-patron/src/main/resources/karate-config.js
+++ b/edge-patron/src/main/resources/karate-config.js
@@ -3,6 +3,7 @@ function fn() {
   karate.configure('logPrettyRequest', true);
   var retryConfig = { count: 20, interval: 30000 }
   karate.configure('retry', retryConfig)
+  karate.configure('logPrettyResponse', true);
 
   var env = karate.env;
 
@@ -19,7 +20,7 @@ function fn() {
 
     // define global features
     login: karate.read('classpath:common/login.feature'),
-    dev: karate.read('classpath:common/dev.feature'),
+    loginRegularUser: karate.read('classpath:common/login.feature'),
 
     // define global functions
     random_string: function() {
@@ -56,11 +57,15 @@ function fn() {
       password: 'admin'
     }
   } else if (env != null && env.match(/^ec2-\d+/)) {
-    // Config for FOLIO CI "folio-integration" public ec2- dns name
-    config.baseUrl = 'http://' + env + ':9130';
+    // edge modules cannot run properly on dedicated environment for the Karate tests
+    // short term solution is to have the module run on testing
+    // This is not ideal as it negates a lot of the purpose of the tests
+    config.baseUrl = 'https://folio-testing-okapi.dev.folio.org:443';
+    config.edgeUrl = 'https://folio-testing.dev.folio.org:8000';
+    config.apikey = 'eyJzIjoiNXNlNGdnbXk1TiIsInQiOiJkaWt1IiwidSI6ImRpa3UifQ==';
     config.admin = {
-      tenant: 'supertenant',
-      name: 'admin',
+      tenant: 'diku',
+      name: 'diku_admin',
       password: 'admin'
     }
   }

--- a/edge-rtac/src/main/resources/karate-config.js
+++ b/edge-rtac/src/main/resources/karate-config.js
@@ -16,11 +16,11 @@ function fn() {
     testTenant: testTenant ? testTenant: 'testTenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},
     testUser: {tenant: testTenant, name: 'test-user', password: 'test'},
-
+  
     // define global features
     login: karate.read('classpath:common/login.feature'),
-    dev: karate.read('classpath:common/dev.feature'),
-
+    loginRegularUser: karate.read('classpath:common/login.feature'),
+    
     // define global functions
     random_string: function() {
       var text = "";
@@ -78,11 +78,15 @@ function fn() {
       password: 'admin'
     }
   } else if (env != null && env.match(/^ec2-\d+/)) {
-    // Config for FOLIO CI "folio-integration" public ec2- dns name
-    config.baseUrl = 'http://' + env + ':9130';
+    // edge modules cannot run properly on dedicated environment for the Karate tests
+    // short term solution is to have the module run on testing
+    // This is not ideal as it negates a lot of the purpose of the tests
+    config.baseUrl = 'https://folio-testing-okapi.dev.folio.org:443';
+    config.edgeUrl = 'https://folio-testing.dev.folio.org:8000';
+    config.apikey = 'eyJzIjoiNXNlNGdnbXk1TiIsInQiOiJkaWt1IiwidSI6ImRpa3UifQ==';
     config.admin = {
-      tenant: 'supertenant',
-      name: 'admin',
+      tenant: 'diku',
+      name: 'diku_admin',
       password: 'admin'
     }
   }


### PR DESCRIPTION
I had to guess a bit on the exact configuration of this file.  I'm assuming here that it's the third branch of the environment if/else code that needs to be modified.  I tried using the exact code used by edge-dematic and edge-caiasoft in that branch, but found that this caused all tests in the module to fail.  Tests also fail in edge-dematic and edge-caiasoft when using that branch as well, so I changed the code to use the test URL and the same credentials it uses for the testing branch.