### PR TITLE
[MODFISTO-362] Expense class code and status are not shown in test rollover results .csv file

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-preview-rollover-need-close-budgets.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-preview-rollover-need-close-budgets.feature
@@ -348,10 +348,12 @@ Feature: Ledger fiscal year rollover when "Close all current budgets" flag is tr
     And match response.fundDetails.fundStatus == <fundStatus>
 
     And match response.expenseClassDetails[0].expenseClassName == <expenseClassName>
+    And match response.expenseClassDetails[0].expenseClassCode == <expenseClassCode>
+    And match response.expenseClassDetails[0].expenseClassStatus == <expenseClassStatus>
 
     Examples:
-      | fundId      | fundCode    | fundStatus  | allocated | available | unavailable | netTransfers | encumbered | allowableEncumbrance | allowableExpenditure | expenseClassName |
-      | taxFund     | 'TAX'       | 'Active'    | 500       | 350       | 150         | 0            | 150        | 100.0                | 100.0                | 'Electronic'     |
+      | fundId      | fundCode    | fundStatus  | allocated | available | unavailable | netTransfers | encumbered | allowableEncumbrance | allowableExpenditure | expenseClassName | expenseClassCode | expenseClassStatus |
+      | taxFund     | 'TAX'       | 'Active'    | 500       | 350       | 150         | 0            | 150        | 100.0                | 100.0                | 'Electronic'     | 'Elec'           | 'Active'           |
 
   Scenario: Check rollover logs
     Given path 'finance/ledger-rollovers-logs', rolloverId


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/89521577/208422625-4cf3afd6-990c-4777-97b9-2a35d44f4379.png)



### Learning
[MODFISTO-362](https://issues.folio.org/browse/MODFISTO-362)
