### PR TITLE
[FAT-3382] - fixed failed karate test with open-order-with-different-po-line-currency.feature

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-different-po-line-currency.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-different-po-line-currency.feature
@@ -102,7 +102,7 @@ Feature: Open order with different po line currency
     When method GET
     Then status 200
     * def transaction = $.transactions[0]
-    And match transaction.amount == java.math.BigDecimal.valueOf(rate).round(new java.math.MathContext(2))
+    And match transaction.amount == java.math.BigDecimal.valueOf(rate).setScale(2, java.math.RoundingMode.HALF_EVEN);
     And match transaction.currency == 'USD'
 
 


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/FAT-3382

## Approach
I have used the setScale method of BigDecimal
### TODOS and Open Questions

### Learning
- http://www.c-jump.com/bcc/c157c/Week05/W05_0380_roundingmodehalfup.htm [ROUND_UP]
- http://www.c-jump.com/bcc/c157c/Week05/W05_0390_roundingmodehalfeve.htm [ROUND_HALF_EVEN]
- https://www.java67.com/2020/04/4-examples-to-round-floating-point-numbers-in-java.html
