### PR TITLE
FAT-1645 - Bulk-edit(Users) move tests run to test tenant

### DIFF
--- a/mod-bulk-edit/src/main/resources/karate-config.js
+++ b/mod-bulk-edit/src/main/resources/karate-config.js
@@ -49,11 +49,6 @@ function fn() {
     config.admin = {tenant: 'supertenant', name: 'admin', password: 'admin'}
   }
 
-   var params = JSON.parse(JSON.stringify(config.admin))
-   params.baseUrl = config.baseUrl;
-   var response = karate.callSingle('classpath:common/login.feature', params)
-   config.adminToken = response.responseHeaders['x-okapi-token'][0]
-
 //   uncomment to run on local
 //   karate.callSingle('classpath:global/add-okapi-permissions.feature', config);
 


### PR DESCRIPTION
[FAT-1645](https://issues.folio.org/browse/FAT-1645) - Bulk-edit(Users) move tests run to test tenant

## Purpose
Fix karate config and remove redundant login.

Verified on snapshot (only users):

![success_snapshot](https://user-images.githubusercontent.com/83696213/194379419-337cbfc6-de09-4815-9528-e7e517cc2682.JPG)

Verified on jenkins testing env (all features):

![success_testing_env](https://user-images.githubusercontent.com/83696213/194403446-02b8ef55-1fa2-488f-ad5f-7865aa148afb.JPG)

