### PR TITLE
[FAT-2100] - Fixed destroy tenant of mod-gobi

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-gobi/gobi-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-gobi/gobi-junit.feature
@@ -10,15 +10,7 @@ Feature: mod-gobi integration tests
       | 'mod-permissions'           |
 
     * table userPermissions
-      | name                                      |
-
-
- # Test tenant name creation:
-    * def random = callonce randomMillis
-    * def testTenant = 'test_mod_gobi' + '_' + random
-    #* def testTenant = 'test_mod_gobi'
-    * def testAdmin = {tenant: '#(testTenant)', name: 'test-admin', password: 'admin'}
-    * def testUser = {tenant: '#(testTenant)', name: 'test-user', password: 'test'}
+      | name                        |
 
   Scenario: Create tenant and users for testing
   # Create tenant and users for testing:

--- a/acquisitions/src/main/resources/thunderjet/mod-gobi/gobi.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-gobi/gobi.feature
@@ -11,7 +11,7 @@ Feature: mod-gobi integration tests
       | 'mod-organizations'         |
 
     * table userPermissions
-      | name                                      |
+      | name                        |
 
 
  # Test tenant name creation:


### PR DESCRIPTION
## Purpose
To fix test failing when destroy tenant

## Approach

- Removing initialization data for tenant (deprecated approach)

## Learning
[FAT-2100](https://issues.folio.org/browse/FAT-2100)