### PR TITLE
FAT-2962: Fix invalid tenant ids

### DIFF
--- a/acquisitions/src/main/resources/domain/mod-finance/features/Create-planned-budget-without-expense-classes-when-there-is-no-current-budget.feature
+++ b/acquisitions/src/main/resources/domain/mod-finance/features/Create-planned-budget-without-expense-classes-when-there-is-no-current-budget.feature
@@ -3,7 +3,7 @@ Feature: Create planned budget without expense classes when there is no current 
   Background:
     * url baseUrl
     # uncomment below line for development
-   # * callonce dev {tenant: 'test_finance35'}
+   # * callonce dev {tenant: 'testfinance35'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/domain/mod-finance/features/When-creating-budget-add-expense-classes-from-previous-budget-automatically.feature
+++ b/acquisitions/src/main/resources/domain/mod-finance/features/When-creating-budget-add-expense-classes-from-previous-budget-automatically.feature
@@ -3,7 +3,7 @@ Feature: Create planned budget with expense classes when there is current budget
   Background:
     * url baseUrl
     # uncomment below line for development
-   # * callonce dev {tenant: 'test_finance35'}
+   # * callonce dev {tenant: 'testfinance35'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/domain/mod-finance/features/When-creating-budget-add-expense-classes-if-them-provided-by-user.feature
+++ b/acquisitions/src/main/resources/domain/mod-finance/features/When-creating-budget-add-expense-classes-if-them-provided-by-user.feature
@@ -3,7 +3,7 @@ Feature: Create planned and current budgets with expense classes
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_finance'}
+    #* callonce dev {tenant: 'testfinance'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
@@ -14,8 +14,7 @@ Feature: cross-module integration tests
 
 
     * def random = callonce randomMillis
-    * def testTenant = 'test_cross_modules' + random
-    #* def testTenant = 'test_cross_modules'
+    * def testTenant = 'testcrossmodules' + random
     * def testAdmin = {tenant: '#(testTenant)', name: 'test-admin', password: 'admin'}
     * def testUser = {tenant: '#(testTenant)', name: 'test-user', password: 'test'}
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/MODFISTO-270-delete-planned-budget-without-transactions.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/MODFISTO-270-delete-planned-budget-without-transactions.feature
@@ -4,7 +4,7 @@ Feature: Planned budgets without transactions should be deleted
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_cross_modules'}
+#    * callonce dev {tenant: 'testcrossmodules'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
     * callonce loginRegularUser testUser

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-po-numbers-updates.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-po-numbers-updates.feature
@@ -3,7 +3,7 @@ Feature: Check poNumbers updates when invoice lines are created and updated
 
   Background:
     * url baseUrl
-    #* callonce dev {tenant: 'test_cross_modules1'}
+    #* callonce dev {tenant: 'testcrossmodules1'}
 
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/chek-po-numbers-updates-when-invoice-line-deleted.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/chek-po-numbers-updates-when-invoice-line-deleted.feature
@@ -3,7 +3,7 @@ Feature: Invoice poNumbers needs to be updated when an invoice line is deleted
 
   Background:
     * url baseUrl
-    #* callonce dev {tenant: 'test_cross_modules2'}
+    #* callonce dev {tenant: 'testcrossmodules2'}
 
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/create-order-and-approve-invoice-were-pol-without-fund-distributions.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/create-order-and-approve-invoice-were-pol-without-fund-distributions.feature
@@ -3,7 +3,7 @@ Feature: Create order and approve invoice were pol without fund distributions
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_cross_modules'}
+    #* callonce dev {tenant: 'testcrossmodules'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/create-order-and-invoice-with-odd-penny.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/create-order-and-invoice-with-odd-penny.feature
@@ -3,7 +3,7 @@ Feature: Create orders and invoices with odd penny
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_cross_modules'}
+#    * callonce dev {tenant: 'testcrossmodules'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/create-order-with-invoice-that-has-enough-money.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/create-order-with-invoice-that-has-enough-money.feature
@@ -3,7 +3,7 @@ Feature: Create order with invoice that has enough money
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_cross_modules'}
+    #* callonce dev {tenant: 'testcrossmodules'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/delete-encumbrance.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/delete-encumbrance.feature
@@ -3,7 +3,7 @@ Feature: Test deleting an encumbrance
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_cross_modules'}
+    #* callonce dev {tenant: 'testcrossmodules'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/order-invoice-relation-can-be-changed.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/order-invoice-relation-can-be-changed.feature
@@ -3,7 +3,7 @@ Feature: Test order invoice relation can be changed
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_cross_modules'}
+    #* callonce dev {tenant: 'testcrossmodules'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/order-invoice-relation-can-be-deleted.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/order-invoice-relation-can-be-deleted.feature
@@ -3,7 +3,7 @@ Feature: Test order invoice relation can be deleted
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_cross_modules'}
+    #* callonce dev {tenant: 'testcrossmodules'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/order-invoice-relation-must-be-deleted-if-invoice-deleted.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/order-invoice-relation-must-be-deleted-if-invoice-deleted.feature
@@ -3,7 +3,7 @@ Feature: When invoice is deleted, then order vs invoice relation must be deleted
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_cross_modules1'}
+    #* callonce dev {tenant: 'testcrossmodules1'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/order-invoice-relation.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/order-invoice-relation.feature
@@ -3,7 +3,7 @@ Feature: Test order invoice relation logic
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_cross_modules'}
+#    * callonce dev {tenant: 'testcrossmodules'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/unopen-order-and-add-addition-pol-and-check-encumbrances.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/unopen-order-and-add-addition-pol-and-check-encumbrances.feature
@@ -3,7 +3,7 @@ Feature: UnOpen order and add addition POL and 1 Fund. Also verify encumbrances
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_cross_modules'}
+    #* callonce dev {tenant: 'testcrossmodules'}
 
     * callonce loginRegularUser testUser
     * def okapitokenUser = okapitoken

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/unopen-order-simple-case.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/unopen-order-simple-case.feature
@@ -3,7 +3,7 @@ Feature: Unpopen order with one line and check encumbrance
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_cross_modules'}
+    #* callonce dev {tenant: 'testcrossmodules'}
 
     * callonce loginRegularUser testUser
     * def okapitokenUser = okapitoken

--- a/acquisitions/src/main/resources/thunderjet/edge-orders/edge-orders-destroy-data.feature
+++ b/acquisitions/src/main/resources/thunderjet/edge-orders/edge-orders-destroy-data.feature
@@ -1,6 +1,6 @@
 Feature: destroy data for edge tenant
 
   Scenario: call destroy data with the edge tenant
-    * def testTenant = 'test_edge_orders'
+    * def testTenant = 'testedgeorders'
     * def testUser = { tenant: '#(testTenant)', name: 'test-user', password: 'test' }
     Given call read('classpath:common/destroy-data.feature') { testUser: #(testUser)}

--- a/acquisitions/src/main/resources/thunderjet/edge-orders/edge-orders-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/edge-orders/edge-orders-junit.feature
@@ -19,7 +19,7 @@ Feature: edge-orders integration tests
       | 'orders.all'        |
       | 'gobi.all'          |
 
-    * def testTenant = 'test_edge_orders'
+    * def testTenant = 'testedgeorders'
     * def testAdmin = { tenant: '#(testTenant)', name: 'test-admin', password: 'admin' }
     * def testUser = { tenant: '#(testTenant)', name: 'test-user', password: 'test' }
 

--- a/acquisitions/src/main/resources/thunderjet/edge-orders/edge-orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/edge-orders/edge-orders.feature
@@ -13,7 +13,7 @@ Feature: edge-orders integration tests
       | 'mod-organizations' |
       | 'mod-permissions'   |
 
-    * def testTenant = 'test_edge_orders'
+    * def testTenant = 'testedgeorders'
     * def testAdmin = { tenant: '#(testTenant)', name: 'test-admin', password: 'admin' }
     * def testUser = { tenant: '#(testTenant)', name: 'test-user', password: 'test' }
 

--- a/acquisitions/src/main/resources/thunderjet/edge-orders/features/ebsconet.feature
+++ b/acquisitions/src/main/resources/thunderjet/edge-orders/features/ebsconet.feature
@@ -2,7 +2,7 @@
 Feature: Edge Orders Ebsconet
 
   Background:
-    * def testTenant = 'test_edge_orders'
+    * def testTenant = 'testedgeorders'
     * def testUser = { tenant: '#(testTenant)', name: 'test-user', password: 'test' }
     * url baseUrl
     * def edgeHeaders = { 'Content-Type': 'application/json', 'Accept': 'application/json'  }

--- a/acquisitions/src/main/resources/thunderjet/edge-orders/features/gobi.feature
+++ b/acquisitions/src/main/resources/thunderjet/edge-orders/features/gobi.feature
@@ -4,7 +4,7 @@ Feature: Edge Orders GOBI
   Background:
     * url baseUrl
     * def edgeHeaders = { 'Content-Type': 'application/xml', 'Accept': 'application/xml'  }
-    * callonce login  { tenant: 'test_edge_orders', name: 'test-admin', password: 'admin' }
+    * callonce login  { tenant: 'testedgeorders', name: 'test-admin', password: 'admin' }
     * def okapitokenAdmin = okapitoken
     * def folioAdminHeaders = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*'  }
     * def apiKey = 'eyJzIjoia1FoWUtGYzFJMFE5bVhKNmRUWU0iLCJ0IjoidGVzdF9lZGdlX29yZGVycyIsInUiOiJ0ZXN0LXVzZXIifQ=='

--- a/acquisitions/src/main/resources/thunderjet/mod-ebsconet/ebsconet.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-ebsconet/ebsconet.feature
@@ -14,8 +14,7 @@ Feature: mod-ebsconet integration tests
       | 'mod-tags'          |
 
     * def random = callonce randomMillis
-    * def testTenant = 'test_ebsconet' + random
-    #* def testTenant = 'test_ebsconet6'
+    * def testTenant = 'testebsconet' + random
     * def testAdmin = {tenant: '#(testTenant)', name: 'test-admin', password: 'admin'}
     * def testUser = {tenant: '#(testTenant)', name: 'test-user', password: 'test'}
 

--- a/acquisitions/src/main/resources/thunderjet/mod-ebsconet/features/update-ebsconet-order-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-ebsconet/features/update-ebsconet-order-line.feature
@@ -3,7 +3,7 @@ Feature: Update Ebsconet Order Line
   Background:
     * url baseUrl
 
-    #* callonce dev {tenant: 'test_ebsconet6'}
+    #* callonce dev {tenant: 'testebsconet6'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-ebsconet/features/update-mixed-order-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-ebsconet/features/update-mixed-order-line.feature
@@ -3,7 +3,7 @@ Feature: Update Ebsconet Order Line
   Background:
     * url baseUrl
 
-#    * callonce dev {tenant: 'test_ebsconet'}
+#    * callonce dev {tenant: 'testebsconet'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/acq-units/verify-get-funds-with-query-where-user-has-units.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/acq-units/verify-get-funds-with-query-where-user-has-units.feature
@@ -3,7 +3,7 @@ Feature: Get funds where filter is provided should take into account acquisition
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_finance'}
+    #* callonce dev {tenant: 'testfinance'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/acq-units/verify-get-funds-without-query-where-user-has-units-and-filter-only-by-units.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/acq-units/verify-get-funds-without-query-where-user-has-units-and-filter-only-by-units.feature
@@ -3,7 +3,7 @@ Feature: Get funds without providing filter query should take into account acqui
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_finance'}
+    #* callonce dev {tenant: 'testfinance'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/allowable-encumbrance-and-expenditure-restrictions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/allowable-encumbrance-and-expenditure-restrictions.feature
@@ -3,7 +3,7 @@ Feature: Test allowable encumbrance and expenditure restrictions
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_finance4'}
+#    * callonce dev {tenant: 'testfinance4'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-can-be-deleted-if-have-only-allocation-transactions-From-or-To.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-can-be-deleted-if-have-only-allocation-transactions-From-or-To.feature
@@ -3,7 +3,7 @@ Feature: Budget can be deleted if have only allocation transactions From or To
   Background:
     * url baseUrl
     # uncomment below line for development
-   # * callonce dev {tenant: 'test_finance'}
+   # * callonce dev {tenant: 'testfinance'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-can-not-be-deleted-if-have-other-than-allocation-transactions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-can-not-be-deleted-if-have-other-than-allocation-transactions.feature
@@ -3,7 +3,7 @@ Feature: Budget can not be deleted if have other than allocation transactions
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_finance'}
+    #* callonce dev {tenant: 'testfinance'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-can-not-be-deleted-if-have-to-and-from-fund-in-allocation-transactions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-can-not-be-deleted-if-have-to-and-from-fund-in-allocation-transactions.feature
@@ -3,7 +3,7 @@ Feature: Budget can not be deleted if have to and from fund in allocation transa
   Background:
     * url baseUrl
     # uncomment below line for development
-   # * callonce dev {tenant: 'test_finance'}
+   # * callonce dev {tenant: 'testfinance'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-expense-classes.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-expense-classes.feature
@@ -3,7 +3,7 @@ Feature: Budget expense classes
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_finance3'}
+#    * callonce dev {tenant: 'testfinance3'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-transfer-transactions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-transfer-transactions.feature
@@ -3,7 +3,7 @@ Feature: Make transfer transaction and verify budget updates
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_finance'}
+#    * callonce dev {tenant: 'testfinance'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-update.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-update.feature
@@ -3,7 +3,7 @@ Feature: Budget expense classes
   Background:
     * url baseUrl
     # uncomment below line for development
-#   * callonce dev {tenant: 'test_finance3'}
+#   * callonce dev {tenant: 'testfinance3'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/budgets-totals-calculation.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/budgets-totals-calculation.feature
@@ -3,7 +3,7 @@ Feature: Should tests budget total amounts calculation
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_finance1'}
+    #* callonce dev {tenant: 'testfinance1'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/create-planned-budget-without-expense-classes-and-current-budget.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/create-planned-budget-without-expense-classes-and-current-budget.feature
@@ -3,7 +3,7 @@ Feature: Create planned budget with expense classes when there is current budget
   Background:
     * url baseUrl
     # uncomment below line for development
-   # * callonce dev {tenant: 'test_finance35'}
+   # * callonce dev {tenant: 'testfinance35'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/create-planned-budget-without-expense-classes-when-there-is-no-current-budget.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/create-planned-budget-without-expense-classes-when-there-is-no-current-budget.feature
@@ -3,7 +3,7 @@ Feature: Create planned budget without expense classes when there is no current 
   Background:
     * url baseUrl
     # uncomment below line for development
-   # * callonce dev {tenant: 'test_finance35'}
+   # * callonce dev {tenant: 'testfinance35'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/curr-fiscal-year-for-ledger-consider-time-zone.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/curr-fiscal-year-for-ledger-consider-time-zone.feature
@@ -3,7 +3,7 @@ Feature:  Return current fiscal year consider time zone
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_finance'}
+    #* callonce dev {tenant: 'testfinance'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/current-budget-for-fund.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/current-budget-for-fund.feature
@@ -3,7 +3,7 @@ Feature: Test API to get current budget by fund
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_finance'}
+#    * callonce dev {tenant: 'testfinance'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/fiscal-year-totals.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/fiscal-year-totals.feature
@@ -3,7 +3,7 @@ Feature: Fiscal year totals
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_finance4'}
+#    * callonce dev {tenant: 'testfinance4'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/group-expense-classes.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/group-expense-classes.feature
@@ -3,7 +3,7 @@ Feature: Group expense classes
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_finance5'}
+#    * callonce dev {tenant: 'testfinance5'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/group-fiscal-year-totals.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/group-fiscal-year-totals.feature
@@ -3,7 +3,7 @@ Feature: Group fiscal year totals
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_finance'}
+    #* callonce dev {tenant: 'testfinance'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover-MODFISTO-247.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover-MODFISTO-247.feature
@@ -3,7 +3,7 @@ Feature: Ledger fiscal year rollover issue MODFISTO-247
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_finance'}
+    #* callonce dev {tenant: 'testfinance'}
 
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover-pol-and-system-currencies-are-different.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover-pol-and-system-currencies-are-different.feature
@@ -3,7 +3,7 @@ Feature: Ledger fiscal year rollover pol and system currencies are different
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_finance1'}
+    #* callonce dev {tenant: 'testfinance1'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover.feature
@@ -3,7 +3,7 @@ Feature: Ledger fiscal year rollover
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_finance1'}
+    #* callonce dev {tenant: 'testfinance1'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollovers-multiple.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollovers-multiple.feature
@@ -4,7 +4,7 @@ Feature: Ledger fiscal year rollover issues MODFISTO-309 and MODFISTO-311
     * print karate.info.scenarioName
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_finance'}
+    #* callonce dev {tenant: 'testfinance'}
 
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-totals.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-totals.feature
@@ -3,7 +3,7 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_finance'}
+    #* callonce dev {tenant: 'testfinance'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/transaction-summaries-crud.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/transaction-summaries-crud.feature
@@ -3,7 +3,7 @@ Feature: Transaction summaries CRUD
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_finance'}
+#    * callonce dev {tenant: 'testfinance'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/unopen-order-after-rollover-MODORDERS-542.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/unopen-order-after-rollover-MODORDERS-542.feature
@@ -3,7 +3,7 @@ Feature: Ledger fiscal year rollover issue MODORDERS-542
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_finance'}
+    #* callonce dev {tenant: 'testfinance'}
 
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/update-encumbrance-transactions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/update-encumbrance-transactions.feature
@@ -3,7 +3,7 @@ Feature: Budge's totals (available, unavailable, encumbered) is updated when enc
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_finance'}
+#    * callonce dev {tenant: 'testfinance'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/when-creating-budget-add-expense-classes-from-previous-budget-automatically.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/when-creating-budget-add-expense-classes-from-previous-budget-automatically.feature
@@ -3,7 +3,7 @@ Feature: Create planned budget with expense classes when there is current budget
   Background:
     * url baseUrl
     # uncomment below line for development
-   # * callonce dev {tenant: 'test_finance35'}
+   # * callonce dev {tenant: 'testfinance35'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/when-creating-budget-add-expense-classes-if-them-provided-by-user.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/when-creating-budget-add-expense-classes-if-them-provided-by-user.feature
@@ -3,7 +3,7 @@ Feature: Create planned and current budgets with expense classes
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_finance'}
+    #* callonce dev {tenant: 'testfinance'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/finance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/finance.feature
@@ -14,8 +14,8 @@ Feature: mod-finance integration tests
       | 'mod-configuration'     |
 
     * def random = callonce randomMillis
-    * def testTenant = 'test_finance' + random
-    #* def testTenant = 'test_finance'
+    * def testTenant = 'testfinance' + random
+    #* def testTenant = 'testfinance'
     * def testAdmin = {tenant: '#(testTenant)', name: 'test-admin', password: 'admin'}
     * def testUser = {tenant: '#(testTenant)', name: 'test-user', password: 'test'}
 

--- a/acquisitions/src/main/resources/thunderjet/mod-gobi/gobi.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-gobi/gobi.feature
@@ -16,8 +16,7 @@ Feature: mod-gobi integration tests
 
  # Test tenant name creation:
     * def random = callonce randomMillis
-    * def testTenant = 'test_mod_gobi' + '_' + random
-    #* def testTenant = 'test_mod_gobi'
+    * def testTenant = 'testmodgobi' + random
     * def testAdmin = {tenant: '#(testTenant)', name: 'test-admin', password: 'admin'}
     * def testUser = {tenant: '#(testTenant)', name: 'test-user', password: 'test'}
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-approve-and-pay-invoice-with-odd-pennies-number.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-approve-and-pay-invoice-with-odd-pennies-number.feature
@@ -3,7 +3,7 @@ Feature: Check approve and pay invoice with odd number of pennies in total
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_invoices1'}
+    #* callonce dev {tenant: 'testinvoices1'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-approve-and-pay-invoice-with-zero-dollar-amount.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-approve-and-pay-invoice-with-zero-dollar-amount.feature
@@ -3,7 +3,7 @@ Feature: Check approve and pay invoice with 0$ amount
 
   Background:
     * url baseUrl
-    #* callonce dev {tenant: 'test_invoices'}
+    #* callonce dev {tenant: 'testinvoices'}
 
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-error-respose-with-fundcode-upon-invoice-approval.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-error-respose-with-fundcode-upon-invoice-approval.feature
@@ -3,7 +3,7 @@ Feature: Check error response with fundcode upon invoice approval
   Background:
     * url baseUrl
     # uncomment below line for development
-#   * callonce dev {tenant: 'test_invoices'}
+#   * callonce dev {tenant: 'testinvoices'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-invoice-and-invoice-lines-deletion-restrictions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-invoice-and-invoice-lines-deletion-restrictions.feature
@@ -3,7 +3,7 @@ Feature: Check invoice and invoice lines deletion restrictions
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_invoices'}
+#    * callonce dev {tenant: 'testinvoices'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-invoice-full-flow-where-subTotal-is-negative.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-invoice-full-flow-where-subTotal-is-negative.feature
@@ -3,7 +3,7 @@ Feature: Check invoice full flow where sub total is negative
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_invoices1'}
+    #* callonce dev {tenant: 'testinvoices1'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-invoice-lines-and-documents-are-deleted-with-invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-invoice-lines-and-documents-are-deleted-with-invoice.feature
@@ -3,7 +3,7 @@ Feature: Check invoice lines and documents are deleted with invoice
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_invoices'}
+#    * callonce dev {tenant: 'testinvoices'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-lock-totals-and-calculated-totals-in-invoice-approve-time.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-lock-totals-and-calculated-totals-in-invoice-approve-time.feature
@@ -3,7 +3,7 @@ Feature: Check invoice approve flow if lockTotal is specified
   Background:
     * url baseUrl
     # uncomment below line for development
-   #* callonce dev {tenant: 'test_invoices1'}
+   #* callonce dev {tenant: 'testinvoices1'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-remaining-amount-upon-invoice-approval.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-remaining-amount-upon-invoice-approval.feature
@@ -3,7 +3,7 @@ Feature: Check remaining amount upon invoice approval
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_invoices'}
+#    * callonce dev {tenant: 'testinvoices'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-that-can-not-approve-invoice-if-organization-is-not-vendor.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-that-can-not-approve-invoice-if-organization-is-not-vendor.feature
@@ -3,7 +3,7 @@ Feature: Check that can not approve invoice if organization is not vendor
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_invoices'}
+    #* callonce dev {tenant: 'testinvoices'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-that-changing-protected-fields-forbidden-for-approved-invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-that-changing-protected-fields-forbidden-for-approved-invoice.feature
@@ -3,7 +3,7 @@ Feature: Checking that it is impossible to pay for the invoice if no voucher for
   Background:
     * url baseUrl
     # uncomment below line for development
-   #* callonce dev {tenant: 'test_invoices1'}
+   #* callonce dev {tenant: 'testinvoices1'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-that-not-possible-add-invoice-line-to-approved-invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-that-not-possible-add-invoice-line-to-approved-invoice.feature
@@ -3,7 +3,7 @@ Feature: Checking that it is impossible to add a invoice line to already approve
   Background:
     * url baseUrl
     # uncomment below line for development
-   #* callonce dev {tenant: 'test_invoices1'}
+   #* callonce dev {tenant: 'testinvoices1'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-that-not-possible-pay-for-invoice-if-no-voucher.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-that-not-possible-pay-for-invoice-if-no-voucher.feature
@@ -3,7 +3,7 @@ Feature: Checking that it is impossible to pay for the invoice if no voucher for
   Background:
     * url baseUrl
     # uncomment below line for development
-   #* callonce dev {tenant: 'test_invoices1'}
+   #* callonce dev {tenant: 'testinvoices1'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-that-not-possible-pay-for-invoice-without-approved.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-that-not-possible-pay-for-invoice-without-approved.feature
@@ -4,7 +4,7 @@ Feature: Check that it is not impossible to pay for the invoice without approved
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_invoices'}
+    #* callonce dev {tenant: 'testinvoices'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-that-voucher-exist-with-parameters.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-that-voucher-exist-with-parameters.feature
@@ -4,7 +4,7 @@ Feature: Check voucher from invoice with lines
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_invoices124'}
+    #* callonce dev {tenant: 'testinvoices124'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-vendor-address-included-with-batch-voucher.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/check-vendor-address-included-with-batch-voucher.feature
@@ -3,7 +3,7 @@ Feature: Check vendor address included with batch voucher
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_invoices'}
+#    * callonce dev {tenant: 'testinvoices'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/create-voucher-lines-honor-expense-classes.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/create-voucher-lines-honor-expense-classes.feature
@@ -3,7 +3,7 @@ Feature: Create voucher lines for each unique : externalAccountNumber-extensionN
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_invoices'}
+    #* callonce dev {tenant: 'testinvoices'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/exchange-rate-update-after-invoice-approval.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/exchange-rate-update-after-invoice-approval.feature
@@ -3,7 +3,7 @@ Feature: Check remaining amount upon invoice approval
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_invoices'}
+    #* callonce dev {tenant: 'testinvoices'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/expense-classes-validation.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/expense-classes-validation.feature
@@ -3,7 +3,7 @@ Feature: Expense classes validation upon invoice approval
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_invoices'}
+    #* callonce dev {tenant: 'testinvoices'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/invoice-with-lock-totals-calculated-totals.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/invoice-with-lock-totals-calculated-totals.feature
@@ -3,7 +3,7 @@ Feature: Check invoice and invoice lines total amount calculation, when adjustme
   Background:
     * url baseUrl
     # uncomment below line for development
-   # * callonce dev {tenant: 'test_invoices1'}
+   # * callonce dev {tenant: 'testinvoices1'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/prorated-adjustments-special-cases.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/prorated-adjustments-special-cases.feature
@@ -3,7 +3,7 @@ Feature: Verify that request will be rejected if provided adjustments no valid
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_invoices'}
+#    * callonce dev {tenant: 'testinvoices'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/should_populate_vendor_address_on_get_voucher_by_id.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/should_populate_vendor_address_on_get_voucher_by_id.feature
@@ -3,7 +3,7 @@ Feature: Should populate vendor address when retrieve voucher by id
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_invoices2222'}
+    #* callonce dev {tenant: 'testinvoices2222'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/voucher-with-lines-using-same-external-account.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/voucher-with-lines-using-same-external-account.feature
@@ -3,7 +3,7 @@ Feature: Check voucher from invoice with lines using the same external account
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_invoices'}
+    #* callonce dev {tenant: 'testinvoices'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/invoice.feature
@@ -10,9 +10,7 @@ Feature: mod-invoice integration tests
       | 'mod-configuration' |
 
     * def random = callonce randomMillis
-    * def testTenant = 'test_invoices' + random
-    #* def testTenant = 'test_invoices124'
-    # -Dkarate.env=testing
+    * def testTenant = 'testinvoices' + random
     * def testAdmin = {tenant: '#(testTenant)', name: 'test-admin', password: 'admin'}
     * def testUser = {tenant: '#(testTenant)', name: 'test-user', password: 'test'}
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/MODORDERS-538-piece-against-non-package-mixed-pol-manual-piece-creation-is-false.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/MODORDERS-538-piece-against-non-package-mixed-pol-manual-piece-creation-is-false.feature
@@ -4,7 +4,7 @@ Feature: Should create and delete pieces for non package mixed POL with quantity
 
   Background:
     * url baseUrl
-    #* callonce dev {tenant: 'test_orders1'}
+    #* callonce dev {tenant: 'testorders1'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
     * callonce loginRegularUser testUser

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/MODORDERS-538-piece-against-non-package-mixed-pol-manual-piece-creation-is-true.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/MODORDERS-538-piece-against-non-package-mixed-pol-manual-piece-creation-is-true.feature
@@ -4,7 +4,7 @@ Feature: Should create and delete pieces for non package mixed POL with quantity
 
   Background:
     * url baseUrl
-    #* callonce dev {tenant: 'test_orders'}
+    #* callonce dev {tenant: 'testorders'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
     * callonce loginRegularUser testUser

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/MODORDERS-579-update-piece-against-non-package-mixed-pol-manual-piece-creation-is-false.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/MODORDERS-579-update-piece-against-non-package-mixed-pol-manual-piece-creation-is-false.feature
@@ -4,7 +4,7 @@ Feature: Should create and update pieces for non package mixed POL with quantity
 
   Background:
     * url baseUrl
-    #* callonce dev {tenant: 'test_orders6'}
+    #* callonce dev {tenant: 'testorders6'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
     * callonce loginRegularUser testUser

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/MODORDERS-580-update-piece-POL-location-not-updated-when-piece-location-edited-against-non-package.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/MODORDERS-580-update-piece-POL-location-not-updated-when-piece-location-edited-against-non-package.feature
@@ -4,7 +4,7 @@ Feature: Should update location in the POL if change Location to a different hol
 
   Background:
     * url baseUrl
-    #* callonce dev {tenant: 'test_orders1'}
+    #* callonce dev {tenant: 'testorders1'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
     * callonce loginRegularUser testUser

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/MODORDERS-583-add-piece-without-item-then-open-to-update-and-set-create-item.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/MODORDERS-583-add-piece-without-item-then-open-to-update-and-set-create-item.feature
@@ -4,7 +4,7 @@ Feature: If I don't choose to create an item when creating the piece. If I edit 
 
   Background:
     * url baseUrl
-    #* callonce dev {tenant: 'test_orders1'}
+    #* callonce dev {tenant: 'testorders1'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
     * callonce loginRegularUser testUser

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-new-tags-in-central-tag-repository.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-new-tags-in-central-tag-repository.feature
@@ -4,7 +4,7 @@ Feature: Check new tags created in central tag repository
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_orders'}
+#    * callonce dev {tenant: 'testorders'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-order-lines-number-retrieve-limit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-order-lines-number-retrieve-limit.feature
@@ -4,7 +4,7 @@ Feature: Check limit number of order lines which can be retrieved in scope of co
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_orders'}
+    #* callonce dev {tenant: 'testorders'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
     * print okapitokenAdmin

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-order-re-encumber-work-correctly.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-order-re-encumber-work-correctly.feature
@@ -4,7 +4,7 @@ Feature: Check re-encumber works correctly
   Background:
     * url baseUrl
     # uncomment below line for development
-    # * callonce dev {tenant: 'test_orders12'}
+    # * callonce dev {tenant: 'testorders12'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-re-encumber-property.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-re-encumber-property.feature
@@ -4,7 +4,7 @@ Feature: Check needReEncumber flag populated correctly
   Background:
     * url baseUrl
     # uncomment below line for development
-    # * callonce dev {tenant: 'test_orders'}
+    # * callonce dev {tenant: 'testorders'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/check_total_encumbered_expended_calculated_correctly.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/check_total_encumbered_expended_calculated_correctly.feature
@@ -4,7 +4,7 @@ Feature: Check that totalEncumbered and totalExpended calculated correctly
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_orders32'}
+    #* callonce dev {tenant: 'testorders32'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/close-order-and-release-encumbrances.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/close-order-and-release-encumbrances.feature
@@ -4,7 +4,7 @@ Feature: Close order and release encumbrances
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_orders'}
+#    * callonce dev {tenant: 'testorders'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/close-order-when-fully-paid-and-received.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/close-order-when-fully-paid-and-received.feature
@@ -4,7 +4,7 @@ Feature: Verify once poline fully paid and received order should be closed
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_orders'}
+#    * callonce dev {tenant: 'testorders'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
     * print okapitokenAdmin

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/create-order-that-has-not-enough-money.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/create-order-that-has-not-enough-money.feature
@@ -5,7 +5,7 @@ Feature: Create order that has not enough money
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_orders'}
+    #* callonce dev {tenant: 'testorders'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/delete-opened-order-and-lines.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/delete-opened-order-and-lines.feature
@@ -4,7 +4,7 @@ Feature: Delete opened order and lines
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_orders'}
+    #* callonce dev {tenant: 'testorders'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/encumbrance-tags-inheritance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/encumbrance-tags-inheritance.feature
@@ -4,7 +4,7 @@ Feature: Verify once order is opened or poline is updated, encumbrance inherit p
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_orders'}
+#    * callonce dev {tenant: 'testorders'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
     * print okapitokenAdmin

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/expense-class-handling-for-order-and-lines.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/expense-class-handling-for-order-and-lines.feature
@@ -4,7 +4,7 @@ Feature: Handling of expense classes for order and order lines
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_orders'}
+#    * callonce dev {tenant: 'testorders'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/increase-poline-quantity-for-open-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/increase-poline-quantity-for-open-order.feature
@@ -4,7 +4,7 @@ Feature: Verify updating poLine location restricted after open order
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_orders'}
+    #* callonce dev {tenant: 'testorders'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-ongoing-order-if-interval-or-renewaldate-notset.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-ongoing-order-if-interval-or-renewaldate-notset.feature
@@ -4,7 +4,7 @@ Feature: Should Open ongoing order if interval or renewal date is not set
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_orders'}
+#    * callonce dev {tenant: 'testorders'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-ongoing-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-ongoing-order.feature
@@ -4,7 +4,7 @@ Feature: Open ongoing order
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_orders'}
+#    * callonce dev {tenant: 'testorders'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-instance-link.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-instance-link.feature
@@ -5,7 +5,7 @@ Feature: Check opening an order links to the right instance based on the identif
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_orders'}
+    #* callonce dev {tenant: 'testorders'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
     * callonce loginRegularUser testUser

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-different-po-line-currency.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-different-po-line-currency.feature
@@ -4,7 +4,7 @@ Feature: Open order with different po line currency
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_orders'}
+#    * callonce dev {tenant: 'testorders'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-manual-exchange-rate.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-manual-exchange-rate.feature
@@ -4,7 +4,7 @@ Feature: Open order with manual exchange rate
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_orders'}
+#    * callonce dev {tenant: 'testorders'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-the-same-fund-distributions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-the-same-fund-distributions.feature
@@ -4,7 +4,7 @@ Feature: Should open order with polines having the same fund distributions
   Background:
     * url baseUrl
     # uncomment below line for development
-#    * callonce dev {tenant: 'test_orders'}
+#    * callonce dev {tenant: 'testorders'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/piece-operations-for-order-flows-mixed-order-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/piece-operations-for-order-flows-mixed-order-line.feature
@@ -38,7 +38,7 @@ Feature: Test operations affecting pieces with different po line options
 
   Background:
     * url baseUrl
-    * callonce dev {tenant: 'test_orders1'}
+    * callonce dev {tenant: 'testorders1'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
     * callonce loginRegularUser testUser

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/piece-operations-for-order-flows-phys-order-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/piece-operations-for-order-flows-phys-order-line.feature
@@ -38,7 +38,7 @@ Feature: Test operations affecting pieces for physical po line with different op
 
   Background:
     * url baseUrl
-    * callonce dev {tenant: 'test_orders1'}
+    * callonce dev {tenant: 'testorders1'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
     * callonce loginRegularUser testUser

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/productIds-field-error-when-attempting-to-update-unmodified-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/productIds-field-error-when-attempting-to-update-unmodified-order.feature
@@ -5,7 +5,7 @@ Feature: Get and put a composite order
   Background:
     * url baseUrl
      # uncomment below line for development
-#    * callonce dev {tenant: 'test_orders'}
+#    * callonce dev {tenant: 'testorders'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
     * callonce loginRegularUser testUser

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/receive-piece-against-non-package-pol.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/receive-piece-against-non-package-pol.feature
@@ -4,7 +4,7 @@ Feature: Receive piece against non-package POL
 
   Background:
     * url baseUrl
-    #* callonce dev {tenant: 'test_orders'}
+    #* callonce dev {tenant: 'testorders'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
     * callonce loginRegularUser testUser

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/receive-piece-against-package-pol.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/receive-piece-against-package-pol.feature
@@ -4,7 +4,7 @@ Feature: Receive piece against package POL
 
   Background:
     * url baseUrl
-    #* callonce dev {tenant: 'test_orders'}
+    #* callonce dev {tenant: 'testorders'}
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
     * callonce loginRegularUser testUser

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/should-decrease-quantity-when-delete-piece-with-no-location.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/should-decrease-quantity-when-delete-piece-with-no-location.feature
@@ -4,7 +4,7 @@ Feature: Should decrease quantity when delete piece with no location
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_orders1'}
+    #* callonce dev {tenant: 'testorders1'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
@@ -12,8 +12,7 @@ Feature: mod-orders integration tests
       | 'mod-invoice'        |
 
     * def random = callonce randomMillis
-    * def testTenant = 'test_orders' + random
-    #* def testTenant = 'test_orders'
+    * def testTenant = 'testorders' + random
     * def testAdmin = {tenant: '#(testTenant)', name: 'test-admin', password: 'admin'}
     * def testUser = {tenant: '#(testTenant)', name: 'test-user', password: 'test'}
 

--- a/acquisitions/src/main/resources/thunderjet/mod-organizations/features/acquisitions-api-tests.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-organizations/features/acquisitions-api-tests.feature
@@ -4,7 +4,7 @@ Feature: Organizations API tests.
      * url baseUrl
 
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_mod_organizations'}
+    #* callonce dev {tenant: 'testmodorganizations'}
 
      * callonce loginAdmin testAdmin
      * def okapitokenAdmin = okapitoken

--- a/acquisitions/src/main/resources/thunderjet/mod-organizations/organizations-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-organizations/organizations-junit.feature
@@ -20,8 +20,7 @@ Feature: mod-organizations integration tests
 
  # Test tenant name creation:
     * def random = callonce randomMillis
-    * def testTenant = 'test_mod_organizations' + '_' + random
-    #* def testTenant = 'test_mod_organizations'
+    * def testTenant = 'testmodorganizations' + random
     * def testAdmin = {tenant: '#(testTenant)', name: 'test-admin', password: 'admin'}
     * def testUser = {tenant: '#(testTenant)', name: 'test-user', password: 'test'}
 

--- a/acquisitions/src/main/resources/thunderjet/mod-organizations/organizations.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-organizations/organizations.feature
@@ -20,8 +20,7 @@ Feature: mod-organizations integration tests
 
  # Test tenant name creation:
     * def random = callonce randomMillis
-    * def testTenant = 'test_mod_organizations' + '_' + random
-    #* def testTenant = 'test_mod_organizations'
+    * def testTenant = 'testmodorganizations' + random
     * def testAdmin = {tenant: '#(testTenant)', name: 'test-admin', password: 'admin'}
     * def testUser = {tenant: '#(testTenant)', name: 'test-user', password: 'test'}
 

--- a/edge-oai-pmh/src/test/java/org/folio/EdgeOaiPmhApiTest.java
+++ b/edge-oai-pmh/src/test/java/org/folio/EdgeOaiPmhApiTest.java
@@ -39,6 +39,6 @@ public class EdgeOaiPmhApiTest extends TestBase {
     public void runHook() {
         Optional.ofNullable(System.getenv("karate.env"))
                 .ifPresent(env -> System.setProperty("karate.env", env));
-        System.setProperty("testTenant", "test_oaipmh");
+        System.setProperty("testTenant", "testoaipmh");
     }
 }

--- a/mod-data-export/src/test/resources/firebird/dataexport/data-export-basic.feature
+++ b/mod-data-export/src/test/resources/firebird/dataexport/data-export-basic.feature
@@ -10,7 +10,7 @@ Feature: data export basic tests
       | 'mod-inventory-storage'     |
 
     * def randomNumber = callonce random
-    * def testTenant = 'data_export_test_tenant' + randomNumber
+    * def testTenant = 'dataexporttesttenant' + randomNumber
     * def testAdmin = {tenant: '#(testTenant)', name: 'test-admin', password: 'admin'}
     * def testUser = {tenant: '#(testTenant)', name: 'test-user', password: 'test'}
 

--- a/mod-inn-reach/src/main/resources/volaris/mod-inn-reach/features/inn-reach-location.feature
+++ b/mod-inn-reach/src/main/resources/volaris/mod-inn-reach/features/inn-reach-location.feature
@@ -4,7 +4,7 @@ Feature: Inn reach location
   Background:
     * url baseUrl
     # uncomment below line for development
-    #* callonce dev {tenant: 'test_inn_reach_integration1'}
+    #* callonce dev {tenant: 'testinnreachintegration1'}
 #    * callonce login testAdmin
 #    * def okapitokenAdmin = okapitoken
 

--- a/mod-oai-pmh/src/test/resources/firebird/oaipmh/oaipmh-q3-marc_withholdings.feature
+++ b/mod-oai-pmh/src/test/resources/firebird/oaipmh/oaipmh-q3-marc_withholdings.feature
@@ -18,7 +18,7 @@ Feature: Test enhancements to oai-pmh
 
     * def pmhUrl = baseUrl + '/oai/records'
     * url pmhUrl
-#    * call destroyData {tenant: 'oaipmh_test_tenant1482'}
+#    * call destroyData {tenant: 'oaipmhtesttenant1482'}
     * configure afterFeature =  function(){ karate.call('classpath:common/destroy-data.feature', {tenant: testUser.tenant})}
     #=========================SETUP================================================
     * callonce read('classpath:common/tenant.feature@create')

--- a/mod-oai-pmh/src/test/resources/karate-config.js
+++ b/mod-oai-pmh/src/test/resources/karate-config.js
@@ -58,7 +58,7 @@ function fn() {
   }
 
   config.runId = karate.properties['runId'] ? karate.properties['runId'] : config.random(10000);
-  config.testTenant = 'oaipmh_test_tenant' +  config.runId
+  config.testTenant = 'oaipmhtesttenant' +  config.runId
   karate.log('===RUNNING TESTS IN ENVIRONMENT===' + env);
   karate.log('===TENANT===' + config.testTenant);
 

--- a/poc/src/main/resources/domain/mod-finance/cases/transactions.feature
+++ b/poc/src/main/resources/domain/mod-finance/cases/transactions.feature
@@ -3,7 +3,7 @@ Feature: transactions tests
   Background:
     * url baseUrl
 
-#    * callonce dev {tenant: 'test_finance'}
+#    * callonce dev {tenant: 'testfinance'}
 
     * call login testUser
     * configure headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json'  }

--- a/poc/src/main/resources/domain/mod-finance/finance.feature
+++ b/poc/src/main/resources/domain/mod-finance/finance.feature
@@ -8,7 +8,7 @@ Feature: mod-finance tests
       | 'mod-login'       |
       | 'mod-permissions' |
 
-    * def testTenant = 'test_finance' + runId
+    * def testTenant = 'testfinance' + runId
 
     * def testAdmin = {tenant: '#(testTenant)', name: 'test-admin', password: 'admin'}
     * def testUser = {tenant: '#(testTenant)', name: 'test-user', password: 'test'}

--- a/poc/src/main/resources/domain/mod-orders/cases/composite-orders.feature
+++ b/poc/src/main/resources/domain/mod-orders/cases/composite-orders.feature
@@ -4,7 +4,7 @@ Feature: Test orders
   Background:
     * url baseUrl
 
-#    * callonce dev {tenant: 'test_orders'}
+#    * callonce dev {tenant: 'testorders'}
 
     * call login testUser
     * configure headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json'  }

--- a/poc/src/main/resources/domain/mod-orders/orders.feature
+++ b/poc/src/main/resources/domain/mod-orders/orders.feature
@@ -9,7 +9,7 @@ Feature: mod-orders tests
       | 'mod-permissions'   |
       | 'mod-configuration' |
 
-    * def testTenant = 'test_orders' + runId
+    * def testTenant = 'testorders' + runId
 
     * def testAdmin = {tenant: '#(testTenant)', name: 'test-admin', password: 'admin'}
     * def testUser = {tenant: '#(testTenant)', name: 'test-user', password: 'test'}


### PR DESCRIPTION
It was decided to restrict the tenant id:

https://wiki.folio.org/display/TC/ADR-000002+-+Tenant+Id+and+Module+Name+Restrictions

    no underscore
    no upper case letters
    maximum length 31 characters
    regex: [a-z][a-z0-9]{0,30}

Some tenants in folio-integration-tests are no longer allowed.