### PR TITLE
logback-classic 1.2.11 (CVE-2021-42550)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <dependency>
       <groupId>ch.qos.logback</groupId>
       <artifactId>logback-classic</artifactId>
-      <version>1.2.3</version>
+      <version>1.2.11</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Upgrade logback-classic from 1.2.3 to 1.2.11 fixing
a remote execution vulnerability:
https://nvd.nist.gov/vuln/detail/CVE-2021-42550