### PR TITLE
FAT-3700 - Karate test fail: [spitfire/mod-kb-ebsco-java] KbEbscoApiTests_exportTest {26} spitfire/mod-kb-ebsco-java/features/export-for-e-holdings.feature

### DIFF
--- a/mod-kb-ebsco-java/src/main/resources/spitfire/mod-kb-ebsco-java/features/export-for-e-holdings.feature
+++ b/mod-kb-ebsco-java/src/main/resources/spitfire/mod-kb-ebsco-java/features/export-for-e-holdings.feature
@@ -24,9 +24,8 @@ Feature: Packages
     And match $.startTime == '#present'
     And match $.endTime == '#present'
     And assert response.files.length == 1
-    And def fileLink = $.files[0]
 
-    Given url fileLink
+    Given path 'data-export-spring/jobs/' + jobId + '/download'
     When method GET
     Then status 200
     And def dateAndTimeRegex = '\\b(\\d{4}-\\d{2}-\\d{2} \\d{2}:\\d{2}:\\d{2}.\\d{3}\\w)'


### PR DESCRIPTION
## Purpose
_5 of 8 scenarios have failed for 'Packages' feature._

## Approach
_Used proper API to download csv file_

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
https://issues.folio.org/browse/FAT-3700
