### PR TITLE
FAT-1001: Fix time interval issue to get aged-to-lost loan

### DIFF
--- a/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
@@ -41,7 +41,6 @@ Feature: mod-circulation integration tests
       | 'circulation.loans.collection.get'                             |
       | 'circulation.loans.declare-item-lost.post'                     |
       | 'circulation.loans.item.get'                                   |
-      | 'circulation.loans.change-due-date.post'                       |
       | 'circulation.requests.collection.get'                          |
       | 'circulation.requests.hold-shelf-clearance-report.get'         |
       | 'circulation.requests.item.get'                                |

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/loans.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/loans.feature
@@ -919,21 +919,19 @@ Feature: Loans tests
     When method PATCH
     Then status 204
 
-    # change due date of the loan so that it will be age to lost
-    * def updateLoanRequest = { dueDate: #('2020-02-01T00:00:00.000Z') }
-    Given path 'circulation', 'loans', extLoanId, 'change-due-date'
-    And request updateLoanRequest
-    When method POST
-    Then status 204
-
     # get the loan and verify that the loan has been aged to lost and updated agedToLostDate, lostItemHasBeenBilled and dateLostItemShouldBeBilled
+    * configure retry = { count: 5, interval: 1000 }
     Given path 'loan-storage', 'loans', extLoanId
+    And print response
+    And retry until response.itemStatus == 'Aged to lost'
     When method GET
-    Then status 200
     And match $.agedToLostDelayedBilling.agedToLostDate == '#present'
     And match $.itemStatus == 'Aged to lost'
     And match $.agedToLostDelayedBilling.lostItemHasBeenBilled == false
     And match $.agedToLostDelayedBilling.dateLostItemShouldBeBilled == '#present'
+
+    # revert retry configuration to default values
+    * configure retry = { count: 3, interval: 3000 }
 
     # revert age-to-lost processor delay time
     Given path '/_/proxy/tenants/' + tenant + '/timers'


### PR DESCRIPTION
## Purpose
[FAT-1001](https://issues.folio.org/browse/FAT-1001)
_When an existing loan is aged to lost update agedToLostDate and aged to lost policy specifies delayed billing,update lostItemHasBeenBilled,dateLostItemShouldBeBilled_

## Approach
- Reproduced test scenario with UI.
- Learned necessary sent requests and then necessary received responses 
- Based on the request/response created karate test scenario
