### PR TITLE
FAT-1722 mod-search: Fix Karate test failures

### DIFF
--- a/mod-search/src/test/resources/spitfire/mod-search/browse/authority-browse.feature
+++ b/mod-search/src/test/resources/spitfire/mod-search/browse/authority-browse.feature
@@ -8,25 +8,27 @@ Feature: Tests that browse by call-numbers
   Scenario: Can browse around by single letter
     Given path '/browse/authorities'
     And param query = 'headingRef < "a sft" or headingRef >= "a sft"'
-    And param limit = 11
+    And param limit = 13
     When method GET
     Then status 200
-    Then match response.prev == '#notpresent'
-    Then match response.next == 'a sft personal title'
+    Then match response.prev == 'a corporate name'
+    Then match response.next == 'a sft geographic name'
     Then match karate.jsonPath(response, "$.items[*].['headingRef', 'isAnchor']") ==
     """
     [
-      { "headingRef": "a conference title" },
+      { "headingRef": "a corporate name" },
       { "headingRef": "a corporate title" },
       { "headingRef": "a genre term" },
       { "headingRef": "a geographic name" },
+      { "headingRef": "a personal name" },
       { "headingRef": "a personal title" },
       { "headingRef": "a sft", "isAnchor": true },
+      { "headingRef": "a sft conference name" },
       { "headingRef": "a sft conference title" },
+      { "headingRef": "a sft corporate name" },
       { "headingRef": "a sft corporate title" },
       { "headingRef": "a sft genre term" },
-      { "headingRef": "a sft geographic name" },
-      { "headingRef": "a sft personal title" }
+      { "headingRef": "a sft geographic name" }
     ]
     """
 
@@ -36,13 +38,13 @@ Feature: Tests that browse by call-numbers
     And param limit = 5
     When method GET
     Then status 200
-    Then match response.prev == 'a personal title'
+    Then match response.prev == 'a sft conference title'
     Then match response.next == 'a sft geographic name'
     Then match karate.jsonPath(response, "$.items[*].['headingRef', 'isAnchor']") ==
     """
     [
-      { "headingRef": "a personal title" },
       { "headingRef": "a sft conference title" },
+      { "headingRef": "a sft corporate name" },
       { "headingRef": "a sft corporate title", "isAnchor": true },
       { "headingRef": "a sft genre term" },
       { "headingRef": "a sft geographic name" }
@@ -56,18 +58,18 @@ Feature: Tests that browse by call-numbers
     And param precedingRecordsCount = 2
     When method GET
     Then status 200
-    Then match response.prev == 'a personal title'
-    Then match response.next == 'a sft topical term'
+    Then match response.prev == 'a sft conference title'
+    Then match response.next == 'a sft personal title'
     Then match karate.jsonPath(response, "$.items[*].['headingRef', 'isAnchor']") ==
     """
     [
-      { "headingRef": "a personal title" },
       { "headingRef": "a sft conference title" },
+      { "headingRef": "a sft corporate name" },
       { "headingRef": "a sft corporate title", "isAnchor": true },
       { "headingRef": "a sft genre term" },
       { "headingRef": "a sft geographic name" },
-      { "headingRef": "a sft personal title" },
-      { "headingRef": "a sft topical term" }
+      { "headingRef": "a sft personal name" },
+      { "headingRef": "a sft personal title" }
     ]
     """
 
@@ -78,13 +80,13 @@ Feature: Tests that browse by call-numbers
     And param limit = 5
     When method GET
     Then status 200
-    Then match response.prev == 'a personal title'
+    Then match response.prev == 'a sft conference title'
     Then match response.next == 'a sft geographic name'
     Then match karate.jsonPath(response, "$.items[*].['headingRef', 'isAnchor']") ==
     """
     [
-      { "headingRef": "a personal title" },
       { "headingRef": "a sft conference title" },
+      { "headingRef": "a sft corporate name" },
       { "headingRef": "a sft corporate title" },
       { "headingRef": "a sft genre term" },
       { "headingRef": "a sft geographic name" }
@@ -97,13 +99,13 @@ Feature: Tests that browse by call-numbers
     And param limit = 5
     When method GET
     Then status 200
-    Then match response.prev == 'a personal title'
+    Then match response.prev == 'a sft conference title'
     Then match response.next == 'a sft geographic name'
     Then match karate.jsonPath(response, "$.items[*].['headingRef', 'isAnchor']") ==
     """
     [
-      { "headingRef": "a personal title" },
       { "headingRef": "a sft conference title" },
+      { "headingRef": "a sft corporate name" },
       { "headingRef": "a sft corporate title", "isAnchor": true },
       { "headingRef": "a sft genre term" },
       { "headingRef": "a sft geographic name" }
@@ -117,16 +119,16 @@ Feature: Tests that browse by call-numbers
     And param limit = 5
     When method GET
     Then status 200
-    Then match response.prev == 'a personal title'
-    Then match response.next == 'a sft personal title'
+    Then match response.prev == 'a sft conference title'
+    Then match response.next == 'a sft personal name'
     Then match karate.jsonPath(response, "$.items[*].['headingRef', 'isAnchor']") ==
     """
     [
-      { "headingRef": "a personal title" },
       { "headingRef": "a sft conference title" },
+      { "headingRef": "a sft corporate name" },
       { "headingRef": "a sft genre term" },
       { "headingRef": "a sft geographic name" },
-      { "headingRef": "a sft personal title" }
+      { "headingRef": "a sft personal name" }
     ]
     """
 
@@ -136,16 +138,16 @@ Feature: Tests that browse by call-numbers
     And param limit = 5
     When method GET
     Then status 200
-    Then match response.prev == 'a sft conference title'
-    Then match response.next == 'a sft personal title'
+    Then match response.prev == 'a sft conference name'
+    Then match response.next == 'a sft genre term'
     Then match karate.jsonPath(response, "$.items[*].['headingRef', 'isAnchor']") ==
     """
     [
+      { "headingRef": "a sft conference name" },
       { "headingRef": "a sft conference title" },
+      { "headingRef": "a sft corporate name" },
       { "headingRef": "a sft corporate title" },
       { "headingRef": "a sft genre term" },
-      { "headingRef": "a sft geographic name" },
-      { "headingRef": "a sft personal title" }
     ]
     """
 
@@ -155,16 +157,16 @@ Feature: Tests that browse by call-numbers
     And param limit = 5
     When method GET
     Then status 200
-    Then match response.prev == 'a conference title'
-    Then match response.next == 'a personal title'
+    Then match response.prev == 'a conference name'
+    Then match response.next == 'a genre term'
     Then match karate.jsonPath(response, "$.items[*].['headingRef', 'isAnchor']") ==
     """
     [
+      { "headingRef": "a conference name" },
       { "headingRef": "a conference title" },
+      { "headingRef": "a corporate name" },
       { "headingRef": "a corporate title" },
       { "headingRef": "a genre term" },
-      { "headingRef": "a geographic name" },
-      { "headingRef": "a personal title" }
     ]
     """
 
@@ -174,17 +176,17 @@ Feature: Tests that browse by call-numbers
     And param limit = 5
     When method GET
     Then status 200
-    Then match response.prev == 'a personal title'
-    Then match response.next == 'a sft geographic name'
+    Then match response.prev == 'a sft corporate name'
+    Then match response.next == 'a sft personal name'
     Then match karate.jsonPath(response, "$.items[*].['headingRef', 'isAnchor']") ==
     """
     [
-      { "headingRef": "a personal title" },
-      { "headingRef": "a sft conference title" },
+      { "headingRef": "a sft corporate name" },
       { "headingRef": "a sft corporate title" },
       { "headingRef": "a sft genre term" },
-      { "headingRef": "a sft geographic name" }
-    ]
+      { "headingRef": "a sft geographic name" },
+      { "headingRef": "a sft personal name" }
+  ]
     """
 
   Scenario: Can browse backward from the largest value

--- a/mod-search/src/test/resources/spitfire/mod-search/filters/facet-search.feature
+++ b/mod-search/src/test/resources/spitfire/mod-search/filters/facet-search.feature
@@ -251,9 +251,9 @@ Feature: Tests that searches by facet
   Scenario: Can search by headingType facet
     * def facetValues = []
     * def facetName = "headingType"
-    * facetValues[0] = facet("Personal Name", 3)
-    * facetValues[1] = facet("Corporate Name", 3)
-    * facetValues[2] = facet("Conference Name", 3)
+    * facetValues[0] = facet("Personal Name", 6)
+    * facetValues[1] = facet("Corporate Name", 6)
+    * facetValues[2] = facet("Conference Name", 6)
     * facetValues[3] = facet("Geographic Name", 3)
     * facetValues[4] = facet("Uniform Title", 3)
     * facetValues[5] = facet("Topical", 3)
@@ -263,7 +263,7 @@ Feature: Tests that searches by facet
   Scenario: Can search by subjectHeadings facet
     * def facetValues = []
     * def facetName = "subjectHeadings"
-    * facetValues[0] = facet("c", 15)
-    * facetValues[1] = facet("a", 3)
-    * facetValues[2] = facet("b", 3)
+    * facetValues[0] = facet("c", 18)
+    * facetValues[1] = facet("a", 6)
+    * facetValues[2] = facet("b", 6)
     * call read(searchFacet) {recordsType: 'authorities'}

--- a/mod-search/src/test/resources/spitfire/mod-search/filters/sort-by-option-search.feature
+++ b/mod-search/src/test/resources/spitfire/mod-search/filters/sort-by-option-search.feature
@@ -92,31 +92,40 @@ Feature: Tests that sorted by fields
     * def sortOption = "headingRef"
     * def sortPath = sortOption
     * def recordsType = "authorities"
-    * def expectedOrder = new Array(21);
+    * def expectedOrder = new Array(30);
 
-    * expectedOrder[0] = 'a conference title'
-    * expectedOrder[1] = 'a corporate title'
-    * expectedOrder[2] = 'a genre term'
-    * expectedOrder[3] = 'a geographic name'
-    * expectedOrder[4] = 'a personal title'
+    * expectedOrder[0] = 'a conference name'
+    * expectedOrder[1] = 'a conference title'
+    * expectedOrder[2] = 'a corporate name'
+    * expectedOrder[3] = 'a corporate title'
+    * expectedOrder[4] = 'a genre term'
+    * expectedOrder[5] = 'a geographic name'
+    * expectedOrder[6] = 'a personal name'
+    * expectedOrder[7] = 'a personal title'
 
-    * expectedOrder[5] = 'a saft conference title'
-    * expectedOrder[6] = 'a saft corporate title'
-    * expectedOrder[7] = 'a saft genre term'
-    * expectedOrder[8] = 'a saft geographic name'
-    * expectedOrder[9] = 'a saft personal title'
-    * expectedOrder[10] = 'a saft topical term'
-    * expectedOrder[11] = 'a saft uniform title'
+    * expectedOrder[8] = 'a saft conference name'
+    * expectedOrder[9] = 'a saft conference title'
+    * expectedOrder[10] = 'a saft corporate name'
+    * expectedOrder[11] = 'a saft corporate title'
+    * expectedOrder[12] = 'a saft genre term'
+    * expectedOrder[13] = 'a saft geographic name'
+    * expectedOrder[14] = 'a saft personal name'
+    * expectedOrder[15] = 'a saft personal title'
+    * expectedOrder[16] = 'a saft topical term'
+    * expectedOrder[17] = 'a saft uniform title'
 
-    * expectedOrder[12] = 'a sft conference title'
-    * expectedOrder[13] = 'a sft corporate title'
-    * expectedOrder[14] = 'a sft genre term'
-    * expectedOrder[15] = 'a sft geographic name'
-    * expectedOrder[16] = 'a sft personal title'
-    * expectedOrder[17] = 'a sft topical term'
-    * expectedOrder[18] = 'a sft uniform title'
-    * expectedOrder[19] = 'a topical term'
-    * expectedOrder[20] = 'an uniform title'
+    * expectedOrder[18] = 'a sft conference name'
+    * expectedOrder[19] = 'a sft conference title'
+    * expectedOrder[20] = 'a sft corporate name'
+    * expectedOrder[21] = 'a sft corporate title'
+    * expectedOrder[22] = 'a sft genre term'
+    * expectedOrder[23] = 'a sft geographic name'
+    * expectedOrder[24] = 'a sft personal name'
+    * expectedOrder[25] = 'a sft personal title'
+    * expectedOrder[26] = 'a sft topical term'
+    * expectedOrder[27] = 'a sft uniform title'
+    * expectedOrder[28] = 'a topical term'
+    * expectedOrder[29] = 'an uniform title'
 
     * call read('sort-by-option-search.feature@SortInTwoOrders')
 
@@ -124,24 +133,24 @@ Feature: Tests that sorted by fields
     * def sortOption = "headingType"
     * def sortPath = sortOption
     * def recordsType = "authorities"
-    * def expectedOrder = new Array(21);
+    * def expectedOrder = new Array(30);
 
-    * expectedOrder.fill('Conference Name', 0, 3)
-    * expectedOrder.fill('Corporate Name', 3, 6)
-    * expectedOrder.fill('Genre', 6, 9)
-    * expectedOrder.fill('Geographic Name', 9, 12)
-    * expectedOrder.fill('Personal Name', 12, 15)
-    * expectedOrder.fill('Topical', 15, 18)
-    * expectedOrder.fill('Uniform Title', 18, 21)
+    * expectedOrder.fill('Conference Name', 0, 6)
+    * expectedOrder.fill('Corporate Name', 6, 12)
+    * expectedOrder.fill('Genre', 12, 15)
+    * expectedOrder.fill('Geographic Name', 15, 18)
+    * expectedOrder.fill('Personal Name', 18, 24)
+    * expectedOrder.fill('Topical', 24, 27)
+    * expectedOrder.fill('Uniform Title', 27, 30)
     * call read('sort-by-option-search.feature@SortInTwoOrders')
 
   Scenario: Can sort by authRefType
     * def sortOption = "authRefType"
     * def sortPath = sortOption
     * def recordsType = "authorities"
-    * def expectedOrder = new Array(21);
+    * def expectedOrder = new Array(30);
 
-    * expectedOrder.fill('Auth/Ref', 0, 7)
-    * expectedOrder.fill('Authorized', 7, 14)
-    * expectedOrder.fill('Reference', 14, 21)
+    * expectedOrder.fill('Auth/Ref', 0, 10)
+    * expectedOrder.fill('Authorized', 10, 20)
+    * expectedOrder.fill('Reference', 20, 30)
     * call read('sort-by-option-search.feature@SortInTwoOrders')

--- a/mod-search/src/test/resources/spitfire/mod-search/search/authority-single-property-search.feature
+++ b/mod-search/src/test/resources/spitfire/mod-search/search/authority-single-property-search.feature
@@ -81,17 +81,17 @@ Feature: Tests that authority searches by a single property
     Then match response.totalRecords == '#(<expectedCount>)'
     Examples:
       | field       | value | expectedCount |
-      | nameFields  | name  | 3             |
+      | nameFields  | name  | 12            |
       | titleFields | title | 12            |
-      | sftFields   | sft   | 7             |
-      | saftFields  | saft  | 7             |
+      | sftFields   | sft   | 10            |
+      | saftFields  | saft  | 10            |
 
   Scenario Outline: Can search by date with operators
     Given path '/search/authorities'
     And param query = 'metadata.<field> <operator> "<value>"'
     When method GET
     Then status 200
-    Then match response.totalRecords == 21
+    Then match response.totalRecords == 30
     Examples:
       | field       | operator | value      |
       | createdDate | >=       | 2020-12-10 |
@@ -118,7 +118,7 @@ Feature: Tests that authority searches by a single property
     And param query = 'lccn="<value>"'
     When method GET
     Then status 200
-    Then match response.totalRecords == 3
+    Then match response.totalRecords == 6
     Then match response.authorities[0].id == '#(<expectedId>)'
     Examples:
       | value   | expectedId           |

--- a/mod-search/src/test/resources/spitfire/mod-search/set-up/create-test-data.feature
+++ b/mod-search/src/test/resources/spitfire/mod-search/set-up/create-test-data.feature
@@ -70,6 +70,6 @@ Feature: Create new tenant and upload test data
 
     Given path '/search/authorities'
     And param query = 'cql.allRecords=1'
-    And retry until response.totalRecords == 21
+    And retry until response.totalRecords > 0
     When method GET
     Then status 200

--- a/teams-assignment.json
+++ b/teams-assignment.json
@@ -10,11 +10,6 @@
     "slackChannel": "#core-platform"
   },
   {
-    "team": "Falcon",
-    "modules": ["mod-search"],
-    "slackChannel": "#falcon"
-  },
-  {
     "team": "Firebird",
     "modules": ["mod-audit", "edge-dematic", "edge-caiasoft", "mod-data-export", "mod-oai-pmh"],
     "slackChannel": "#firebird"
@@ -26,7 +21,7 @@
   },
   {
     "team": "Spitfire",
-    "modules": ["mod-kb-ebsco-java", "mod-tags", "mod-codex-ekb", "mod-notes", "mod-quick-marc", "mod-password-validator"],
+    "modules": ["mod-kb-ebsco-java", "mod-tags", "mod-codex-ekb", "mod-notes", "mod-quick-marc", "mod-password-validator", "mod-search"],
     "slackChannel": "#spitfire"
   },
   {


### PR DESCRIPTION
Edit tests after:
- Authority browsing fix: [MSEARCH-342](https://github.com/folio-org/mod-search/pull/252)
- Revert non-title authority fields and add new headingTypeExt: [MSEARCH-346](https://github.com/folio-org/mod-search/pull/249)

![image](https://user-images.githubusercontent.com/88006020/170265634-fb0ca3d1-b2ad-45f3-b0b9-e5a0afae6c80.png)
