### PR TITLE
MODQM-272 Update all bib-auth links on update record

### DIFF
--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-bib-records.feature
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-bib-records.feature
@@ -9,6 +9,7 @@ Feature: Test quickMARC
 
     * def testInstanceId = karate.properties['instanceId']
     * def linkedAuthorityId = karate.properties['linkedAuthorityId']
+    * def authorityNaturalId = karate.properties['authorityNaturalId']
 
   # ================= positive test cases =================
   Scenario: Retrieve existing quickMarcJson by instanceId
@@ -18,9 +19,9 @@ Feature: Test quickMARC
     When method GET
     Then status 200
     * def result = $
-    * def fieldWithLink = {"tag": "035", "indicators": [ "\\", "\\" ], "content":"$a 12883376", "isProtected":false, "authorityId":#(linkedAuthorityId), "authorityControlledSubfields": [ "a" ] }
+    * def fieldWithLink = {"tag": "035", "indicators": [ "\\", "\\" ], "content":"$a 12883376", "isProtected":false, "authorityId":#(linkedAuthorityId), "authorityNaturalId":#(authorityNaturalId), "authorityControlledSubfields": [ "a" ] }
     * def repeatedFieldNoLink = {"tag": "020", "indicators": [ "\\", "\\" ], "content":"$a 0786808772", "isProtected":false }
-    * def repeatedFieldWithLink = {"tag": "020", "indicators": [ "\\", "\\" ], "content":'#("$a 0786816155 (pbk.) $9 " + linkedAuthorityId)', "isProtected":false, "authorityId":#(linkedAuthorityId), "authorityControlledSubfields": [ "a" ] }
+    * def repeatedFieldWithLink = {"tag": "020", "indicators": [ "\\", "\\" ], "content":'#("$a 0786816155 (pbk.) $9 " + linkedAuthorityId)', "isProtected":false, "authorityId":#(linkedAuthorityId), "authorityNaturalId":#(authorityNaturalId), "authorityControlledSubfields": [ "a" ] }
     And match result.fields contains fieldWithLink
     And match result.fields contains repeatedFieldNoLink
     And match result.fields contains repeatedFieldWithLink
@@ -53,6 +54,36 @@ Feature: Test quickMARC
     * def result = $
     And match result.fields contains newField
 
+  Scenario: PUT quickMarc with linked and unlinked fields
+    Given path 'records-editor/records'
+    And param externalId = testInstanceId
+    And headers headersUser
+    When method GET
+    Then status 200
+    * def quickMarcJson = $
+    * def recordId = quickMarcJson.parsedRecordId
+    * def fields = quickMarcJson.fields
+    * def newField = { "tag": "500", "indicators": [ "\\", "\\" ], "content": "$a Test note", "isProtected":false, "authorityId":#(linkedAuthorityId), "authorityNaturalId":#(authorityNaturalId), "authorityControlledSubfields": [ "a" ] }
+    * fields.push(newField)
+    * def filtered = karate.filter(fields, function( obj ) { return obj.tag !== '035' })
+    * set quickMarcJson.fields = filtered
+    * set quickMarcJson.relatedRecordVersion = 2
+    Given path 'records-editor/records', recordId
+    And headers headersUser
+    And request quickMarcJson
+    When method PUT
+    Then status 202
+
+    * def newLink = { "id": 3, "authorityId": #(linkedAuthorityId), "authorityNaturalId": #(authorityNaturalId), "instanceId": #(testInstanceId), "bibRecordTag": #(newField.tag), "bibRecordSubfields": #(newField.authorityControlledSubfields) }
+
+    Given path 'links/instances', testInstanceId
+    And headers headersUser
+    When method GET
+    Then status 200
+    * def result = $
+    And match result.links == '#[2]'
+    And match result.links contains newLink
+
   Scenario: Should update record twice without any errors
     Given path 'records-editor/records'
     And param externalId = testInstanceId
@@ -65,7 +96,7 @@ Feature: Test quickMARC
     * def newField = { "tag": "500", "indicators": [ "\\", "\\" ], "content": "$a Test note", "isProtected":false }
     * fields.push(newField)
     * set record.fields = fields
-    * set record.relatedRecordVersion = 2
+    * set record.relatedRecordVersion = 3
 
     Given path 'records-editor/records', record.parsedRecordId
     And headers headersUser
@@ -86,7 +117,7 @@ Feature: Test quickMARC
     * def newField = { "tag": "550", "content": "$z Test tag", "indicators": [ "\\", "\\" ], "isProtected":false }
     * fields.push(newField)
     * set record.fields = fields
-    * set record.relatedRecordVersion = 3
+    * set record.relatedRecordVersion = 4
 
     Given path 'records-editor/records', record.parsedRecordId
     And headers headersUser

--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/samples/setup-records/instance-links.json
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/samples/setup-records/instance-links.json
@@ -3,7 +3,7 @@
     {
       "id": 1,
       "authorityId": "#(linkedAuthorityId)",
-      "authorityNaturalId": "12345",
+      "authorityNaturalId": "#(authorityNaturalId)",
       "instanceId": "#(instanceId)",
       "bibRecordTag": "020",
       "bibRecordSubfields": ["a"]

--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/setup.feature
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/setup.feature
@@ -14,6 +14,7 @@ Feature: Setup quickMARC
     * def instanceId = '337d160e-a36b-4a2b-b4c1-3589f230bd2c'
     * def instanceHrid = 'in00000000001'
     * def linkedAuthorityId = 'e7537134-0724-4720-9b7d-bddec65c0fad'
+    * def authorityNaturalId = '12345'
 
   Scenario: Setup locations
     Given path 'location-units/institutions'
@@ -75,6 +76,7 @@ Feature: Setup quickMARC
     Then status 204
 
     * setSystemProperty('linkedAuthorityId', linkedAuthorityId)
+    * setSystemProperty('authorityNaturalId', authorityNaturalId)
 
   Scenario: Create MARC-BIB record
     Given path 'instance-storage/instances'

--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/quick-marc-junit.feature
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/quick-marc-junit.feature
@@ -24,6 +24,7 @@ Feature: mod-quick-marc integration tests
       | 'change-manager.jobexecutions.get'                  |
       | 'converter-storage.field-protection-settings.get'   |
       | 'instance-authority-links.instances.collection.put' |
+      | 'instance-authority-links.instances.collection.get' |
 
   Scenario: create tenant and users for testing
     Given call read('classpath:common/setup-users.feature')


### PR DESCRIPTION
## Purpose
Cover new quickMarc bib record response field related to instance-authority linking
Cover instance-authority linking/unlinking on PUT quickMarc

## Approach
- add authorityId field to linked fields
- add test for link/unlink marc bib fields

### Learning
[MODQM-272](https://issues.folio.org/browse/MODQM-272)
