### PR TITLE
[FAT-2406] - Set a new ammount due to changing calculation logic

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/fiscal-year-totals.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/fiscal-year-totals.feature
@@ -142,5 +142,5 @@ Feature: Fiscal year totals
     And match response.financialSummary.totalFunding == 45103
     And match response.financialSummary.available == 16863.43
     And match response.financialSummary.cashBalance == 44361
-    And match response.financialSummary.overEncumbrance == 0.04
+    And match response.financialSummary.overEncumbrance == 2345.04
     And match response.financialSummary.overExpended == 841.96


### PR DESCRIPTION
## Purpose
After [MODFISTO-283](https://issues.folio.org/browse/MODFISTO-283) overEncumbrance calculation logic was changed but tests not updated. 

## Approach

- Update with a new ammount overEncumbrance matching line

## Learning
[FAT-2406](https://issues.folio.org/browse/FAT-2406)