### PR TITLE
FAT-1048: Deleted unnecessary retry configuration

### DIFF
--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
@@ -912,9 +912,6 @@ Feature: Requests tests
     And match $.automatedPatronBlocks[0].blockRenewals == false
     And match $.automatedPatronBlocks[0].blockRequests == true
 
-    # revert retry configuration to default values
-    * configure retry = { count: 3, interval: 3000 }
-
     # verify that requesting has been blocked for user1:
     * def requestId = call uuid1
     * def extRequestType = 'Recall'


### PR DESCRIPTION
Implement Karate tests for Scenario: "When patron has exceeded their Patron Group Limit for 'Maximum number of overdue recalls', patron is not allowed to request items per Conditions settings"
  
JIRA: https://issues.folio.org/browse/FAT-1048