### PR TITLE
FAT-3397 - Review Karate test fails, then subsequent succeeds - Part 2

### DIFF
--- a/data-import/src/main/resources/folijet/data-import/features/data-import-integration.feature
+++ b/data-import/src/main/resources/folijet/data-import/features/data-import-integration.feature
@@ -5852,6 +5852,7 @@ Feature: Data Import integration tests
     * call pause 10000
     Given path 'metadata-provider/jobLogEntries', importJobExecutionId
     And headers headersUser
+    And retry until response.entries[0].instanceActionStatus != null && response.entries[0].holdingsActionStatus != null && response.entries[0].itemActionStatus != null
     When method GET
     Then status 200
     And assert response.entries[0].sourceRecordActionStatus == 'UPDATED'
@@ -7318,6 +7319,7 @@ Feature: Data Import integration tests
     * call pause 10000
     Given path 'metadata-provider/jobLogEntries', importJobExecutionId
     And headers headersUser
+    And retry until response.entries[0].instanceActionStatus != null && response.entries[0].holdingsActionStatus != null && response.entries[0].itemActionStatus != null
     When method GET
     Then status 200
     And assert response.entries[0].sourceRecordActionStatus == 'UPDATED'

--- a/data-import/src/main/resources/folijet/data-import/features/data-import-integration.feature
+++ b/data-import/src/main/resources/folijet/data-import/features/data-import-integration.feature
@@ -7349,7 +7349,7 @@ Feature: Data Import integration tests
     And match response.instances[0].statisticalCodeIds[*] contains '264c4f94-1538-43a3-8b40-bed68384b31b'
     And match response.instances[0].previouslyHeld == true
 
-  Scenario: Import MARC file, match on location, update Holdings and Item locations
+  Scenario: FAT-1204 Import MARC file, match on location, update Holdings and Item locations
     # Create mapping profile for create holdings
     Given path 'data-import-profiles/mappingProfiles'
     And headers headersUser
@@ -7375,9 +7375,7 @@ Feature: Data Import integration tests
                   "53cf956f-c1df-410b-8bea-27f712cca7c0": "Annex (KU/CC/DI/A)",
                   "fcd64ce1-6995-48f0-840e-89ffa2288371": "Main Library (KU/CC/DI/M)",
                   "184aae84-a5bf-4c6a-85ba-4a7c73026cd5": "Online (E)",
-                  "758258bc-ecc1-41b8-abca-f7b610822ffd": "ORWIG ETHNO CD (KU/CC/DI/O)",
-                  "b241764c-1466-4e1d-a028-1a3684a5da87": "Popular Reading Collection (KU/CC/DI/P)",
-                  "f34d27c6-a8eb-461b-acd6-5dea81771e70": "SECOND FLOOR (KU/CC/DI/2)"
+                  "758258bc-ecc1-41b8-abca-f7b610822ffd": "ORWIG ETHNO CD (KU/CC/DI/O)"
                 }
               }
             ]
@@ -7453,9 +7451,7 @@ Feature: Data Import integration tests
                   "53cf956f-c1df-410b-8bea-27f712cca7c0": "Annex (KU/CC/DI/A)",
                   "fcd64ce1-6995-48f0-840e-89ffa2288371": "Main Library (KU/CC/DI/M)",
                   "184aae84-a5bf-4c6a-85ba-4a7c73026cd5": "Online (E)",
-                  "758258bc-ecc1-41b8-abca-f7b610822ffd": "ORWIG ETHNO CD (KU/CC/DI/O)",
-                  "b241764c-1466-4e1d-a028-1a3684a5da87": "Popular Reading Collection (KU/CC/DI/P)",
-                  "f34d27c6-a8eb-461b-acd6-5dea81771e70": "SECOND FLOOR (KU/CC/DI/2)"
+                  "758258bc-ecc1-41b8-abca-f7b610822ffd": "ORWIG ETHNO CD (KU/CC/DI/O)"
                 }
               }
             ]
@@ -7579,9 +7575,7 @@ Feature: Data Import integration tests
                   "53cf956f-c1df-410b-8bea-27f712cca7c0": "Annex (KU/CC/DI/A)",
                   "fcd64ce1-6995-48f0-840e-89ffa2288371": "Main Library (KU/CC/DI/M)",
                   "184aae84-a5bf-4c6a-85ba-4a7c73026cd5": "Online (E)",
-                  "758258bc-ecc1-41b8-abca-f7b610822ffd": "ORWIG ETHNO CD (KU/CC/DI/O)",
-                  "b241764c-1466-4e1d-a028-1a3684a5da87": "Popular Reading Collection (KU/CC/DI/P)",
-                  "f34d27c6-a8eb-461b-acd6-5dea81771e70": "SECOND FLOOR (KU/CC/DI/2)"
+                  "758258bc-ecc1-41b8-abca-f7b610822ffd": "ORWIG ETHNO CD (KU/CC/DI/O)"
                 },
                 "value": "910$a"
               }
@@ -7642,9 +7636,7 @@ Feature: Data Import integration tests
                   "53cf956f-c1df-410b-8bea-27f712cca7c0": "Annex (KU/CC/DI/A)",
                   "fcd64ce1-6995-48f0-840e-89ffa2288371": "Main Library (KU/CC/DI/M)",
                   "184aae84-a5bf-4c6a-85ba-4a7c73026cd5": "Online (E)",
-                  "758258bc-ecc1-41b8-abca-f7b610822ffd": "ORWIG ETHNO CD (KU/CC/DI/O)",
-                  "b241764c-1466-4e1d-a028-1a3684a5da87": "Popular Reading Collection (KU/CC/DI/P)",
-                  "f34d27c6-a8eb-461b-acd6-5dea81771e70": "SECOND FLOOR (KU/CC/DI/2)"
+                  "758258bc-ecc1-41b8-abca-f7b610822ffd": "ORWIG ETHNO CD (KU/CC/DI/O)"
                 }
               }
             ]
@@ -7988,7 +7980,7 @@ Feature: Data Import integration tests
     And assert response.totalRecords == 6
     And match response.items[*].permanentLocationId == ["758258bc-ecc1-41b8-abca-f7b610822ffd","758258bc-ecc1-41b8-abca-f7b610822ffd","758258bc-ecc1-41b8-abca-f7b610822ffd","758258bc-ecc1-41b8-abca-f7b610822ffd","758258bc-ecc1-41b8-abca-f7b610822ffd","758258bc-ecc1-41b8-abca-f7b610822ffd"]
 
-  Scenario: Test import with static match on Holdings permanent location
+  Scenario: FAT-1472 Test import with static match on Holdings permanent location
      # Create mapping profile for create instances
     Given path 'data-import-profiles/mappingProfiles'
     And headers headersUser

--- a/data-import/src/main/resources/folijet/data-import/global/default-import-instance-holding-item.feature
+++ b/data-import/src/main/resources/folijet/data-import/global/default-import-instance-holding-item.feature
@@ -435,6 +435,7 @@ Feature: Util feature to import instance, holding, item. Based on FAT-937 scenar
     * call pause 10000
     Given path 'metadata-provider/jobLogEntries', jobExecutionId
     And headers headersUser
+    And retry until response.entries[0].instanceActionStatus != null && response.entries[0].holdingsActionStatus != null && response.entries[0].itemActionStatus != null
     When method GET
     Then status 200
     And assert response.entries[0].sourceRecordActionStatus == 'CREATED'

--- a/data-import/src/main/resources/folijet/data-import/global/inventory_data_setup_util.feature
+++ b/data-import/src/main/resources/folijet/data-import/global/inventory_data_setup_util.feature
@@ -3,11 +3,6 @@ Feature: calls for inventory storage related data setup
   Background:
     * url baseUrl
 
-    * call login testAdmin
-    * def okapitokenAdmin = okapitoken
-
-    * configure headers = { 'Content-Type': 'application/json', 'Accept': 'application/json', 'x-okapi-token': '#(okapitoken)' }
-
   @PostInstanceType
   Scenario: create instance type if not exists
     Given path 'instance-types'

--- a/data-import/src/main/resources/folijet/data-import/global/mod_inventory_init_data.feature
+++ b/data-import/src/main/resources/folijet/data-import/global/mod_inventory_init_data.feature
@@ -58,6 +58,7 @@ Feature: init data for mod-inventory-storage
     * call read('classpath:folijet/data-import/global/inventory_data_setup_util.feature@PostLocation') {location: #(locations[0])}
     * call read('classpath:folijet/data-import/global/inventory_data_setup_util.feature@PostLocation') {location: #(locations[1])}
     * call read('classpath:folijet/data-import/global/inventory_data_setup_util.feature@PostLocation') {location: #(locations[2])}
+    * call read('classpath:folijet/data-import/global/inventory_data_setup_util.feature@PostLocation') {location: #(locations[3])}
     #setup call number type
     * json callNumberTypes = read('classpath:folijet/data-import/samples/call_number/call_number_type.json')
     * call read('classpath:folijet/data-import/global/inventory_data_setup_util.feature@PostCallNumberType') {callNumberType: #(callNumberTypes[0])}

--- a/data-import/src/main/resources/folijet/data-import/samples/location/locations.json
+++ b/data-import/src/main/resources/folijet/data-import/samples/location/locations.json
@@ -42,6 +42,20 @@
       "3a40852d-49fd-4df2-a1f9-6e2641a6e91f"
     ],
     "servicePoints": []
+  },
+  {
+    "id": "758258bc-ecc1-41b8-abca-f7b610822ffd",
+    "name": "ORWIG ETHNO CD",
+    "code": "(KU/CC/DI/O)",
+    "isActive": true,
+    "institutionId": "40ee00ca-a518-4b49-be01-0638d0a4ac57",
+    "campusId": "62cf76b7-cca5-4d33-9217-edf42ce1a848",
+    "libraryId": "5d78803e-ca04-4b4a-aeae-2c63b924518b",
+    "primaryServicePoint": "3a40852d-49fd-4df2-a1f9-6e2641a6e91f",
+    "servicePointIds": [
+      "3a40852d-49fd-4df2-a1f9-6e2641a6e91f"
+    ],
+    "servicePoints": []
   }
 ]
 


### PR DESCRIPTION
## Purpose
after locations movement from reference data to sample data in the inventory-storage the "FAT-1204 Import MARC file, match on location, update Holdings and Item locations" test keep fails because of used location absence.
Add used "ORWIG ETHNO CD (KU/CC/DI/O)" location to test data initialization.


## Learning
[FAT-3397](https://issues.folio.org/browse/FAT-3397)