### PR TITLE
[FAT-2131] https://issues.folio.org/browse/FAT-2131

### DIFF
--- a/mod-data-export/src/test/java/org/folio/ModDataExportApiTest.java
+++ b/mod-data-export/src/test/java/org/folio/ModDataExportApiTest.java
@@ -18,25 +18,25 @@ class ModDataExportApiTest extends TestBase {
     }
 
     @Test
-    @Order(1)
+    @Order(6)
     void quickExportTest() {
         runFeatureTest("quick-export");
     }
 
     @Test
-    @Order(2)
+    @Order(1)
     void mappingProfilesTest() {
         runFeatureTest("mapping-profiles");
     }
 
     @Test
-    @Order(3)
+    @Order(2)
     void jobProfilesTest() {
         runFeatureTest("job-profiles");
     }
 
     @Test
-    @Order(4)
+    @Order(3)
     void fileUploadAndExportTest() {
         runFeatureTest("export");
     }
@@ -48,7 +48,7 @@ class ModDataExportApiTest extends TestBase {
     }
 
     @Test
-    @Order(6)
+    @Order(4)
     void fileExportForMarcHoldingRecordExportTest() {
         runFeatureTest("export-for-holdings");
     }

--- a/mod-data-export/src/test/resources/firebird/dataexport/features/export-for-authority.feature
+++ b/mod-data-export/src/test/resources/firebird/dataexport/features/export-for-authority.feature
@@ -141,8 +141,8 @@ Feature: Tests export hodings records
     And match response.jobExecutions[0].progress == {exported:0, failed:0, total:0}
 
     #error logs should be saved
-    Given path 'data-export/logs?query=jobExecutionId=' + jobExecutionId
-    And param query = "jobExecutionId=" + jobExecutionId
+    Given path 'data-export/logs'
+    And param query = 'jobExecutionId==' + jobExecutionId
     When method GET
     Then status 200
     And def errorLog = response.errorLogs[0]
@@ -206,8 +206,8 @@ Feature: Tests export hodings records
     And match response.jobExecutions[0].progress == {exported:0, failed:0, total:0}
 
     #error logs should be saved
-    Given path 'data-export/logs?query=jobExecutionId=' + jobExecutionId
-    And param query = "jobExecutionId=" + jobExecutionId
+    Given path 'data-export/logs'
+    And param query = 'jobExecutionId==' + jobExecutionId
     When method GET
     Then status 200
     And def errorLog = response.errorLogs[0]

--- a/mod-data-export/src/test/resources/firebird/dataexport/features/export-for-cql.feature
+++ b/mod-data-export/src/test/resources/firebird/dataexport/features/export-for-cql.feature
@@ -79,7 +79,8 @@ Feature: Tests for cql and exporting the records
     * def downloadLink = response.link
 
     #error logs should be empty after successful scenarios
-    Given path 'data-export/logs?query=jobExecutionId=' + jobExecutionId
+    Given path 'data-export/logs'
+    And param query = 'jobExecutionId==' + jobExecutionId
     When method GET
     Then status 200
     And match response.totalRecords == 0

--- a/mod-data-export/src/test/resources/firebird/dataexport/features/export-for-holdings.feature
+++ b/mod-data-export/src/test/resources/firebird/dataexport/features/export-for-holdings.feature
@@ -132,9 +132,12 @@ Feature: Tests export hodings records
     #should return job execution by id and wait until the job status will be 'COMPLETED'
     Given path 'data-export/job-executions'
     And param query = 'id==' + jobExecutionId
-    And retry until response.jobExecutions[0].status == 'COMPLETED' && JSON.stringify(response.jobExecutions[0].progress) == '{"exported":1,"failed":0,"total":1}'
+    And retry until response.jobExecutions[0].status == 'COMPLETED'
     When method GET
     Then status 200
+    And match response.jobExecutions[0].progress.exported == 1
+    And match response.jobExecutions[0].progress.failed == 0
+    And match response.jobExecutions[0].progress.total == 1
 
     #error logs should be empty
     Given path 'data-export/logs'

--- a/mod-data-export/src/test/resources/firebird/dataexport/features/export-for-holdings.feature
+++ b/mod-data-export/src/test/resources/firebird/dataexport/features/export-for-holdings.feature
@@ -132,12 +132,13 @@ Feature: Tests export hodings records
     #should return job execution by id and wait until the job status will be 'COMPLETED'
     Given path 'data-export/job-executions'
     And param query = 'id==' + jobExecutionId
-    And retry until response.jobExecutions[0].status == 'COMPLETED' && JSON.stringify(response.jobExecutions[0].progress) == '{"exported":1,"total":1,"failed":0}'
+    And retry until response.jobExecutions[0].status == 'COMPLETED' && JSON.stringify(response.jobExecutions[0].progress) == '{"exported":1,"failed":0,"total":1}'
     When method GET
     Then status 200
 
     #error logs should be empty
-    Given path 'data-export/logs?query=jobExecutionId=' + jobExecutionId
+    Given path 'data-export/logs'
+    And param query = 'jobExecutionId==' + jobExecutionId
     When method GET
     Then status 200
     And match response.totalRecords == 0
@@ -200,8 +201,8 @@ Feature: Tests export hodings records
     And match response.jobExecutions[0].progress == {exported:0, failed:0, total:0}
 
     #error logs should be saved
-    Given path 'data-export/logs?query=jobExecutionId=' + jobExecutionId
-    And param query = "jobExecutionId=" + jobExecutionId
+    Given path 'data-export/logs'
+    And param query = 'jobExecutionId==' + jobExecutionId
     When method GET
     Then status 200
     And def errorLog = response.errorLogs[0]
@@ -265,8 +266,8 @@ Feature: Tests export hodings records
     And match response.jobExecutions[0].progress == {exported:0, failed:0, total:0}
 
     #error logs should be saved
-    Given path 'data-export/logs?query=jobExecutionId=' + jobExecutionId
-    And param query = "jobExecutionId=" + jobExecutionId
+    Given path 'data-export/logs'
+    And param query = 'jobExecutionId==' + jobExecutionId
     When method GET
     Then status 200
     And def errorLog = response.errorLogs[0]

--- a/mod-data-export/src/test/resources/firebird/dataexport/features/export.feature
+++ b/mod-data-export/src/test/resources/firebird/dataexport/features/export.feature
@@ -61,6 +61,7 @@ Feature: Tests for uploading "uuids file" and exporting the records
     When method POST
     Then status 204
 
+
     #should return job execution by id and wait until the job status will be 'COMPLETED'
     Given path 'data-export/job-executions'
     And param query = 'id==' + jobExecutionId
@@ -79,7 +80,9 @@ Feature: Tests for uploading "uuids file" and exporting the records
     * def downloadLink = response.link
 
     #error logs should be empty after successful scenarios
-    Given path 'data-export/logs?query=jobExecutionId=' + jobExecutionId
+
+    Given path 'data-export/logs'
+    And param query = 'jobExecutionId==' + jobExecutionId
     When method GET
     Then status 200
     And match response.totalRecords == 0


### PR DESCRIPTION
[FAT-2131] : https://issues.folio.org/browse/FAT-2131

Purpose/Overview:
Karate tests for ModDataExportApiTest were failed
 after the dependency version were upgraded specifically for - 
<karate.junit.version>1.2.0</karate.junit.version>
<junit.version>5.8.2</junit.version> (edited) 


Couple of reason they failed - 
1. Issue with escaping the special character in the endpoint (question mark sign)
2. The test case scenarios had to be reordered so that the data export jobs were not effected.

Acceptance criteria:

Karate tests are passed on corresponding Jenkins job

![image](https://user-images.githubusercontent.com/34331959/173774627-6190cce0-cc07-4326-a8ed-286d14a3de10.png)
