### PR TITLE
FAT-2302 - Review Karate test fails, then subsequent succeeds

### DIFF
--- a/data-import/src/main/resources/folijet/data-import/features/data-import-integration.feature
+++ b/data-import/src/main/resources/folijet/data-import/features/data-import-integration.feature
@@ -5852,6 +5852,7 @@ Feature: Data Import integration tests
     * call pause 10000
     Given path 'metadata-provider/jobLogEntries', importJobExecutionId
     And headers headersUser
+    And retry until response.entries[0].instanceActionStatus != null && response.entries[0].holdingsActionStatus != null && response.entries[0].itemActionStatus != null
     When method GET
     Then status 200
     And assert response.entries[0].sourceRecordActionStatus == 'UPDATED'
@@ -7318,6 +7319,7 @@ Feature: Data Import integration tests
     * call pause 10000
     Given path 'metadata-provider/jobLogEntries', importJobExecutionId
     And headers headersUser
+    And retry until response.entries[0].instanceActionStatus != null && response.entries[0].holdingsActionStatus != null && response.entries[0].itemActionStatus != null
     When method GET
     Then status 200
     And assert response.entries[0].sourceRecordActionStatus == 'UPDATED'


### PR DESCRIPTION
## Purpose
to handle intermittent error: 

> did not evaluate to 'true': response.entries[0].holdingsActionStatus == 'UPDATED' 

that appears due to holdingsActionStatus == null at the moment of data retrieving by test



## Learning
[FAT-2302](https://issues.folio.org/browse/FAT-2302)