### PR TITLE
[FAT-2408] -  Missed param when call createFund function

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/current-budget-for-fund.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/current-budget-for-fund.feature
@@ -21,8 +21,8 @@ Feature: Test API to get current budget by fund
     * def budgetId = callonce uuid3
 
   Scenario: Create finances
-    * call createFund { 'id': '#(fundId)'}
-    * call createFund { 'id': '#(fundIdWithoutBudget)'}
+    * call createFund { 'id': '#(fundId)', 'code': '#(fundId)'}
+    * call createFund { 'id': '#(fundIdWithoutBudget)', 'code': '#(fundIdWithoutBudget)'}
     * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)'}
 
   Scenario: Call API to get current budget for fund


### PR DESCRIPTION
## Purpose
When we call createFund feature in the "current budget for fund" main scenario we should specify "code" param if not code will be retrieved from response.

## Learning
[FAT-2408](https://issues.folio.org/browse/FAT-2408)