### PR TITLE
FAT-4401 add retry when adding permission to test user

### DIFF
--- a/common/src/main/resources/common/setup-users.feature
+++ b/common/src/main/resources/common/setup-users.feature
@@ -111,6 +111,7 @@ Feature: prepare data for api test
       "permissions": #(permissions)
     }
     """
+    And retry until responseStatus == 201
     When method POST
     Then status 201
 


### PR DESCRIPTION
## Purpose
Resolves FAT-4401

## Approach
Daily integration tests runs fail consistently when adding permissions to test users. This is on test setup and not related to the actual functionality being tested. Integration tests run normally on local environments but fail consistently in CI. The hypothesis is that when a new tenant is created for a test, appropriate permissions are not posted to the tenant by okapi , but the test suite is asking to add permissions that don't exist yet. The hope is that the permissions arrive before the retry policy expires. Other avenues will be explored if this is not successful.

