### PR TITLE
[MODFISTO-318]. Fixing karate tests after transactional outbox implementation

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/order-event.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/order-event.feature
@@ -16,6 +16,9 @@ Feature: mod audit order events
     * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
     * callonce createOrder { id: #(orderId) }
 
+    # we need pause because transactional outbox implementation fetches events each 2 seconds to send them to kafka
+    * call pause 2000
+
   Scenario: Check event saved in audit
     Given path 'audit-data/acquisition/order/', orderId
     When method GET
@@ -35,6 +38,9 @@ Feature: mod audit order events
     And request orderResponse
     When method PUT
     Then status 204
+
+    # we need pause because transactional outbox implementation fetches events each 2 seconds to send them to kafka
+    * call pause 2000
 
   Scenario: Check 2 events saved in audit
     Given path 'audit-data/acquisition/order/' + orderId

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/order-line-event.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/order-line-event.feature
@@ -21,6 +21,9 @@ Feature: mod audit order_line events
     * callonce createOrder { id: #(orderId) }
     * callonce createOrderLine { id: #(poLineId1), orderId: #(orderId), fundId: #(fundId) }
 
+    # we need pause because transactional outbox implementation fetches events each 2 seconds to send them to kafka
+    * call pause 2000
+
   Scenario: Check event saved in audit
     Given path 'audit-data/acquisition/order-line/', poLineId1
     When method GET
@@ -40,6 +43,9 @@ Feature: mod audit order_line events
     And request orderLineResponse
     When method PUT
     Then status 204
+
+    # we need pause because transactional outbox implementation fetches events each 2 seconds to send them to kafka
+    * call pause 2000
 
     Scenario: Check 2 events saved in audit
     Given path 'audit-data/acquisition/order-line/', poLineId1


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODORDSTOR-323

## Approach
After implementation of transactional outbox pattern logic to fetch outbox events from DB and send them to Kafka invoked each 2 sec. So we need to update karate tests accordingly

![image](https://user-images.githubusercontent.com/25097693/209951045-89012fd0-830d-4374-8cd0-91fa158d2db5.png)

![image](https://user-images.githubusercontent.com/25097693/209951069-0578a6e5-85f8-44f6-809e-57249b69431d.png)

