### PR TITLE
FAT-1150 Fix integration tests for authority search

### DIFF
--- a/mod-search/src/test/resources/falcon/mod-search/filters/sort-by-option-search.feature
+++ b/mod-search/src/test/resources/falcon/mod-search/filters/sort-by-option-search.feature
@@ -68,56 +68,65 @@ Feature: Tests that sorted by fields
     * def sortOption = "headingRef"
     * def sortPath = sortOption
     * def recordsType = "authorities"
-    * def expectedOrder = new Array(21);
+    * def expectedOrder = new Array(30);
 
     * expectedOrder[0] = 'a conference name'
-    * expectedOrder[1] = 'a corporate name'
-    * expectedOrder[2] = 'a genre term'
-    * expectedOrder[3] = 'a geographic name'
-    * expectedOrder[4] = 'a personal name'
+    * expectedOrder[1] = 'a conference title'
+    * expectedOrder[2] = 'a corporate name'
+    * expectedOrder[3] = 'a corporate title'
+    * expectedOrder[4] = 'a genre term'
+    * expectedOrder[5] = 'a geographic name'
+    * expectedOrder[6] = 'a personal name'
+    * expectedOrder[7] = 'a personal title'
 
-    * expectedOrder[5] = 'a saft conference name'
-    * expectedOrder[6] = 'a saft corporate name'
-    * expectedOrder[7] = 'a saft genre term'
-    * expectedOrder[8] = 'a saft geographic name'
-    * expectedOrder[9] = 'a saft personal name'
-    * expectedOrder[10] = 'a saft topical term'
-    * expectedOrder[11] = 'a saft uniform title'
+    * expectedOrder[8] = 'a saft conference name'
+    * expectedOrder[9] = 'a saft conference title'
+    * expectedOrder[10] = 'a saft corporate name'
+    * expectedOrder[11] = 'a saft corporate title'
+    * expectedOrder[12] = 'a saft genre term'
+    * expectedOrder[13] = 'a saft geographic name'
+    * expectedOrder[14] = 'a saft personal name'
+    * expectedOrder[15] = 'a saft personal title'
+    * expectedOrder[16] = 'a saft topical term'
+    * expectedOrder[17] = 'a saft uniform title'
 
-    * expectedOrder[12] = 'a sft conference name'
-    * expectedOrder[13] = 'a sft corporate name'
-    * expectedOrder[14] = 'a sft genre term'
-    * expectedOrder[15] = 'a sft geographic name'
-    * expectedOrder[16] = 'a sft personal name'
-    * expectedOrder[17] = 'a sft topical term'
-    * expectedOrder[18] = 'a sft uniform title'
-    * expectedOrder[19] = 'a topical term'
-    * expectedOrder[20] = 'an uniform title'
+    * expectedOrder[18] = 'a sft conference name'
+    * expectedOrder[19] = 'a sft conference title'
+    * expectedOrder[20] = 'a sft corporate name'
+    * expectedOrder[21] = 'a sft corporate title'
+    * expectedOrder[22] = 'a sft genre term'
+    * expectedOrder[23] = 'a sft geographic name'
+    * expectedOrder[24] = 'a sft personal name'
+    * expectedOrder[25] = 'a sft personal title'
+    * expectedOrder[26] = 'a sft topical term'
+    * expectedOrder[27] = 'a sft uniform title'
+    * expectedOrder[28] = 'a topical term'
+    * expectedOrder[29] = 'an uniform title'
+
     * call read('sort-by-option-search.feature@SortInTwoOrders')
 
   Scenario: Can sort by headingType
     * def sortOption = "headingType"
     * def sortPath = sortOption
     * def recordsType = "authorities"
-    * def expectedOrder = new Array(21);
+    * def expectedOrder = new Array(30);
 
-    * expectedOrder.fill('Conference Name', 0, 2)
-    * expectedOrder.fill('Corporate Name', 2, 4)
-    * expectedOrder.fill('Genre', 4, 6)
-    * expectedOrder.fill('Geographic Name', 6, 8)
-    * expectedOrder.fill('Other', 8, 15)
-    * expectedOrder.fill('Personal Name', 15, 17)
-    * expectedOrder.fill('Topical', 17, 19)
-    * expectedOrder.fill('Uniform Title', 19, 21)
+    * expectedOrder.fill('Conference Name', 0, 6)
+    * expectedOrder.fill('Corporate Name', 6, 12)
+    * expectedOrder.fill('Genre', 12, 15)
+    * expectedOrder.fill('Geographic Name', 15, 18)
+    * expectedOrder.fill('Personal Name', 18, 24)
+    * expectedOrder.fill('Topical', 24, 27)
+    * expectedOrder.fill('Uniform Title', 27, 30)
     * call read('sort-by-option-search.feature@SortInTwoOrders')
 
   Scenario: Can sort by authRefType
     * def sortOption = "authRefType"
     * def sortPath = sortOption
     * def recordsType = "authorities"
-    * def expectedOrder = new Array(21);
+    * def expectedOrder = new Array(30);
 
-    * expectedOrder.fill('Auth/Ref', 0, 7)
-    * expectedOrder.fill('Authorized', 7, 14)
-    * expectedOrder.fill('Reference', 14, 21)
+    * expectedOrder.fill('Auth/Ref', 0, 10)
+    * expectedOrder.fill('Authorized', 10, 20)
+    * expectedOrder.fill('Reference', 20, 30)
     * call read('sort-by-option-search.feature@SortInTwoOrders')

--- a/mod-search/src/test/resources/falcon/mod-search/search/authority-single-property-search.feature
+++ b/mod-search/src/test/resources/falcon/mod-search/search/authority-single-property-search.feature
@@ -13,11 +13,15 @@ Feature: Tests that authority searches by a single property
     Then match response.totalRecords == 1
     Then match response.authorities[0].id == '#(<expectedId>)'
     Examples:
-      | field           | value                | expectedId          |
-      | sftTopicalTerm  | sft topical term     | personalAuthorityId |
-      | uniformTitle    | uniform title        | personalAuthorityId |
-      | sftMeetingName  | sft conference name  | meetingAuthorityId  |
-      | saftMeetingName | saft conference name | meetingAuthorityId  |
+      | field                  | value                 | expectedId           |
+      | sftTopicalTerm         | sft topical term      | personalAuthorityId  |
+      | uniformTitle           | an uniform title      | personalAuthorityId  |
+      | sftUniformTitle        | sft uniform title     | personalAuthorityId  |
+      | saftUniformTitle       | saft uniform title    | personalAuthorityId  |
+      | sftMeetingNameTitle    | sft conference title  | meetingAuthorityId   |
+      | saftMeetingNameTitle   | saft conference title | meetingAuthorityId   |
+      | sftCorporateNameTitle  | sft corporate title   | corporateAuthorityId |
+      | saftCorporateNameTitle | saft corporate title  | corporateAuthorityId |
 
   Scenario Outline: Can search by keyword that matches '<field>' component with order match
     Given path '/search/authorities'
@@ -27,13 +31,47 @@ Feature: Tests that authority searches by a single property
     Then match response.totalRecords == 1
     Then match response.authorities[0].id == '#(<expectedId>)'
     Examples:
+      | field                  | value                  | expectedId           |
+      | personalNameTitle      | a personal title       | personalAuthorityId  |
+      | sftPersonalNameTitle   | a sft personal title   | personalAuthorityId  |
+      | saftPersonalNameTitle  | a saft personal title  | personalAuthorityId  |
+      | meetingNameTitle       | a conference title     | meetingAuthorityId   |
+      | sftMeetingNameTitle    | sft conference title   | meetingAuthorityId   |
+      | saftMeetingNameTitle   | saft conference title  | meetingAuthorityId   |
+      | corporateNameTitle     | a corporate title      | corporateAuthorityId |
+      | sftCorporateNameTitle  | a sft corporate title  | corporateAuthorityId |
+      | saftCorporateNameTitle | a saft corporate title | corporateAuthorityId |
+      | geographicName         | a geographic name      | personalAuthorityId  |
+      | sftGeographicName      | a sft geographic name  | personalAuthorityId  |
+      | saftGeographicName     | a saft geographic name | personalAuthorityId  |
+
+  Scenario Outline: Can search by '<field>' that matches '<value>' with exact match
+    Given path '/search/authorities'
+    And param query = '<field> == "<value>"'
+    When method GET
+    Then status 200
+    Then match response.totalRecords == 1
+    Then match response.authorities[0].id == '#(<expectedId>)'
+    Examples:
       | field              | value                  | expectedId           |
+      | personalName       | a personal name        | personalAuthorityId  |
+      | sftPersonalName    | a sft personal name    | personalAuthorityId  |
+      | saftPersonalName   | a saft personal name   | personalAuthorityId  |
       | corporateName      | a corporate name       | corporateAuthorityId |
       | sftCorporateName   | a sft corporate name   | corporateAuthorityId |
       | saftCorporateName  | a saft corporate name  | corporateAuthorityId |
       | geographicName     | a geographic name      | personalAuthorityId  |
-      | sftGeographicTerm  | a sft geographic name  | personalAuthorityId  |
-      | saftGeographicTerm | a saft geographic name | personalAuthorityId  |
+      | sftGeographicName  | a sft geographic name  | personalAuthorityId  |
+      | saftGeographicName | a saft geographic name | personalAuthorityId  |
+      | topicalTerm        | a topical term         | personalAuthorityId  |
+      | sftTopicalTerm     | a sft topical term     | personalAuthorityId  |
+      | saftTopicalTerm    | a saft topical term    | personalAuthorityId  |
+      | uniformTitle       | an uniform title       | personalAuthorityId  |
+      | sftUniformTitle    | a sft uniform title    | personalAuthorityId  |
+      | saftUniformTitle   | a saft uniform title   | personalAuthorityId  |
+      | meetingName        | a conference name      | meetingAuthorityId   |
+      | sftMeetingName     | a sft conference name  | meetingAuthorityId   |
+      | saftMeetingName    | a saft conference name | meetingAuthorityId   |
 
   Scenario Outline: Can search by keyword that matches '<field>' component with any of values
     Given path '/search/authorities'
@@ -42,17 +80,18 @@ Feature: Tests that authority searches by a single property
     Then status 200
     Then match response.totalRecords == '#(<expectedCount>)'
     Examples:
-      | field      | value | expectedCount |
-      | nameFields | name  | 12            |
-      | sftFields  | sft   | 6             |
-      | saftFields | saft  | 6             |
+      | field       | value | expectedCount |
+      | nameFields  | name  | 3             |
+      | titleFields | title | 12            |
+      | sftFields   | sft   | 7             |
+      | saftFields  | saft  | 7             |
 
   Scenario Outline: Can search by date with operators
     Given path '/search/authorities'
     And param query = 'metadata.<field> <operator> "<value>"'
     When method GET
     Then status 200
-    Then match response.totalRecords == 21
+    Then match response.totalRecords == 30
     Examples:
       | field       | operator | value      |
       | createdDate | >=       | 2020-12-10 |
@@ -71,15 +110,15 @@ Feature: Tests that authority searches by a single property
       | sftCorporateName   | a sft*           | corporateAuthorityId |
       | saftCorporateName  | a saft*          | corporateAuthorityId |
       | geographicName     | *name            | personalAuthorityId  |
-      | sftGeographicTerm  | *geographic name | personalAuthorityId  |
-      | saftGeographicTerm | *raphic name     | personalAuthorityId  |
+      | sftGeographicName  | *geographic name | personalAuthorityId  |
+      | saftGeographicName | *raphic name     | personalAuthorityId  |
 
   Scenario Outline: Can search by lccn
     Given path '/search/authorities'
     And param query = 'lccn="<value>"'
     When method GET
     Then status 200
-    Then match response.totalRecords == 3
+    Then match response.totalRecords == 6
     Then match response.authorities[0].id == '#(<expectedId>)'
     Examples:
       | value   | expectedId           |

--- a/mod-search/src/test/resources/falcon/mod-search/set-up/create-test-data.feature
+++ b/mod-search/src/test/resources/falcon/mod-search/set-up/create-test-data.feature
@@ -62,6 +62,6 @@ Feature: Create new tenant and upload test data
 
     Given path '/search/authorities'
     And param query = 'cql.allRecords=1'
-    And retry until response.totalRecords == 21
+    And retry until response.totalRecords == 30
     When method GET
     Then status 200

--- a/mod-search/src/test/resources/samples/test-data/authorities/CorporateAuthority.json
+++ b/mod-search/src/test/resources/samples/test-data/authorities/CorporateAuthority.json
@@ -7,6 +7,13 @@
   "saftCorporateName": [
     "a saft corporate name"
   ],
+  "corporateNameTitle": "a corporate title",
+  "sftCorporateNameTitle": [
+    "a sft corporate title"
+  ],
+  "saftCorporateNameTitle": [
+    "a saft corporate title"
+  ],
   "subjectHeadings": "a subject heading",
   "identifiers": [
     {

--- a/mod-search/src/test/resources/samples/test-data/authorities/MeetingAuthority.json
+++ b/mod-search/src/test/resources/samples/test-data/authorities/MeetingAuthority.json
@@ -7,6 +7,13 @@
   "saftMeetingName": [
     "a saft conference name"
   ],
+  "meetingNameTitle": "a conference title",
+  "sftMeetingNameTitle": [
+    "a sft conference title"
+  ],
+  "saftMeetingNameTitle": [
+    "a saft conference title"
+  ],
   "subjectHeadings": "a subject heading",
   "identifiers": [
     {

--- a/mod-search/src/test/resources/samples/test-data/authorities/PersonalAuthority.json
+++ b/mod-search/src/test/resources/samples/test-data/authorities/PersonalAuthority.json
@@ -7,11 +7,18 @@
   "saftPersonalName": [
     "a saft personal name"
   ],
+  "personalNameTitle": "a personal title",
+  "sftPersonalNameTitle": [
+    "a sft personal title"
+  ],
+  "saftPersonalNameTitle": [
+    "a saft personal title"
+  ],
   "geographicName": "a geographic name",
-  "sftGeographicTerm": [
+  "sftGeographicName": [
     "a sft geographic name"
   ],
-  "saftGeographicTerm": [
+  "saftGeographicName": [
     "a saft geographic name"
   ],
   "uniformTitle": "an uniform title",


### PR DESCRIPTION
### Purpose
This merge request adds new integration tests to authority search and fixes failed tests after updating authority search.

### Approach
- Fix the `keyword` search tests for authority
- Add tests non-title fields
- Fix sorting by authority `authRefType` because `Other` option has been removed