### PR TITLE
[MODFIN-272] - Revert FAT-2407 changes

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-totals.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-totals.feature
@@ -99,8 +99,6 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
     When method POST
     Then status 201
 
-    #fund1 & fund3 contains same ledgerId(ledgerWithBudgets1), so allocations between fund1 & fund3 will affect allocationTo & allocationFrom Values of ledgerId.
-    #For Example:- if we allocate '10' to fund3 from fund1 then allocationTo & allocationFrom Values of ledgerId (ledgerWithBudgets1) would be '10'.
     Examples:
       | fundId  | budgetId  | ledgerId           | initialAllocation | encumbered | awaitingPayment | expenditures |
       | fundId1 | budgetId1 | ledgerWithBudgets1 | 10000             | 231.34     | 763.23          | 242          |
@@ -262,7 +260,7 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
 
     Examples:
       | ledgerId           | initialAllocation | allocationFrom |allocationTo | netTransfers | allocated | encumbered | awaitingPayment | expenditures | unavailable | totalFunding | available | overEncumbrance | overExpended |
-      | ledgerWithBudgets1 | 16601.91          |1042.0           |63.0          | -21.0        | 15622.91  | 231.34     | 3108.23         | 742          | 4081.57     | 15601.91     | 11520.34  |0.0              | 0.0          |
+      | ledgerWithBudgets1 | 16601.91          |979.0           |0.0          | -21.0        | 15622.91  | 231.34     | 3108.23         | 742          | 4081.57     | 15601.91     | 11520.34  |0.0              | 0.0          |
       | ledgerWithBudgets2 | 24500             |20.0            |954.0        | 21.0         | 25434.0   | 25000      | 0.0             | 0.0          | 25000.0     | 25455.0      | 455       |0.0              | 0.0          |
 
 
@@ -307,8 +305,8 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
      * def ledger3 = karate.jsonPath(response, '$.ledgers[*][?(@.id == "' + ledgerWithBudgets2 + '")]')[0]
 
      And match ledger1.initialAllocation == 16601.91
-     And match ledger1.allocationTo == 63.0
-     And match ledger1.allocationFrom == 1042.0
+     And match ledger1.allocationTo == 0.0
+     And match ledger1.allocationFrom == 979.0
      And match ledger1.allocated == 15622.91
      And match ledger1.encumbered == 231.34
      And match ledger1.awaitingPayment == 3108.23


### PR DESCRIPTION
### Purpose
We should revert changes [FAT-2407](https://issues.folio.org/browse/FAT-2407) because allocationTo and allocationFrom incorrectly calculated due to RMB tool CQLtoPGJson in mod-finance-storage

### Approach

- Reverted [FAT-2407](https://issues.folio.org/browse/FAT-2407) changes

###Learning
[FAT-2407](https://issues.folio.org/browse/FAT-2407)