### PR TITLE
[MODFIN-308] Summary available can now be negative

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-totals.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-totals.feature
@@ -154,7 +154,7 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
   Examples:
       | ledgerId           | initialAllocation | allocated | encumbered | awaitingPayment | expenditures | unavailable | totalFunding | available | overEncumbrance | overExpended |
       | ledgerWithBudgets1 | 16601.91          | 16601.91  | 231.34     | 3108.23         | 742          | 4081.57     | 16601.91     | 12520.34  |0.0              | 0.0          |
-      | ledgerWithBudgets2 | 24500             | 24500     | 25000      | 0.0             | 0.0          | 25000       | 24500        | 0.0       |500.0            | 0.0          |
+      | ledgerWithBudgets2 | 24500             | 24500     | 25000      | 0.0             | 0.0          | 25000       | 24500        | -500.0       |500.0            | 0.0          |
 
 
   Scenario Outline: Create allocation from <fromFundId> to <toFundId>


### PR DESCRIPTION
## Purpose
[MODFIN-308](https://issues.folio.org/browse/MODFIN-308) - Maintain displaying "Available" as a negative number for group and ledger

## Approach
Updated test to check available amount in summary.
Did not add a check for group totals, as this is already done in unit tests, it is easy to check manually, and the change was minimal.
