### PR TITLE
[MODFIN-264] Budget and fund optimistic locking and rollback

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-and-fund-optimistic-locking.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-and-fund-optimistic-locking.feature
@@ -1,0 +1,150 @@
+# For https://issues.folio.org/browse/MODFIN-264
+@parallel=false
+Feature: Budget and fund optimistic locking
+
+  Background:
+    * print karate.info.scenarioName
+
+    * url baseUrl
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
+    * configure headers = headersUser
+
+    * callonce variables
+
+    * def fundId = callonce uuid1
+    * def budgetId = callonce uuid2
+    * def groupId1 = callonce uuid3
+    * def groupId2 = callonce uuid4
+
+
+  Scenario: Create fund and budget
+    * call createFund { 'id': '#(fundId)' }
+    * call createBudget { 'id': '#(budgetId)', 'allocated': 100, 'fundId': '#(fundId)', 'status': 'Active' }
+
+
+  Scenario Outline: Create groups
+    * def groupId = <groupId>
+    Given path '/finance/groups'
+    And request
+    """
+    {
+      "id": "#(groupId)",
+      "code": "#(groupId)",
+      "name": "#(groupId)",
+      "status": "Active"
+    }
+    """
+    When method POST
+    Then status 201
+
+    Examples:
+      | groupId  |
+      | groupId1 |
+      | groupId2 |
+
+
+  Scenario: Optimistic locking test for budget expense classes
+    Given path '/finance/budgets', budgetId
+    When method GET
+    Then status 200
+    * def initialBudget = $
+
+    * copy budget1 = initialBudget
+    * set budget1.statusExpenseClasses = [ { 'expenseClassId': '#(globalElecExpenseClassId)' } ]
+
+    * copy budget2 = initialBudget
+    * set budget2.statusExpenseClasses = [ { 'expenseClassId': '#(globalPrnExpenseClassId)' } ]
+
+    Given path '/finance/budgets', budgetId
+    And request budget1
+    When method PUT
+    Then status 204
+
+    Given path '/finance/budgets', budgetId
+    And request budget2
+    When method PUT
+    Then status 409
+
+    Given path '/finance/budgets', budgetId
+    When method GET
+    Then status 200
+    And match $.statusExpenseClasses == '#[1]'
+    And match $.statusExpenseClasses[0].expenseClassId == '#(globalElecExpenseClassId)'
+
+
+  Scenario: Optimistic locking test for fund groups
+    Given path '/finance/funds', fundId
+    When method GET
+    Then status 200
+    * def initialCompositeFund = $
+
+    * copy compositeFund1 = initialCompositeFund
+    * set compositeFund1.groupIds = ['#(groupId1)']
+
+    * copy compositeFund2 = initialCompositeFund
+    * set compositeFund2.groupIds = ['#(groupId2)']
+
+    Given path '/finance/funds', fundId
+    And request compositeFund1
+    When method PUT
+    Then status 204
+
+    Given path '/finance/funds', fundId
+    And request compositeFund2
+    When method PUT
+    Then status 409
+
+    Given path '/finance/funds', fundId
+    When method GET
+    Then status 200
+    And match $.groupIds == '#[1]'
+    And match $.groupIds[0] == '#(groupId1)'
+
+
+  Scenario: Test rollback with a budget update using a bad expense class id
+    Given path '/finance/budgets', budgetId
+    When method GET
+    Then status 200
+    * def initialBudget = $
+
+    * copy budget = initialBudget
+    * set budget.name = 'other name'
+    * set budget.statusExpenseClasses = [ { 'expenseClassId': '00000000-0000-1000-8000-000000000000' } ]
+
+    Given path '/finance/budgets', budgetId
+    And request budget
+    When method PUT
+    Then status 400
+
+    Given path '/finance/budgets', budgetId
+    When method GET
+    Then status 200
+    And match $.name == initialBudget.name
+    And match $.statusExpenseClasses == initialBudget.statusExpenseClasses
+    And assert response._version > initialBudget._version
+
+
+  Scenario: Test rollback with a fund update using a bad group id
+    Given path '/finance/funds', fundId
+    When method GET
+    Then status 200
+    * def initialCompositeFund = $
+
+    * copy compositeFund = initialCompositeFund
+    * set compositeFund.fund.code = 'other_code'
+    * set compositeFund.groupIds = ['00000000-0000-1000-8000-000000000000']
+
+    Given path '/finance/funds', fundId
+    And request compositeFund
+    When method PUT
+    Then status 422
+
+    Given path '/finance/funds', fundId
+    When method GET
+    Then status 200
+    And match $.fund.code == initialCompositeFund.fund.code
+    And match $.groupIds == initialCompositeFund.groupIds
+    And assert response.fund._version > initialCompositeFund.fund._version

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/finance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/finance.feature
@@ -124,5 +124,8 @@ Feature: mod-finance integration tests
   Scenario: Test multiple ledger fiscal year rollovers with different parameters
     Given call read('features/ledger-fiscal-year-rollovers-multiple.feature')
 
+  Scenario: Budget and fund optimistic locking
+    Given call read('features/budget-and-fund-optimistic-locking.feature')
+
   Scenario: wipe data
     Given call read('classpath:common/destroy-data.feature')

--- a/acquisitions/src/test/java/org/folio/FinanceApiTest.java
+++ b/acquisitions/src/test/java/org/folio/FinanceApiTest.java
@@ -172,6 +172,11 @@ public class FinanceApiTest extends TestBase {
     runFeatureTest("ledger-fiscal-year-preview-rollover-need-close-budgets");
   }
 
+  @Test
+  void budgetAndFundOptimisticLocking() {
+    runFeatureTest("budget-and-fund-optimistic-locking");
+  }
+
   @BeforeAll
   public void financeApiTestBeforeAll() {
     runFeature("classpath:thunderjet/mod-finance/finance-junit.feature");


### PR DESCRIPTION
## Purpose
[MODFIN-264](https://issues.folio.org/browse/MODFIN-264) - Optimistic locking ignored when changing expense class and adding group

## Approach
Added a new test for optimistic locking and rollbacks for budget and fund updates.
