### PR TITLE
FAT-1592: Remove active filed verificiation

### DIFF
--- a/mod-bulk-edit/src/main/resources/samples/user/expected-users-preview-after-identifiers-job.json
+++ b/mod-bulk-edit/src/main/resources/samples/user/expected-users-preview-after-identifiers-job.json
@@ -5,7 +5,6 @@
       "id": "02c8d1dc-509d-4c1b-ae9e-624dc8d27058",
       "externalSystemId": null,
       "barcode": "11111",
-      "active": false,
       "type": "Original",
       "patronGroup": "03f7690c-09e8-419f-97ec-2e753d0fa672",
       "departments": [
@@ -59,7 +58,6 @@
       "id": "fec78372-9845-4bd3-b234-b16e5608475f",
       "externalSystemId": null,
       "barcode": "22222",
-      "active": false,
       "type": "Original",
       "patronGroup": "03f7690c-09e8-419f-97ec-2e753d0fa672",
       "departments": [
@@ -113,7 +111,6 @@
       "id": "9468dbb8-4338-4f2b-9830-32a1d69d513a",
       "externalSystemId": null,
       "barcode": "33333",
-      "active": false,
       "type": "Original",
       "patronGroup": "03f7690c-09e8-419f-97ec-2e753d0fa672",
       "departments": [

--- a/mod-bulk-edit/src/main/resources/samples/user/expected-users-preview-after-update-job.json
+++ b/mod-bulk-edit/src/main/resources/samples/user/expected-users-preview-after-update-job.json
@@ -5,7 +5,6 @@
       "id": "9468dbb8-4338-4f2b-9830-32a1d69d513a",
       "externalSystemId": null,
       "barcode": "30000",
-      "active": true,
       "type": "Changed",
       "patronGroup": "9ad391f4-da1c-4760-a9ef-5943dedf13b8",
       "departments": [
@@ -60,7 +59,6 @@
       "id": "02c8d1dc-509d-4c1b-ae9e-624dc8d27058",
       "externalSystemId": null,
       "barcode": "10000",
-      "active": true,
       "type": "Changed",
       "patronGroup": "9ad391f4-da1c-4760-a9ef-5943dedf13b8",
       "departments": [
@@ -115,7 +113,6 @@
       "id": "fec78372-9845-4bd3-b234-b16e5608475f",
       "externalSystemId": null,
       "barcode": "20000",
-      "active": true,
       "type": "Changed",
       "patronGroup": "9ad391f4-da1c-4760-a9ef-5943dedf13b8",
       "departments": [


### PR DESCRIPTION
### PURPOSE

The user "active" field behaves weirdly in snapshot env. After the update job that changes the field from false to true, the value of the field is set from true to false back by the system automatically, and after several seconds the value turns back to be true. It breaks the consistency within tests. In testing env it works as expected but for now lets omit this field verification and will put attention to this in the scope of [FAT-1645](https://issues.folio.org/browse/FAT-1645)
JYI the filed value is still verified against the identifiers job and expected CSV file after the update job has been done. In the scope of the mentioned ticket, the additional verification with JSON comparing should be moved back.