### PR TITLE
FAT-1645 - Bulk-edit(Users) move tests run to test tenant

### DIFF
--- a/mod-bulk-edit/src/test/java/org/folio/ModBulkEditApiTest.java
+++ b/mod-bulk-edit/src/test/java/org/folio/ModBulkEditApiTest.java
@@ -28,12 +28,12 @@ public class ModBulkEditApiTest extends TestBase {
         runFeatureTest("bulk-edit-users.feature");
     }
 
-//    @Test
+    @Test
     public void bulkdEditItemTest() {
         runFeatureTest("bulk-edit-items.feature");
     }
 
-//    @Test
+    @Test
     public void bulkdEditItemStatusTest() {
         runFeatureTest("bulk-edit-items-status.feature");
     }

--- a/mod-bulk-edit/src/test/java/org/folio/ModBulkEditApiTest.java
+++ b/mod-bulk-edit/src/test/java/org/folio/ModBulkEditApiTest.java
@@ -28,17 +28,17 @@ public class ModBulkEditApiTest extends TestBase {
         runFeatureTest("bulk-edit-users.feature");
     }
 
-    @Test
+//    @Test
     public void bulkdEditItemTest() {
         runFeatureTest("bulk-edit-items.feature");
     }
 
-    @Test
+//    @Test
     public void bulkdEditItemStatusTest() {
         runFeatureTest("bulk-edit-items-status.feature");
     }
 
-    @AfterAll
+//    @AfterAll
     public void tearDown() {
         runFeature("classpath:common/destroy-data.feature");
     }


### PR DESCRIPTION
[FAT-1645](https://issues.folio.org/browse/FAT-1645) - Bulk-edit(Users) move tests run to test tenant

## Purpose
Temporary comment out destroy feature to clearly see what happens to the job command that cannot be found.