### PR TITLE
Upgrade to Vert.x 4.3.7, Netty 4.1.85, Karate 1.3.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
   <properties>
     <cucumber.reporting.version>5.7.3</cucumber.reporting.version>
     <maven.surefire.version>2.22.2</maven.surefire.version>
-    <karate.junit.version>1.2.0</karate.junit.version>
+    <karate.junit.version>1.3.1</karate.junit.version>
     <junit.version>5.8.2</junit.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <spring.version>5.3.20</spring.version>
@@ -112,6 +112,15 @@
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
       <version>1.15</version>
+    </dependency>
+    <dependency>
+      <!-- Remove this netty-codec-haproxy dependency when karate-junit5
+           comes with netty-codec-haproxy >= 4.1.86.Final Denial of Service (DoS)
+           https://security.snyk.io/vuln/SNYK-JAVA-IONETTY-3167776
+      -->
+      <groupId>io.netty</groupId>
+      <artifactId>netty-codec-haproxy</artifactId>
+      <version>4.1.86.Final</version>
     </dependency>
     <dependency>
       <groupId>org.yaml</groupId>

--- a/testrail-integration/pom.xml
+++ b/testrail-integration/pom.xml
@@ -16,7 +16,7 @@
       <dependency>
         <groupId>io.vertx</groupId>
         <artifactId>vertx-stack-depchain</artifactId>
-        <version>4.3.4</version>
+        <version>4.3.7</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Upgrade Vert.x from 4.3.4 to 4.3.7.

Upgrade Karate-Junit5 from 1.2.0 to 1.3.1.

The Vert.x and the Karate upgrades indirectly upgrade Netty from 4.1.70.Final to 4.1.86.Final fixing

* Denial of Service (DoS) https://app.snyk.io/vuln/SNYK-JAVA-IONETTY-3167776
* HTTP Response Splitting https://app.snyk.io/vuln/SNYK-JAVA-IONETTY-3167773
* HTTP Request Smuggling https://app.snyk.io/vuln/SNYK-JAVA-IONETTY-2314893
* Information Exposure https://app.snyk.io/vuln/SNYK-JAVA-IONETTY-2812456