### PR TITLE
FAT-1046 Create Karate test for Requests: When patron has exceeded their Patron Group Limit for 'Maximum number of lost items', patron is not allowed to request items per Conditions settings

### DIFF
--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
@@ -1125,6 +1125,7 @@ Feature: Requests tests
     * def ownerId = call uuid1
 
   # post a group and user
+    * def groupId = call uuid1
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: #(groupId) }
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(extUserId1), extUserBarcode: #(extUserBarcode1) }
 


### PR DESCRIPTION
https://issues.folio.org/browse/FAT-1046