### PR TITLE
[FAT-1529] mod-inn-reach: Implement API Karate tests - Central server b…

### DIFF
--- a/mod-inn-reach/src/main/resources/volaris/mod-inn-reach/features/central-server.feature
+++ b/mod-inn-reach/src/main/resources/volaris/mod-inn-reach/features/central-server.feature
@@ -19,6 +19,8 @@ Feature: Central server
     * def notExistedCentralServerId1 = globalCentralServerId1
     * def centralServerUrl = 'http://10.0.2.2:' + port
 
+    * def invalidCentralServerId3 = callonce uuid3
+
   @create
   Scenario: Create and check central servers
     * configure headers = headersUser
@@ -98,3 +100,94 @@ Feature: Central server
     Given path '/inn-reach/central-servers', centralServer2.id
     When method DELETE
     Then status 204
+
+  @update
+  Scenario: Create and update central server by id
+    * configure headers = headersUser
+    * print 'Create central server 3'
+    Given path '/inn-reach/central-servers'
+    And request read(samplesPath + "central-server/create-central-server1.json")
+    When method POST
+    Then status 201
+    * def centralServerId3 = $.id
+
+    * print 'Get central server by id 3'
+    Given path '/inn-reach/central-servers', centralServerId3
+    When method GET
+    Then status 200
+
+    * def centralServerResponse = $
+    * set centralServerResponse.loanTypeId = "0706fdbd-cad7-4929-ae5f-fb2c096d68ce"
+    * set centralServerResponse.localAgencies[0].code = "x1w5e"
+
+    * print 'Update central server by id 3'
+    Given path '/inn-reach/central-servers', centralServerId3
+    And request centralServerResponse
+    When method PUT
+    Then status 204
+
+    * configure headers = headersUser
+    * print 'Get central server by id 3'
+    Given path '/inn-reach/central-servers', centralServerId3
+    When method GET
+    Then status 200
+
+    * def centralServerResponse = $
+    And match centralServerResponse.id == centralServerId3
+    And match centralServerResponse.loanTypeId == "0706fdbd-cad7-4929-ae5f-fb2c096d68ce"
+    And match centralServerResponse.localAgencies[1].code == "x1w5e"
+
+    * print 'Delete central server by id 3'
+    Given path '/inn-reach/central-servers', centralServerId3
+    When method DELETE
+    Then status 204
+
+  @update
+  Scenario: Create and update central server by invalid id
+    * configure headers = headersUser
+    * print 'Create central server 3 for negative scenario'
+    Given path '/inn-reach/central-servers'
+    And request read(samplesPath + "central-server/create-central-server1.json")
+    When method POST
+    Then status 201
+    * def centralServerId3 = $.id
+
+    * print 'Get central server by id 3 for negative scenario'
+    Given path '/inn-reach/central-servers', centralServerId3
+    When method GET
+    Then status 200
+
+    * def centralServerResponse = $
+    * set centralServerResponse.loanTypeId = "2d7a90d5-a9dc-42d3-ab25-2d4c9fa35714"
+    * set centralServerResponse.localAgencies[0].code = "w1w5e"
+
+    * print 'Update central server by invalid id 3'
+    Given path '/inn-reach/central-servers', invalidCentralServerId3
+    And request centralServerResponse
+    When method PUT
+    Then status 404
+
+    * print 'Delete central server by id 3 for negative scenario'
+    Given path '/inn-reach/central-servers', centralServerId3
+    When method DELETE
+    Then status 204
+
+  Scenario: Create and delete central server by id
+    * configure headers = headersUser
+    * print 'Create central server 4'
+    Given path '/inn-reach/central-servers'
+    And request read(samplesPath + "central-server/create-central-server2.json")
+    When method POST
+    Then status 201
+    * def centralServerId4 = $.id
+
+    * print 'Delete central server by id 4'
+    Given path '/inn-reach/central-servers', centralServerId4
+    When method DELETE
+    Then status 204
+
+    * configure headers = headersUser
+    * print 'Check deleted central server by id'
+    Given path '/inn-reach/central-servers', centralServerId4
+    When method GET
+    Then status 404


### PR DESCRIPTION
Purpose
Karate implementation is created for the following endpoints
GET /central-servers/{id}
PUT /central-servers/{id}
DELETE /central-servers/{id}

Acceptance criteris:
1 API Tests are created at  https://github.com/folio-org/folio-integration-tests
2 Both positive and negative cases covered
3 Test are shown as passed in Cucumber report.