### PR TITLE
FAT-1048: When patron has exceeded their Patron Group Limit for 'Maximum number of overdue recalls', patron is not allowed to request items

### DIFF
--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
@@ -830,13 +830,18 @@ Feature: Requests tests
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostRequest') { requestId: #(extRequestId2), itemId: #(extItemId2), requesterId: #(extUserId2), extRequestType: #(extRequestType), extInstanceId: #(instanceId), extHoldingsRecordId: #(holdingId) }
 
     # check automated patron block of user1 and verify that user1 has block for requesting
+    * configure retry = { count: 10, interval: 1000 }
     Given path 'automated-patron-blocks', extUserId1
+    And retry until response.automatedPatronBlocks.length > 0
     When method GET
     Then status 200
     And match $.automatedPatronBlocks[0].patronBlockConditionId == maxOverdueRecallsConditionId
     And match $.automatedPatronBlocks[0].blockBorrowing == false
     And match $.automatedPatronBlocks[0].blockRenewals == false
     And match $.automatedPatronBlocks[0].blockRequests == true
+
+    # revert retry configuration to default values
+    * configure retry = { count: 3, interval: 3000 }
 
     # verify that requesting has been blocked for user1:
     * def requestId = call uuid1

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
@@ -823,7 +823,7 @@ Feature: Requests tests
 
     # post two recall requests for user2 in order to exceed limit (for 'Maximum number of overdue recalls' for user1)
     * def extRequestId1 = call uuid1
-    * def extRequestId2 = call uuid2
+    * def extRequestId2 = call uuid1
     * def extRequestType = 'Recall'
     * def extRequestLevel = 'Item'
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostRequest') { requestId: #(extRequestId1), itemId: #(extItemId1), requesterId: #(extUserId2), extRequestType: #(extRequestType), extInstanceId: #(instanceId), extHoldingsRecordId: #(holdingId) }


### PR DESCRIPTION
Implement Karate test for Scenario: "When patron has exceeded their Patron Group Limit for 'Maximum number of overdue recalls', patron is not allowed to request items per Conditions settings"

JIRA: https://issues.folio.org/browse/FAT-1048