### PR TITLE
FAT 1601 ( Fix api karate tests failures for mod-data-export module )

### DIFF
--- a/mod-data-export/src/test/resources/firebird/dataexport/data-export-basic-junit.feature
+++ b/mod-data-export/src/test/resources/firebird/dataexport/data-export-basic-junit.feature
@@ -10,6 +10,7 @@ Feature: mod-orders integration tests
       | 'mod-configuration'         |
       | 'mod-source-record-storage' |
       | 'mod-inventory-storage'     |
+      | 'mod-inventory'             |
 
     * table adminAdditionalPermissions
       | name |
@@ -20,6 +21,7 @@ Feature: mod-orders integration tests
       | 'configuration.all'     |
       | 'inventory-storage.all' |
       | 'source-storage.all'    |
+      | 'inventory.instances.collection.get' |
 
   Scenario: create tenant and users for testing
     Given call read('classpath:common/setup-users.feature')

--- a/mod-data-export/src/test/resources/karate-config.js
+++ b/mod-data-export/src/test/resources/karate-config.js
@@ -63,10 +63,6 @@ function fn() {
     config.admin = {tenant: 'supertenant', name: 'admin', password: 'admin'}
   }
 
-   var params = JSON.parse(JSON.stringify(config.admin))
-   params.baseUrl = config.baseUrl;
-   var response = karate.callSingle('classpath:common/login.feature', params)
-   config.adminToken = response.responseHeaders['x-okapi-token'][0]
 
 //   uncomment to run on local
 //   karate.callSingle('classpath:global/add-okapi-permissions.feature', config);


### PR DESCRIPTION
FAT-1601 ( https://issues.folio.org/browse/FAT-1601 ) 
### Purpose
Fix api karate tests failures for mod-data-export module 

### Approach
1. Permission added : | 'inventory.instances.collection.get' | 
2. Module added : | 'mod-inventory' |

Output : 
![FAT-1601_cucmber_Report](https://user-images.githubusercontent.com/103935659/172851499-f694e0f5-9365-40fb-9709-42ab1d0c4579.JPG)

