### PR TITLE
MSEARCH-412 Extend contributor's index with authority ID field

### DIFF
--- a/mod-search/src/test/resources/samples/test-data/instances.json
+++ b/mod-search/src/test/resources/samples/test-data/instances.json
@@ -451,7 +451,19 @@
       "title": "Test Instance#14",
       "subjects": [ "Electronic books.", "Mongolian poetry.", "Folk poetry, Mongolian." ],
       "instanceTypeId": "6312d172-f0cf-40f6-b27d-9fa8feaf332f",
-      "source": "FOLIO"
+      "source": "FOLIO",
+      "contributors": [
+        {
+          "name": "Quiter",
+          "contributorNameTypeId": "2e48e713-17e3-4c13-a9f8-23845bb210aa",
+          "authorityId": "3aaa7f45-c6fd-4e49-90c9-9773edbaaa2c"
+        },
+        {
+          "name": "Quiter",
+          "contributorNameTypeId": "2e48e713-17e3-4c13-a9f8-23845bb210aa",
+          "authorityId": "3aba7f45-c6fd-4e49-90c9-9773edbaaa2c"
+        }
+      ]
     },
     {
       "id": "02ea8cb6-1a7d-4806-a11d-788428329927",
@@ -459,7 +471,14 @@
       "title": "Test Instance#15",
       "subjects": [ "science", "Molecular biology.", "Molecular genetics." ],
       "instanceTypeId": "6312d172-f0cf-40f6-b27d-9fa8feaf332f",
-      "source": "FOLIO"
+      "source": "FOLIO",
+      "contributors": [
+        {
+          "name": "Quiter",
+          "contributorNameTypeId": "2e48e713-17e3-4c13-a9f8-23845bb210aa",
+          "authorityId": "3aaa7f45-c6fd-4e49-90c9-9773edbaaa2c"
+        }
+      ]
     }
   ]
 }

--- a/mod-search/src/test/resources/spitfire/mod-search/browse/contributor-browse.feature
+++ b/mod-search/src/test/resources/spitfire/mod-search/browse/contributor-browse.feature
@@ -11,7 +11,7 @@ Feature: Tests that browse by contributors
     And param limit = 11
     When method GET
     Then status 200
-    Then match response.totalRecords == 15
+    Then match response.totalRecords == 17
     Then match response.prev == 'Brie'
     Then match response.next == 'John, Lennon'
     Then match response.items[*] ==
@@ -101,7 +101,7 @@ Feature: Tests that browse by contributors
     And param limit = 5
     When method GET
     Then status 200
-    Then match response.totalRecords == 15
+    Then match response.totalRecords == 17
     Then match response.prev == 'Falcon Griffin'
     Then match response.next == 'John, Lennon'
     Then match response.items[*] ==
@@ -152,7 +152,7 @@ Feature: Tests that browse by contributors
     And param precedingRecordsCount = 2
     When method GET
     Then status 200
-    Then match response.totalRecords == 15
+    Then match response.totalRecords == 17
     Then match response.prev == 'Antoniou, Grigoris'
     Then match response.next == 'Darth Vader (The father)'
     Then match response.items[*] ==
@@ -217,7 +217,7 @@ Feature: Tests that browse by contributors
     And param limit = 5
     When method GET
     Then status 200
-    Then match response.totalRecords == 15
+    Then match response.totalRecords == 17
     Then match response.prev == 'Antoniou, Grigoris'
     Then match response.next == 'Celin, Cerol (Cerol E.)'
     Then match response.items[*] ==
@@ -267,7 +267,7 @@ Feature: Tests that browse by contributors
     And param limit = 5
     When method GET
     Then status 200
-    Then match response.totalRecords == 15
+    Then match response.totalRecords == 17
     Then match response.prev == 'Ben'
     Then match response.next == 'Clark, Carol (Carol E.)'
     Then match response.items[*] ==
@@ -316,7 +316,7 @@ Feature: Tests that browse by contributors
     And param limit = 5
     When method GET
     Then status 200
-    Then match response.totalRecords == 15
+    Then match response.totalRecords == 17
     Then match response.prev == 'Antoniou, Grigoris'
     Then match response.next == 'Clark, Carol (Carol E.)'
     Then match response.items[*] ==
@@ -366,7 +366,7 @@ Feature: Tests that browse by contributors
     And param limit = 5
     When method GET
     Then status 200
-    Then match response.totalRecords == 15
+    Then match response.totalRecords == 17
     Then match response.prev == 'Abraham'
     Then match response.next == 'Brie.'
     Then match response.items[*] ==
@@ -416,7 +416,7 @@ Feature: Tests that browse by contributors
     And param limit = 5
     When method GET
     Then status 200
-    Then match response.totalRecords == 15
+    Then match response.totalRecords == 17
     Then match response.prev == 'Abraham'
     Then match response.next == 'Brie.'
     Then match response.items[*] ==
@@ -466,8 +466,8 @@ Feature: Tests that browse by contributors
     And param limit = 5
     When method GET
     Then status 200
-    Then match response.totalRecords == 15
-    Then match response.prev == 'Frank Foster'
+    Then match response.totalRecords == 17
+    Then match response.prev == 'John, Lennon'
     Then match response.next == 'Van Helsing, Frank'
     Then match response.items[*] ==
     """
@@ -476,23 +476,25 @@ Feature: Tests that browse by contributors
         "isAnchor": false,
         "totalRecords": 1,
         "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a",
-        "name": "Frank Foster",
-        "contributorTypeId": ["null"]
-      },
-      {
-        "isAnchor": false,
-        "totalRecords": 1,
-        "contributorNameTypeId": "d376e36c-b759-4fed-8502-7130d1eeff39",
-        "name": "Frank Fosters",
-        "contributorTypeId": ["6e09d47d-95e2-4d8a-831b-f777b8ef6d81"]
-      },
-      {
-        "isAnchor": false,
-        "totalRecords": 1,
-        "contributorNameTypeId": "2b94c631-fca9-4892-a730-03ee529ffe2a",
         "name": "John, Lennon",
         "contributorTypeId": ["6e09d47d-95e2-4d8a-831b-f777b8ef6d81"]
       },
+      {
+        "isAnchor": false,
+        "totalRecords": 1,
+        "contributorNameTypeId": "2e48e713-17e3-4c13-a9f8-23845bb210aa",
+        "name": "Quiter",
+        "contributorTypeId": ["null"],
+        "authorityId": "3aba7f45-c6fd-4e49-90c9-9773edbaaa2c"
+      },
+      {
+        "isAnchor": false,
+        "totalRecords": 2,
+        "contributorNameTypeId": "2e48e713-17e3-4c13-a9f8-23845bb210aa",
+        "name": "Quiter",
+        "contributorTypeId": ["null"],
+        "authorityId": "3aaa7f45-c6fd-4e49-90c9-9773edbaaa2c",
+      }
       {
         "isAnchor": false,
         "totalRecords": 2,

--- a/mod-search/src/test/resources/spitfire/mod-search/filters/facet-search.feature
+++ b/mod-search/src/test/resources/spitfire/mod-search/filters/facet-search.feature
@@ -276,5 +276,6 @@ Feature: Tests that searches by facet
     * facetValues[0] = facet("2e48e713-17f3-4c13-a9f8-23845bb210aa", 6)
     * facetValues[1] = facet("2b94c631-fca9-4892-a730-03ee529ffe2a", 4)
     * facetValues[2] = facet("d376e36c-b759-4fed-8502-7130d1eeff39", 3)
-    * facetValues[3] = facet("e8b311a6-3b21-43f2-a269-dd9310cb2d0a", 2)
+    * facetValues[3] = facet("2e48e713-17e3-4c13-a9f8-23845bb210aa", 2)
+    * facetValues[4] = facet("e8b311a6-3b21-43f2-a269-dd9310cb2d0a", 2)
     * call read(searchFacet) {recordsType: 'contributors'}

--- a/mod-search/src/test/resources/spitfire/mod-search/filters/sort-by-option-search.feature
+++ b/mod-search/src/test/resources/spitfire/mod-search/filters/sort-by-option-search.feature
@@ -65,6 +65,8 @@ Feature: Tests that sorted by fields
     * expectedOrder[8] = 'Falcon Griffin'
     * expectedOrder[9] = 'Farmer'
     * expectedOrder[10] = 'John, Lennon'
+    * expectedOrder[11] = 'Quiter'
+    * expectedOrder[12] = 'Quiter'
 
     Given path '/search/instances'
     And param query = 'cql.allRecords=1 sortBy contributors/sort.ascending'


### PR DESCRIPTION
- update tests with 'authorityId' contributor field

[MSEARCH-412](https://issues.folio.org/browse/MSEARCH-412)