### PR TITLE
FAT-964 Investigate causes for data-import-integration karate tests failure on autorun

### DIFF
--- a/data-import/src/main/resources/karate-config.js
+++ b/data-import/src/main/resources/karate-config.js
@@ -66,11 +66,6 @@ function fn() {
     config.admin = {tenant: 'supertenant', name: 'admin', password: 'admin'}
   }
 
-  var params = JSON.parse(JSON.stringify(config.admin))
-  params.baseUrl = config.baseUrl;
-  var response = karate.callSingle('classpath:common/login.feature', params)
-  config.adminToken = response.responseHeaders['x-okapi-token'][0]
-
 //   uncomment to run on local
 //   karate.callSingle('classpath:folijet/data-import/global/add-okapi-permissions.feature', config);
 


### PR DESCRIPTION
### Purpose
Fix karate pipline failure after implementing new build env approach

### Approach
Removed overriding url and admin token.  Removing the lines below doesn't affect to running on other envs.

### Learning
[FAT-964](https://issues.folio.org/browse/FAT-964)