### PR TITLE
FAT-3206: Upgrade vulnerable dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
   </licenses>
 
   <properties>
-    <cucumber.reporting.version>5.7.1</cucumber.reporting.version>
+    <cucumber.reporting.version>5.7.3</cucumber.reporting.version>
     <maven.surefire.version>2.22.2</maven.surefire.version>
     <karate.junit.version>1.2.0</karate.junit.version>
     <junit.version>5.8.2</junit.version>
@@ -103,6 +103,34 @@
       <groupId>com.intuit.karate</groupId>
       <artifactId>karate-junit5</artifactId>
       <version>${karate.junit.version}</version>
+    </dependency>
+    <dependency>
+      <!-- Remove this graal-sdk dependency when karate-junit5
+           comes with graal-sdk >= 21.3.1 fixing Access Restriction Bypass
+           https://www.cve.org/CVERecord?id=CVE-2021-35567
+      -->
+      <groupId>org.graalvm.sdk</groupId>
+      <artifactId>graal-sdk</artifactId>
+      <version>21.3.3.1</version>
+    </dependency>
+    <dependency>
+      <!-- Remove this commons-codec dependency when karate-junit5
+           comes with commons-codec >= 1.13 fixing Information Exposure
+           https://app.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518
+      -->
+      <groupId>commons-codec</groupId>
+      <artifactId>commons-codec</artifactId>
+      <version>1.15</version>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>1.33</version>
+    </dependency>
+    <dependency>
+      <groupId>com.fasterxml.jackson.core</groupId>
+      <artifactId>jackson-databind</artifactId>
+      <version>2.13.4.2</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/testrail-integration/pom.xml
+++ b/testrail-integration/pom.xml
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.2.7</version>
+        <version>4.3.4</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>
@@ -24,10 +24,6 @@
   </dependencyManagement>
 
   <dependencies>
-    <dependency>
-      <groupId>com.fasterxml.jackson.core</groupId>
-      <artifactId>jackson-databind</artifactId>
-    </dependency>
     <dependency>
       <groupId>net.masterthought</groupId>
       <artifactId>cucumber-reporting</artifactId>


### PR DESCRIPTION
Upgrade cucumber-reporting from 5.7.1 to 5.7.3, this indirectly upgrades jsoup from 1.15.1 to 1.15.3 fixing cross-site scripting (XSS) https://nvd.nist.gov/vuln/detail/CVE-2022-36033

Upgrade graal-sdk from 21.2.0 to 21.3.3.1 fixing 18 vulnerabilities https://security.snyk.io/package/maven/org.graalvm.sdk:graal-sdk/21.2.0

Upgrade commons-codec from 1.11 to 1.15 fixing Information Exposure https://app.snyk.io/vuln/SNYK-JAVA-COMMONSCODEC-561518

Upgrade snakeyaml from 1.29 to 1.33 fixing Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2022-25857
https://nvd.nist.gov/vuln/detail/CVE-2022-38749

Upgrade jackson-databind from 2.13.0 to 2.13.4.2 fixing Denial of Service (DoS) https://nvd.nist.gov/vuln/detail/CVE-2022-42003

Upgrade Vert.x from unsupported version 4.2.7 to supported version 4.3.4.