### PR TITLE
Upgrade Vert.x (Netty), jackson-databind, commons-lang3

### DIFF
--- a/testrail-integration/pom.xml
+++ b/testrail-integration/pom.xml
@@ -10,7 +10,24 @@
   <modelVersion>4.0.0</modelVersion>
 
   <artifactId>testrail-integration</artifactId>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>io.vertx</groupId>
+        <artifactId>vertx-stack-depchain</artifactId>
+        <version>4.2.7</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+    </dependency>
     <dependency>
       <groupId>net.masterthought</groupId>
       <artifactId>cucumber-reporting</artifactId>
@@ -19,7 +36,6 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-core</artifactId>
-      <version>3.9.3</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -29,13 +45,8 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.10</version>
+      <version>3.12.0</version>
       <scope>compile</scope>
-    </dependency>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-      <version>2.11.3</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
Upgrade Vert.x from 3.9.3 to 4.2.7 fixing Netty:

 * HTTP Request Smuggling https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-21295
 * Denial of Service (DoS) https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-37136
 * Denial of Service (DoS) https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-37137

Upgrade jackson-databind from 2.11.3 to 2.13.2.1 fixing Denial of Service (DoS)
https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2020-36518

Upgrade commons-lang3 from 3.10 to latest 3.12.0 fixing bugs.