### PR TITLE
FAT-3244: Fix calendar deletion endpoint

### DIFF
--- a/mod-calendar/src/main/resources/bama/mod-calendar/features/calendar-create.feature
+++ b/mod-calendar/src/main/resources/bama/mod-calendar/features/calendar-create.feature
@@ -111,7 +111,8 @@ Feature: Calendar searching
     And match $..id contains only [#(createdCalendarId1), #(createdCalendarId2), #(createdCalendarId3)]
 
     # cleanup
-    Given path 'calendar/calendars/' + createdCalendarId1 + ',' + createdCalendarId2 + ',' + createdCalendarId3
+    Given path 'calendar/calendars/'
+    And param id = [createdCalendarId1,createdCalendarId2,createdCalendarId3]
     When method DELETE
     Then status 204
 


### PR DESCRIPTION
This fixes [FAT-3244](https://issues.folio.org/browse/FAT-3244), [FAT-3245](https://issues.folio.org/browse/FAT-3245), and [FAT-3246](https://issues.folio.org/browse/FAT-3246).  3245 and 3246 were false negatives from 3244.

This issue was due to the change of the calendar API's multi-delete endpoint, a change which was made after these tests were written.  Since the calendars were not deleted successfully, all tests afterwards failed.