### PR TITLE
MSEARCH-342 Add prev/next values validation for mod-search tests

### DIFF
--- a/mod-search/src/test/resources/samples/test-data/instances.json
+++ b/mod-search/src/test/resources/samples/test-data/instances.json
@@ -121,9 +121,6 @@
           "alternativeTitle": "Le parler arabe de Cherchell, Algérie."
         }
       ],
-      "instanceFormatIds": [
-        "5bfb7b4f-9cd5-4577-a364-f95352146a56"
-      ],
       "editions": [],
       "series": [
         "Cooperative information systems"
@@ -362,7 +359,7 @@
       "id": "02ea8cb6-1a7d-4806-a11d-788428329927",
       "hrid": "falconTestInstance15",
       "title": "Test Instance#15",
-      "subjects": [ "Science", "Molecular biology.", "Molecular genetics." ],
+      "subjects": [ "science", "Molecular biology.", "Molecular genetics." ],
       "instanceTypeId": "6312d172-f0cf-40f6-b27d-9fa8feaf332f",
       "source": "FOLIO"
     }

--- a/mod-search/src/test/resources/spitfire/mod-search/browse/authority-browse.feature
+++ b/mod-search/src/test/resources/spitfire/mod-search/browse/authority-browse.feature
@@ -136,7 +136,7 @@ Feature: Tests that browse by call-numbers
     And param limit = 5
     When method GET
     Then status 200
-    Then match response.prev == '#notpresent'
+    Then match response.prev == 'a sft conference title'
     Then match response.next == 'a sft personal title'
     Then match karate.jsonPath(response, "$.items[*].['headingRef', 'isAnchor']") ==
     """
@@ -155,7 +155,7 @@ Feature: Tests that browse by call-numbers
     And param limit = 5
     When method GET
     Then status 200
-    Then match response.prev == '#notpresent'
+    Then match response.prev == 'a conference title'
     Then match response.next == 'a personal title'
     Then match karate.jsonPath(response, "$.items[*].['headingRef', 'isAnchor']") ==
     """
@@ -175,7 +175,7 @@ Feature: Tests that browse by call-numbers
     When method GET
     Then status 200
     Then match response.prev == 'a personal title'
-    Then match response.next == '#notpresent'
+    Then match response.next == 'a sft geographic name'
     Then match karate.jsonPath(response, "$.items[*].['headingRef', 'isAnchor']") ==
     """
     [
@@ -194,7 +194,7 @@ Feature: Tests that browse by call-numbers
     When method GET
     Then status 200
     Then match response.prev == 'a sft personal title'
-    Then match response.next == '#notpresent'
+    Then match response.next == 'an uniform title'
     Then match karate.jsonPath(response, "$.items[*].['headingRef', 'isAnchor']") ==
     """
     [

--- a/mod-search/src/test/resources/spitfire/mod-search/browse/call-number-browse.feature
+++ b/mod-search/src/test/resources/spitfire/mod-search/browse/call-number-browse.feature
@@ -12,6 +12,8 @@ Feature: Tests that browse by call-numbers
     When method GET
     Then status 200
     Then match response.totalRecords == 17
+    Then match response.prev == 'BC 522918 T21'
+    Then match response.next == 'TK 45105.88815 A58 42004 FT MEADE SUFFIX-90000'
     Then match karate.jsonPath(response, "$.items[*].['shelfKey', 'fullCallNumber', 'totalRecords', 'isAnchor']") ==
     """
     [
@@ -40,6 +42,8 @@ Feature: Tests that browse by call-numbers
     When method GET
     Then status 200
     Then match response.totalRecords == 18
+    Then match response.prev == 'BC 522918 T21'
+    Then match response.next == 'C 3829.29'
     Then match karate.jsonPath(response, "$.items[*].['shelfKey', 'fullCallNumber', 'totalRecords', 'isAnchor']") ==
     """
     [
@@ -59,6 +63,8 @@ Feature: Tests that browse by call-numbers
     When method GET
     Then status 200
     Then match response.totalRecords == 18
+    Then match response.prev == 'BC 522918 T21'
+    Then match response.next == 'J 3839.20 _OVERSIZE'
     Then match karate.jsonPath(response, "$.items[*].['shelfKey', 'fullCallNumber', 'totalRecords', 'isAnchor']") ==
     """
     [
@@ -80,6 +86,8 @@ Feature: Tests that browse by call-numbers
     When method GET
     Then status 200
     Then match response.totalRecords == 18
+    Then match response.prev == 'BC 522918 T21'
+    Then match response.next == 'C 3829.29'
     Then match karate.jsonPath(response, "$.items[*].['shelfKey', 'fullCallNumber', 'totalRecords', 'isAnchor']") ==
     """
     [
@@ -98,6 +106,8 @@ Feature: Tests that browse by call-numbers
     When method GET
     Then status 200
     Then match response.totalRecords == 18
+    Then match response.prev == 'BC 522918 T21'
+    Then match response.next == 'C 3829.29'
     Then match karate.jsonPath(response, "$.items[*].['shelfKey', 'fullCallNumber', 'totalRecords', 'isAnchor']") ==
     """
     [
@@ -117,6 +127,8 @@ Feature: Tests that browse by call-numbers
     When method GET
     Then status 200
     Then match response.totalRecords == 18
+    Then match response.prev == 'BC 522918 T21'
+    Then match response.next == 'GROUP SMITH'
     Then match karate.jsonPath(response, "$.items[*].['shelfKey', 'fullCallNumber', 'totalRecords', 'isAnchor']") ==
     """
     [
@@ -135,6 +147,8 @@ Feature: Tests that browse by call-numbers
     When method GET
     Then status 200
     Then match response.totalRecords == 9
+    Then match response.prev == 'A 252'
+    Then match response.next == 'C 3829.27'
     Then match karate.jsonPath(response, "$.items[*].['shelfKey', 'fullCallNumber', 'totalRecords']") ==
     """
     [
@@ -153,6 +167,8 @@ Feature: Tests that browse by call-numbers
     When method GET
     Then status 200
     Then match response.totalRecords == 15
+    Then match response.prev == '11'
+    Then match response.next == '3325 D A 41908 FREETOWN MAP'
     Then match karate.jsonPath(response, "$.items[*].['shelfKey', 'fullCallNumber', 'totalRecords']") ==
     """
     [
@@ -171,6 +187,8 @@ Feature: Tests that browse by call-numbers
     When method GET
     Then status 200
     Then match response.totalRecords == 15
+    Then match response.prev == 'K 228 210'
+    Then match response.next == 'ZZ 3920.92'
     Then match karate.jsonPath(response, "$.items[*].['shelfKey', 'fullCallNumber', 'totalRecords']") ==
     """
     [

--- a/mod-search/src/test/resources/spitfire/mod-search/browse/subject-browse.feature
+++ b/mod-search/src/test/resources/spitfire/mod-search/browse/subject-browse.feature
@@ -12,6 +12,8 @@ Feature: Tests that browse by subjects
     When method GET
     Then status 200
     Then match response.totalRecords == 35
+    Then match response.prev == 'Church and the world.'
+    Then match response.next == 'French language--Figures of speech'
     Then match response.items[*] ==
     """
     [
@@ -36,12 +38,14 @@ Feature: Tests that browse by subjects
     When method GET
     Then status 200
     Then match response.totalRecords == 35
+    Then match response.prev == 'Musical texts.'
+    Then match response.next == 'Science Fiction.'
     Then match response.items[*] ==
     """
     [
       { "totalRecords": 1, "subject": "Musical texts." },
       { "totalRecords": 1, "subject": "Persian poetry." },
-      { "totalRecords": 4, "subject": "Science", "isAnchor": true },
+      { "totalRecords": 4, "subject": "science", "isAnchor": true },
       { "totalRecords": 1, "subject": "Science (General)." },
       { "totalRecords": 1, "subject": "Science Fiction." }
     ]
@@ -55,6 +59,8 @@ Feature: Tests that browse by subjects
     When method GET
     Then status 200
     Then match response.totalRecords == 35
+    Then match response.prev == 'geography'
+    Then match response.next == 'Magic--Fiction'
     Then match response.items[*] ==
     """
     [
@@ -76,6 +82,8 @@ Feature: Tests that browse by subjects
     When method GET
     Then status 200
     Then match response.totalRecords == 35
+    Then match response.prev == 'geography'
+    Then match response.next == 'imaginary world'
     Then match response.items[*] ==
     """
     [
@@ -94,6 +102,8 @@ Feature: Tests that browse by subjects
     When method GET
     Then status 200
     Then match response.totalRecords == 35
+    Then match response.prev == 'Historiography.'
+    Then match response.next == 'Literary style.'
     Then match response.items[*] ==
     """
     [
@@ -113,6 +123,8 @@ Feature: Tests that browse by subjects
     When method GET
     Then status 200
     Then match response.totalRecords == 35
+    Then match response.prev == 'geography'
+    Then match response.next == 'Literary style.'
     Then match response.items[*] ==
     """
     [
@@ -131,6 +143,8 @@ Feature: Tests that browse by subjects
     When method GET
     Then status 200
     Then match response.totalRecords == 35
+    Then match response.prev == 'biology'
+    Then match response.next == 'Engineering--Mathematical models.'
     Then match response.items[*] ==
     """
     [
@@ -149,6 +163,8 @@ Feature: Tests that browse by subjects
     When method GET
     Then status 200
     Then match response.totalRecords == 35
+    Then match response.prev == 'biology'
+    Then match response.next == 'Engineering--Mathematical models.'
     Then match response.items[*] ==
     """
     [
@@ -167,6 +183,8 @@ Feature: Tests that browse by subjects
     When method GET
     Then status 200
     Then match response.totalRecords == 35
+    Then match response.prev == 'Science (General).'
+    Then match response.next == 'Translations.'
     Then match response.items[*] ==
     """
     [


### PR DESCRIPTION
Fix failed karate tests after implemting previous/next values for browsing by subjects, call-numbers and authority-record heading types.