### PR TITLE
[MODFISTO-371] - Add support to rollover cash balance during FY rollover

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/partial-rollover.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/partial-rollover.feature
@@ -82,7 +82,7 @@ Feature: Partial rollover
           {
             "rolloverAllocation": false,
             "adjustAllocation": 0,
-            "rolloverAvailable": false,
+            "rolloverBudgetValue": "None",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/rollover-with-closed-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/rollover-with-closed-order.feature
@@ -78,7 +78,7 @@ Feature: Rollover with closed order
           {
             "rolloverAllocation": false,
             "adjustAllocation": 0,
-            "rolloverAvailable": false,
+            "rolloverBudgetValue": "None",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/group-and-ledger-transfers-after-rollover.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/group-and-ledger-transfers-after-rollover.feature
@@ -165,7 +165,7 @@ Feature: Group and ledger transfers after rollover
         "budgetsRollover": [
           {
             "rolloverAllocation": false,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "setAllowances": false,
             "adjustAllocation": 0,
             "addAvailableTo": "Available",

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-preview-rollover.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-preview-rollover.feature
@@ -819,7 +819,7 @@ Feature: Ledger fiscal year rollover
           {
             "rolloverAllocation": false,
             "adjustAllocation": 0,
-            "rolloverAvailable": false,
+            "rolloverBudgetValue": "None",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -828,7 +828,7 @@ Feature: Ledger fiscal year rollover
             "fundTypeId": "#(books)",
             "rolloverAllocation": true,
             "adjustAllocation": 10,
-            "rolloverAvailable": false,
+            "rolloverBudgetValue": "None",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -837,7 +837,7 @@ Feature: Ledger fiscal year rollover
             "fundTypeId": "#(serials)",
             "rolloverAllocation": true,
             "adjustAllocation": 0,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "addAvailableTo": "Available",
             "setAllowances": true,
             "allowableEncumbrance": 110,
@@ -847,7 +847,7 @@ Feature: Ledger fiscal year rollover
             "fundTypeId": "#(gifts)",
             "rolloverAllocation": true,
             "adjustAllocation": 0,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "addAvailableTo": "Allocation",
             "setAllowances": true
           },
@@ -855,7 +855,7 @@ Feature: Ledger fiscal year rollover
             "fundTypeId": "#(rollHist)",
             "rolloverAllocation": true,
             "adjustAllocation": 0,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "addAvailableTo": "Allocation",
             "setAllowances": false,
             "allowableEncumbrance": 110,
@@ -865,7 +865,7 @@ Feature: Ledger fiscal year rollover
             "fundTypeId": "#(monographs)",
             "rolloverAllocation": true,
             "adjustAllocation": 15,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "addAvailableTo": "Available",
             "setAllowances": false,
             "allowableEncumbrance": 110 ,

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover-MODFISTO-247.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover-MODFISTO-247.feature
@@ -301,7 +301,7 @@ Feature: Ledger fiscal year rollover issue MODFISTO-247
           {
             "rolloverAllocation": true,
             "adjustAllocation": 0,
-            "rolloverAvailable": false,
+            "rolloverBudgetValue": "None",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -367,7 +367,7 @@ Feature: Ledger fiscal year rollover issue MODFISTO-247
           {
             "rolloverAllocation": true,
             "adjustAllocation": 0,
-            "rolloverAvailable": false,
+            "rolloverBudgetValue": "None",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover-cash-balance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover-cash-balance.feature
@@ -1,5 +1,5 @@
 @parallel=false
-# for https://issues.folio.org/browse/MODORDERS-834
+# for https://issues.folio.org/browse/MODFISTO-371
 Feature: Test ledger fiscal year rollover based on cash balance value
 
   Background:

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover-cash-balance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover-cash-balance.feature
@@ -1,0 +1,339 @@
+@parallel=false
+# for https://issues.folio.org/browse/MODORDERS-834
+Feature: Test ledger fiscal year rollover based on cash balance value
+
+  Background:
+    * print karate.info.scenarioName
+
+    * url baseUrl
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json' }
+
+    * configure headers = headersUser
+
+    * callonce variables
+
+    * def orderLineTemplate = read('classpath:samples/mod-orders/orderLines/minimal-order-line.json')
+    * def invoiceTemplate = read('classpath:samples/mod-invoice/invoices/global/invoice.json')
+    * def invoiceLineTemplate = read('classpath:samples/mod-invoice/invoices/global/invoice-line-percentage.json')
+
+    * def fundId = callonce uuid1
+    * def budgetId = callonce uuid2
+    * def orderId = callonce uuid3
+    * def poLineId1 = callonce uuid4
+    * def poLineId2 = callonce uuid5
+    * def invoiceId = callonce uuid6
+    * def invoiceLineId = callonce uuid7
+    * def fromYear = callonce getCurrentYear
+    * def toYear = parseInt(fromYear) + 1
+    * def fyId1 = callonce uuid8
+    * def fyId2 = callonce uuid9
+    * def ledgerId = callonce uuid10
+    * def previewFirstFlowId = callonce uuid11
+    * def previewSecondFlowId = callonce uuid12
+    * def previewThirdFlowId = callonce uuid13
+    * def previewFourthFlowId = callonce uuid14
+    * def commonRolloverId = callonce uuid15
+
+
+  Scenario: Create fiscal years and associated ledger
+    * def periodStart1 = fromYear + '-01-01T00:00:00Z'
+    * def periodEnd1 = fromYear + '-12-30T23:59:59Z'
+    * def v = call createFiscalYear { id: #(fyId1), code: 'TESTFY0001', periodStart: #(periodStart1), periodEnd: #(periodEnd1), series: 'TESTFY' }
+    * def periodStart2 = toYear + '-01-01T00:00:00Z'
+    * def periodEnd2 = toYear + '-12-30T23:59:59Z'
+    * def v = call createFiscalYear { id: #(fyId2), code: 'TESTFY0002', periodStart: #(periodStart2), periodEnd: #(periodEnd2), series: 'TESTFY' }
+    * call createLedger { 'id': '#(ledgerId)', fiscalYearId: '#(fyId1)'}
+
+
+  Scenario: Prepare finances
+    * def fundCode = fundId
+    * configure headers = headersAdmin
+    * call createFund { id: '#(fundId)', code: '#(fundCode)', ledgerId: '#(ledgerId)' }
+    * call createBudget { id: '#(budgetId)', fundId: '#(fundId)', fiscalYearId: '#(fyId1)', allocated: 100 }
+
+
+  Scenario: Create an order
+    * configure headers = headersAdmin
+    Given path 'orders/composite-orders'
+    And request
+    """
+    {
+      id: '#(orderId)',
+      vendor: '#(globalVendorId)',
+      orderType: 'One-Time',
+      reEncumber: 'False'
+    }
+    """
+    When method POST
+    Then status 201
+
+  Scenario Outline: Create a po lines
+    * configure headers = headersAdmin
+    * copy poLine = orderLineTemplate
+    * set poLine.id = <poLineId>
+    * set poLine.purchaseOrderId = orderId
+    * set poLine.fundDistribution[0].fundId = fundId
+    * set poLine.fundDistribution[0].code = fundId
+    * set poLine.paymentStatus = 'Awaiting Payment'
+    * set poLine.receiptStatus = 'Partially Received'
+    * set poLine.cost.listUnitPrice = <unitPrice>
+    * set poLine.cost.poLineEstimatedPrice = <unitPrice>
+
+    Given path 'orders/order-lines'
+    And request poLine
+    When method POST
+    Then status 201
+
+    Examples:
+      | unitPrice   | poLineId    |
+      | 40.0        | poLineId1   |
+      | 10.0        | poLineId2   |
+
+  Scenario: Open the order
+    * configure headers = headersAdmin
+    Given path 'orders/composite-orders', orderId
+    When method GET
+    Then status 200
+
+    * def order = $
+    * set order.workflowStatus = 'Open'
+
+    Given path 'orders/composite-orders', orderId
+    And request order
+    When method PUT
+    Then status 204
+
+  Scenario: Create an invoice
+    * configure headers = headersAdmin
+    * copy invoice = invoiceTemplate
+    * set invoice.id = invoiceId
+    Given path 'invoice/invoices'
+    And request invoice
+    When method POST
+    Then status 201
+
+  Scenario: Create a invoice line
+    * configure headers = headersAdmin
+    * print "Get the encumbrance id"
+    Given path 'orders/order-lines', poLineId1
+    When method GET
+    Then status 200
+    * def poLine = $
+    * def encumbranceId = poLine.fundDistribution[0].encumbrance
+
+    * print "Add an invoice line linked to the po line"
+    * copy invoiceLine = invoiceLineTemplate
+    * set invoiceLine.id = invoiceLineId
+    * set invoiceLine.invoiceId = invoiceId
+    * set invoiceLine.poLineId = poLineId1
+    * set invoiceLine.fundDistributions[0].fundId = fundId
+    * set invoiceLine.fundDistributions[0].encumbrance = encumbranceId
+    * set invoiceLine.total = 40
+    * set invoiceLine.subTotal = 40
+    * remove invoiceLine.fundDistributions[0].expenseClassId
+    Given path 'invoice/invoice-lines'
+    And request invoiceLine
+    When method POST
+    Then status 201
+
+  Scenario: Approve the invoice
+    * configure headers = headersAdmin
+    Given path 'invoice/invoices', invoiceId
+    When method GET
+    Then status 200
+    * def invoice = $
+    * set invoice.status = 'Approved'
+    Given path 'invoice/invoices', invoiceId
+    And request invoice
+    When method PUT
+    Then status 204
+
+  Scenario: Pay the invoice
+    * configure headers = headersAdmin
+    Given path 'invoice/invoices', invoiceId
+    When method GET
+    Then status 200
+    * def invoice = $
+    * set invoice.status = 'Paid'
+    Given path 'invoice/invoices', invoiceId
+    And request invoice
+    When method PUT
+    Then status 204
+
+  Scenario: Check the budget before preview rollover
+    Given path 'finance/budgets', budgetId
+    When method GET
+    Then status 200
+
+    And match $.available == 50
+    And match $.encumbered == 10
+    And match $.allocated == 100
+    And match $.cashBalance == 60
+    And match $.netTransfers == 0
+    And match $.allocationTo == 0
+    And match $.expenditures == 40
+    And match $.totalFunding == 100
+    And match $.allocationFrom == 0
+    And match $.awaitingPayment == 0
+    And match $.initialAllocation == 100
+
+  Scenario Outline: Start preview rollover based on CashBalance
+
+    * def rolloverId = <id>
+    * def addAvailableTo = <addAvailableTo>
+    * def rolloverAllocation = <rolloverAllocation>
+
+    Given path 'finance/ledger-rollovers'
+    And request
+    """
+      {
+        "id": "#(rolloverId)",
+        "ledgerId": "#(ledgerId)",
+        "fromFiscalYearId": "#(fyId1)",
+        "toFiscalYearId": "#(fyId2)",
+        "rolloverType": "Preview",
+        "restrictEncumbrance": true,
+        "restrictExpenditures": true,
+        "needCloseBudgets": true,
+        "budgetsRollover": [
+          {
+            "rolloverAllocation": #(rolloverAllocation),
+            "addAvailableTo": "#(addAvailableTo)",
+            "rolloverBudgetValue": "CashBalance"
+          }
+        ],
+        "encumbrancesRollover": []
+      }
+    """
+    When method POST
+    Then status 201
+
+    * configure retry = { count: 10, interval: 500 }
+    Given path 'finance/ledger-rollovers-progress'
+    And param query = 'ledgerRolloverId==' + rolloverId
+    And retry until response.ledgerFiscalYearRolloverProgresses[0].overallRolloverStatus != 'In Progress'
+    When method GET
+    Then status 200
+
+    Examples:
+      | id                   | addAvailableTo | rolloverAllocation |
+      | previewFirstFlowId   | 'Allocation'   | true               |
+      | previewSecondFlowId  | 'Available'    | true               |
+      | previewThirdFlowId   | 'Allocation'   | false              |
+      | previewFourthFlowId  | 'Available'    | false              |
+
+
+  Scenario Outline: Check new budgets after preview rollover based on CashBalance
+    Given path 'finance/ledger-rollovers-budgets'
+    And param query = 'fundId==' + fundId + ' AND ledgerRolloverId==' + <id>
+    And retry until response.totalRecords > 0
+    When method GET
+    Then status 200
+    * def budget_id = $.ledgerFiscalYearRolloverBudgets[0].id
+
+    Given path 'finance/ledger-rollovers-budgets', budget_id
+    When method GET
+    Then status 200
+
+    And match response.available == <available>
+    And match response.allocated == <allocated>
+    And match response.cashBalance == <cashBalance>
+    And match response.netTransfers == <netTransfers>
+    And match response.totalFunding == <totalFunding>
+    And match response.allocationTo == <allocationTo>
+    And match response.allocationFrom == <allocationFrom>
+    And match response.initialAllocation == <initialAllocation>
+
+    Examples:
+      | id                   | initialAllocation | allocationTo | allocationFrom | allocated | netTransfers | totalFunding | cashBalance | available |
+      | previewFirstFlowId   | 160               | 0            | 0              | 160       | 0            | 160          | 160         | 160       |
+      | previewSecondFlowId  | 100               | 0            | 0              | 100       | 60           | 160          | 160         | 160       |
+      | previewThirdFlowId   | 60                | 0            | 0              | 60        | 0            | 60           | 60          | 60        |
+      | previewFourthFlowId  | 0                 | 0            | 0              | 0         | 60           | 60           | 60          | 60        |
+
+
+  Scenario: Start rollover
+    Given path 'finance/ledger-rollovers'
+    And request
+    """
+      {
+        "id": "#(commonRolloverId)",
+        "ledgerId": "#(ledgerId)",
+        "fromFiscalYearId": "#(fyId1)",
+        "toFiscalYearId": "#(fyId2)",
+        "restrictEncumbrance": true,
+        "restrictExpenditures": true,
+        "needCloseBudgets": true,
+        "budgetsRollover": [
+          {
+            "rolloverAllocation": true,
+            "addAvailableTo": "Allocation",
+            "rolloverBudgetValue": "CashBalance"
+          }
+        ],
+        "encumbrancesRollover": [
+          {
+            "orderType": "One-time",
+            "basedOn": "Expended",
+            "increaseBy": 0
+          }
+        ]
+      }
+    """
+    When method POST
+    Then status 201
+
+
+  Scenario: Wait for rollover to end
+    * configure retry = { count: 10, interval: 500 }
+    Given path 'finance/ledger-rollovers-progress'
+    And param query = 'ledgerRolloverId==' + commonRolloverId
+    And retry until response.ledgerFiscalYearRolloverProgresses[0].overallRolloverStatus != 'In Progress'
+    When method GET
+    Then status 200
+
+
+  Scenario: Check rollover statuses
+    Given path 'finance/ledger-rollovers-progress'
+    And param query = 'ledgerRolloverId==' + commonRolloverId
+    When method GET
+    Then status 200
+    And match response.ledgerFiscalYearRolloverProgresses[0].budgetsClosingRolloverStatus == 'Success'
+    And match response.ledgerFiscalYearRolloverProgresses[0].ordersRolloverStatus == 'Success'
+    And match response.ledgerFiscalYearRolloverProgresses[0].financialRolloverStatus == 'Success'
+    And match response.ledgerFiscalYearRolloverProgresses[0].overallRolloverStatus == 'Success'
+
+
+  Scenario: Check rollover errors
+    Given path 'finance/ledger-rollovers-errors'
+    And param query = 'ledgerRolloverId==' + commonRolloverId
+    When method GET
+    Then status 200
+    And match $.totalRecords == 0
+
+
+  Scenario: Check the new budgets after common rollover
+    Given path 'finance/budgets'
+    And param query = 'fiscalYearId==' + fyId2 + ' AND fundId==' + fundId
+    When method GET
+    Then status 200
+    * def budget_id = $.budgets[0].id
+
+    Given path 'finance/budgets', budget_id
+    When method GET
+    Then status 200
+
+    And match response.available == 160
+    And match response.allocated == 160
+    And match response.cashBalance == 160
+    And match response.netTransfers == 0
+    And match response.totalFunding == 160
+    And match response.allocationTo == 0
+    And match response.allocationFrom == 0
+    And match response.initialAllocation == 160

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover-pol-and-system-currencies-are-different.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover-pol-and-system-currencies-are-different.feature
@@ -825,7 +825,7 @@ Feature: Ledger fiscal year rollover pol and system currencies are different
           {
             "rolloverAllocation": false,
             "adjustAllocation": 0,
-            "rolloverAvailable": false,
+            "rolloverBudgetValue": "None",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -834,7 +834,7 @@ Feature: Ledger fiscal year rollover pol and system currencies are different
             "fundTypeId": "#(books)",
             "rolloverAllocation": true,
             "adjustAllocation": 10,
-            "rolloverAvailable": false,
+            "rolloverBudgetValue": "None",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -843,7 +843,7 @@ Feature: Ledger fiscal year rollover pol and system currencies are different
             "fundTypeId": "#(serials)",
             "rolloverAllocation": true,
             "adjustAllocation": 0,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "addAvailableTo": "Available",
             "setAllowances": true,
             "allowableEncumbrance": 110,
@@ -853,7 +853,7 @@ Feature: Ledger fiscal year rollover pol and system currencies are different
             "fundTypeId": "#(gifts)",
             "rolloverAllocation": true,
             "adjustAllocation": 0,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "addAvailableTo": "Allocation",
             "setAllowances": true
           },
@@ -861,7 +861,7 @@ Feature: Ledger fiscal year rollover pol and system currencies are different
             "fundTypeId": "#(rollHist)",
             "rolloverAllocation": true,
             "adjustAllocation": 0,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "addAvailableTo": "Allocation",
             "setAllowances": false,
             "allowableEncumbrance": 110,
@@ -871,7 +871,7 @@ Feature: Ledger fiscal year rollover pol and system currencies are different
             "fundTypeId": "#(monographs)",
             "rolloverAllocation": true,
             "adjustAllocation": 15,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "addAvailableTo": "Available",
             "setAllowances": false,
             "allowableEncumbrance": 110 ,
@@ -899,6 +899,15 @@ Feature: Ledger fiscal year rollover pol and system currencies are different
     """
     When method POST
     Then status 201
+
+  Scenario: Wait for rollover to end
+    * configure retry = { count: 10, interval: 1000 }
+    Given path 'finance/ledger-rollovers-progress'
+    And param query = 'ledgerRolloverId==' + rolloverId
+    And retry until response.ledgerFiscalYearRolloverProgresses[0].overallRolloverStatus != 'In Progress'
+    When method GET
+    Then status 200
+
 
   Scenario Outline: Check that budget <id> status is <status> after rollover
     * configure headers = headersAdmin

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover.feature
@@ -832,7 +832,7 @@ Feature: Ledger fiscal year rollover
           {
             "rolloverAllocation": false,
             "adjustAllocation": 0,
-            "rolloverAvailable": false,
+            "rolloverBudgetValue": "None",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -841,7 +841,7 @@ Feature: Ledger fiscal year rollover
             "fundTypeId": "#(books)",
             "rolloverAllocation": true,
             "adjustAllocation": 10,
-            "rolloverAvailable": false,
+            "rolloverBudgetValue": "None",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -850,7 +850,7 @@ Feature: Ledger fiscal year rollover
             "fundTypeId": "#(serials)",
             "rolloverAllocation": true,
             "adjustAllocation": 0,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "addAvailableTo": "Available",
             "setAllowances": true,
             "allowableEncumbrance": 110,
@@ -860,7 +860,7 @@ Feature: Ledger fiscal year rollover
             "fundTypeId": "#(gifts)",
             "rolloverAllocation": true,
             "adjustAllocation": 0,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "addAvailableTo": "Allocation",
             "setAllowances": true
           },
@@ -868,7 +868,7 @@ Feature: Ledger fiscal year rollover
             "fundTypeId": "#(rollHist)",
             "rolloverAllocation": true,
             "adjustAllocation": 0,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "addAvailableTo": "Allocation",
             "setAllowances": false,
             "allowableEncumbrance": 110,
@@ -878,7 +878,7 @@ Feature: Ledger fiscal year rollover
             "fundTypeId": "#(monographs)",
             "rolloverAllocation": true,
             "adjustAllocation": 15,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "addAvailableTo": "Available",
             "setAllowances": false,
             "allowableEncumbrance": 110 ,
@@ -906,6 +906,16 @@ Feature: Ledger fiscal year rollover
     """
     When method POST
     Then status 201
+
+
+  Scenario: Wait for rollover to end
+    * configure retry = { count: 10, interval: 500 }
+    Given path 'finance/ledger-rollovers-progress'
+    And param query = 'ledgerRolloverId==' + rolloverId
+    And retry until response.ledgerFiscalYearRolloverProgresses[0].overallRolloverStatus != 'In Progress'
+    When method GET
+    Then status 200
+
 
   Scenario Outline: Check that budget <id> status is <status> after rollover
     * configure headers = headersAdmin

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollovers-multiple.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollovers-multiple.feature
@@ -661,7 +661,7 @@ Feature: Ledger fiscal year rollover issues MODFISTO-309 and MODFISTO-311
           {
             "rolloverAllocation": false,
             "adjustAllocation": 0,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -670,7 +670,7 @@ Feature: Ledger fiscal year rollover issues MODFISTO-309 and MODFISTO-311
             "fundTypeId": "#(books)",
             "rolloverAllocation": false,
             "adjustAllocation": 10,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -716,7 +716,7 @@ Feature: Ledger fiscal year rollover issues MODFISTO-309 and MODFISTO-311
           {
             "rolloverAllocation": false,
             "adjustAllocation": 0,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -725,7 +725,7 @@ Feature: Ledger fiscal year rollover issues MODFISTO-309 and MODFISTO-311
             "fundTypeId": "#(books)",
             "rolloverAllocation": false,
             "adjustAllocation": 10,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -771,7 +771,7 @@ Feature: Ledger fiscal year rollover issues MODFISTO-309 and MODFISTO-311
           {
             "rolloverAllocation": false,
             "adjustAllocation": 0,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "setAllowances": true,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -780,7 +780,7 @@ Feature: Ledger fiscal year rollover issues MODFISTO-309 and MODFISTO-311
             "fundTypeId": "#(books)",
             "rolloverAllocation": false,
             "adjustAllocation": 10,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "setAllowances": true,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -826,7 +826,7 @@ Feature: Ledger fiscal year rollover issues MODFISTO-309 and MODFISTO-311
           {
             "rolloverAllocation": false,
             "adjustAllocation": 0,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -835,7 +835,7 @@ Feature: Ledger fiscal year rollover issues MODFISTO-309 and MODFISTO-311
             "fundTypeId": "#(books)",
             "rolloverAllocation": true,
             "adjustAllocation": 10,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/unopen-order-after-rollover-MODORDERS-542.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/unopen-order-after-rollover-MODORDERS-542.feature
@@ -297,7 +297,7 @@ Feature: Ledger fiscal year rollover issue MODORDERS-542
           {
             "rolloverAllocation": true,
             "adjustAllocation": 0,
-            "rolloverAvailable": false,
+            "rolloverBudgetValue": "None",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -324,7 +324,15 @@ Feature: Ledger fiscal year rollover issue MODORDERS-542
     """
     When method POST
     Then status 201
-    * call pause 1000
+
+
+  Scenario: Wait for rollover to end
+    * configure retry = { count: 10, interval: 500 }
+    Given path 'finance/ledger-rollovers-progress'
+    And param query = 'ledgerRolloverId==' + rolloverId
+    And retry until response.ledgerFiscalYearRolloverProgresses[0].overallRolloverStatus != 'In Progress'
+    When method GET
+    Then status 200
 
 
   Scenario: Delete rollover with Success status

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/finance-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/finance-junit.feature
@@ -7,6 +7,8 @@ Feature: mod-finance integration tests
       | 'mod-inventory-storage' |
       | 'mod-orders-storage'    |
       | 'mod-orders'            |
+      | 'mod-invoice'           |
+      | 'mod-invoice-storage'   |
       | 'mod-finance-storage'   |
       | 'mod-finance'           |
       | 'mod-login'             |

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/finance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/finance.feature
@@ -7,6 +7,8 @@ Feature: mod-finance integration tests
       | 'mod-inventory-storage' |
       | 'mod-orders-storage'    |
       | 'mod-orders'            |
+      | 'mod-invoice'           |
+      | 'mod-invoice-storage'   |
       | 'mod-finance-storage'   |
       | 'mod-finance'           |
       | 'mod-login'             |
@@ -94,6 +96,9 @@ Feature: mod-finance integration tests
 
   Scenario: Test ledger preview rollover
     Given call read('features/ledger-fiscal-year-preview-rollover.feature')
+
+  Scenario: Test ledger fiscal year rollover based on cash balance value
+    Given call read('features/ledger-fiscal-year-rollover-cash-balance.feature')
 
   Scenario: Test ledger rollover pol and system currencies are different
     Given call read('features/ledger-fiscal-year-rollover-pol-and-system-currencies-are-different.feature')

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/moving_expended_value_to_newly_created_encumbrance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/moving_expended_value_to_newly_created_encumbrance.feature
@@ -252,7 +252,7 @@ Feature: Moving expended amount when editing fund distribution for POL
           {
             "rolloverAllocation": true,
             "adjustAllocation": 0,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -318,7 +318,7 @@ Feature: Moving expended amount when editing fund distribution for POL
           {
             "rolloverAllocation": true,
             "adjustAllocation": 0,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -384,7 +384,7 @@ Feature: Moving expended amount when editing fund distribution for POL
           {
             "rolloverAllocation": true,
             "adjustAllocation": 0,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
@@ -449,7 +449,7 @@ Feature: Moving expended amount when editing fund distribution for POL
           {
             "rolloverAllocation": true,
             "adjustAllocation": 0,
-            "rolloverAvailable": true,
+            "rolloverBudgetValue": "Available",
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100

--- a/acquisitions/src/test/java/org/folio/FinanceApiTest.java
+++ b/acquisitions/src/test/java/org/folio/FinanceApiTest.java
@@ -182,6 +182,11 @@ public class FinanceApiTest extends TestBase {
     runFeatureTest("group-and-ledger-transfers-after-rollover");
   }
 
+  @Test
+  void ledgerFiscalYearRolloverCashBalance() {
+    runFeatureTest("ledger-fiscal-year-rollover-cash-balance");
+  }
+
   @BeforeAll
   public void financeApiTestBeforeAll() {
     runFeature("classpath:thunderjet/mod-finance/finance-junit.feature");


### PR DESCRIPTION
## Purpose
To test rollover following by [miro diagram](https://miro.com/app/board/uXjVOkZO8Qk=/) (Cash balance section)
![image](https://user-images.githubusercontent.com/89521577/217545342-e9fb06a7-8587-4bbc-b5e7-1b0cfac2daee.png)

## Approach

- Implemented new test scenario
- Replace boolean field to rolloverBudgetValue enum
- Replaced pauses after rollover start scenario to retries

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
[MODFISTO-371](https://issues.folio.org/browse/MODFISTO-371)

