### PR TITLE
FAT-3427: ModBulkEditApiTest add sample locations

### DIFF
--- a/mod-bulk-edit/src/main/resources/global/mod_item_init_data.feature
+++ b/mod-bulk-edit/src/main/resources/global/mod_item_init_data.feature
@@ -9,7 +9,31 @@ Feature: init data for mod-users
     * configure headers = { 'Content-Type': 'application/json', 'Accept': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)' }
     * configure retry = { interval: 3000, count: 10 }
 
-  Scenario: setup test data for invenory
+  Scenario: setup service point test data
+    * def servicePoint = karate.read('classpath:samples/item/service-point-cd3.json')
+    * call read('classpath:global/util/mod-item-util.feature@PostServicePoint') servicePoint
+
+  Scenario: setup institution test data
+    * def institution = karate.read('classpath:samples/item/institution-ku.json')
+    * call read('classpath:global/util/mod-item-util.feature@PostInstitution') institution
+
+  Scenario: setup campus test data
+    * def campus = karate.read('classpath:samples/item/campus-city.json')
+    * call read('classpath:global/util/mod-item-util.feature@PostCampus') campus
+
+  Scenario: setup library test data
+    * def library = karate.read('classpath:samples/item/library-diku.json')
+    * call read('classpath:global/util/mod-item-util.feature@PostLibrary') library
+
+  Scenario: setup location test data
+    * def location = karate.read('classpath:samples/item/location-main-library.json')
+    * call read('classpath:global/util/mod-item-util.feature@PostLocation') location
+    * def location = karate.read('classpath:samples/item/location-annex.json')
+    * call read('classpath:global/util/mod-item-util.feature@PostLocation') location
+    * def location = karate.read('classpath:samples/item/location-online.json')
+    * call read('classpath:global/util/mod-item-util.feature@PostLocation') location
+
+  Scenario: setup test data for instance
     #setup inventory
     * def instance = karate.read('classpath:samples/item/inventory_instance.json')
     * call read('classpath:global/util/mod-item-util.feature@PostInstance') instance

--- a/mod-bulk-edit/src/main/resources/global/util/mod-item-util.feature
+++ b/mod-bulk-edit/src/main/resources/global/util/mod-item-util.feature
@@ -4,6 +4,41 @@ Feature: setup user data feature
     * url baseUrl
     * configure headers = { 'Content-Type': 'application/json', 'Accept': '*/*', 'x-okapi-token': '#(okapitoken)' }
 
+  @PostServicePoint
+  Scenario: Create service point
+    Given path 'service-points'
+    And request servicePoint
+    When method POST
+    Then status 201
+
+  @PostInstitution
+  Scenario: POST institution
+    Given path 'location-units/institutions'
+    And request institution
+    When method POST
+    Then status 201
+
+  @PostCampus
+  Scenario: POST campus
+    Given path 'location-units/campuses'
+    And request campus
+    When method POST
+    Then status 201
+
+  @PostLibrary
+  Scenario: POST library
+    Given path 'location-units/libraries'
+    And request library
+    When method POST
+    Then status 201
+
+  @PostLocation
+  Scenario: POST location
+    Given path 'locations'
+    And request location
+    When method POST
+    Then status 201
+
   @PostInstance
   Scenario: POST inventory
     Given path 'inventory'

--- a/mod-bulk-edit/src/main/resources/samples/item/campus-city.json
+++ b/mod-bulk-edit/src/main/resources/samples/item/campus-city.json
@@ -1,0 +1,6 @@
+{
+  "id": "62cf76b7-cca5-4d33-9217-edf42ce1a848",
+  "name": "City Campus",
+  "code": "CC",
+  "institutionId": "40ee00ca-a518-4b49-be01-0638d0a4ac57"
+}

--- a/mod-bulk-edit/src/main/resources/samples/item/institution-ku.json
+++ b/mod-bulk-edit/src/main/resources/samples/item/institution-ku.json
@@ -1,0 +1,5 @@
+{
+  "id": "40ee00ca-a518-4b49-be01-0638d0a4ac57",
+  "name": "Københavns Universitet",
+  "code": "KU"
+}

--- a/mod-bulk-edit/src/main/resources/samples/item/library-diku.json
+++ b/mod-bulk-edit/src/main/resources/samples/item/library-diku.json
@@ -1,0 +1,6 @@
+{
+  "id": "5d78803e-ca04-4b4a-aeae-2c63b924518b",
+  "name": "Datalogisk Institut",
+  "code": "DI",
+  "campusId": "62cf76b7-cca5-4d33-9217-edf42ce1a848"
+}

--- a/mod-bulk-edit/src/main/resources/samples/item/location-annex.json
+++ b/mod-bulk-edit/src/main/resources/samples/item/location-annex.json
@@ -1,0 +1,11 @@
+{
+  "id": "53cf956f-c1df-410b-8bea-27f712cca7c0",
+  "name": "Annex",
+  "code": "KU/CC/DI/A",
+  "isActive": true,
+  "institutionId": "40ee00ca-a518-4b49-be01-0638d0a4ac57",
+  "campusId": "62cf76b7-cca5-4d33-9217-edf42ce1a848",
+  "libraryId": "5d78803e-ca04-4b4a-aeae-2c63b924518b",
+  "primaryServicePoint": "33323b51-13de-4ae4-8533-c9a80279da87",
+  "servicePointIds": [ "33323b51-13de-4ae4-8533-c9a80279da87" ]
+}

--- a/mod-bulk-edit/src/main/resources/samples/item/location-main-library.json
+++ b/mod-bulk-edit/src/main/resources/samples/item/location-main-library.json
@@ -1,0 +1,11 @@
+{
+  "id": "fcd64ce1-6995-48f0-840e-89ffa2288371",
+  "name": "Main Library",
+  "code": "KU/CC/DI/M",
+  "isActive": true,
+  "institutionId": "40ee00ca-a518-4b49-be01-0638d0a4ac57",
+  "campusId": "62cf76b7-cca5-4d33-9217-edf42ce1a848",
+  "libraryId": "5d78803e-ca04-4b4a-aeae-2c63b924518b",
+  "primaryServicePoint": "33323b51-13de-4ae4-8533-c9a80279da87",
+  "servicePointIds": [ "33323b51-13de-4ae4-8533-c9a80279da87" ]
+}

--- a/mod-bulk-edit/src/main/resources/samples/item/location-online.json
+++ b/mod-bulk-edit/src/main/resources/samples/item/location-online.json
@@ -1,0 +1,13 @@
+{
+  "id": "184aae84-a5bf-4c6a-85ba-4a7c73026cd5",
+  "name": "Online",
+  "code": "E",
+  "isActive": true,
+  "institutionId": "40ee00ca-a518-4b49-be01-0638d0a4ac57",
+  "campusId": "62cf76b7-cca5-4d33-9217-edf42ce1a848",
+  "libraryId": "5d78803e-ca04-4b4a-aeae-2c63b924518b",
+  "primaryServicePoint": "33323b51-13de-4ae4-8533-c9a80279da87",
+  "servicePointIds": [ "33323b51-13de-4ae4-8533-c9a80279da87" ],
+  "discoveryDisplayName" : "Online",
+  "description" : "Use for online resources"
+}

--- a/mod-bulk-edit/src/main/resources/samples/item/service-point-cd3.json
+++ b/mod-bulk-edit/src/main/resources/samples/item/service-point-cd3.json
@@ -1,0 +1,11 @@
+{
+  "id": "33323b51-13de-4ae4-8533-c9a80279da87",
+  "name": "Circ Desk 3",
+  "code": "cd3",
+  "discoveryDisplayName": "Circulation Desk -- Remote Stacks",
+  "pickupLocation": true,
+  "holdShelfExpiryPeriod": {
+    "duration": 3,
+    "intervalId": "Weeks"
+  }
+}


### PR DESCRIPTION
mod-inventory-storage has moved locations and location-units from reference data to sample data: https://issues.folio.org/browse/MODINVSTOR-443
https://github.com/folio-org/mod-inventory-storage/pull/850/files

We need to create all needed locations in mod_item_init_data.feature/mod-item-util.feature.