### PR TITLE
Upgrade Spring from 5.2.11.RELEASE to 5.3.19 (CVE-2022-22965)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <karate.junit.version>1.0.1</karate.junit.version>
     <junit.version>5.6.0</junit.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring.version>5.2.11.RELEASE</spring.version>
+    <spring.version>5.3.19</spring.version>
     <testrail-api-java-client.version>2.0.1</testrail-api-java-client.version>
   </properties>
 


### PR DESCRIPTION
Fixing

* Spring4Shell Remote Code Execution https://nvd.nist.gov/vuln/detail/CVE-2022-22965
* Privilege Escalation https://nvd.nist.gov/vuln/detail/CVE-2021-22118
* Improper Input Validation https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-22060
* Improper Output Neutralization for Logs https://nvd.nist.gov/view/vuln/detail?vulnId=CVE-2021-22096