### PR TITLE
FAT-4889: Changed response object list order

### DIFF
--- a/mod-search/src/test/resources/spitfire/mod-search/browse/contributor-browse.feature
+++ b/mod-search/src/test/resources/spitfire/mod-search/browse/contributor-browse.feature
@@ -483,17 +483,17 @@ Feature: Tests that browse by contributors
         "name": "Quiter",
         "contributorTypeId": ["null"],
         "contributorNameTypeId": "2e48e713-17e3-4c13-a9f8-23845bb210aa",
-        "authorityId": "3aba7f45-c6fd-4e49-90c9-9773edbaaa2c",
+        "authorityId": "3aaa7f45-c6fd-4e49-90c9-9773edbaaa2c",
         "isAnchor": false,
-        "totalRecords": 1
+        "totalRecords": 2
       },
       {
         "name": "Quiter",
         "contributorTypeId": ["null"],
         "contributorNameTypeId": "2e48e713-17e3-4c13-a9f8-23845bb210aa",
-        "authorityId": "3aaa7f45-c6fd-4e49-90c9-9773edbaaa2c",
+        "authorityId": "3aba7f45-c6fd-4e49-90c9-9773edbaaa2c",
         "isAnchor": false,
-        "totalRecords": 2
+        "totalRecords": 1
       },
       {
         "name": "Van Harmelen, Frank",


### PR DESCRIPTION
## Purpose
Fix current integration test failure

## Approach
Rectify object order in items list

### Learning
[https://issues.folio.org/browse/FAT-4889](https://issues.folio.org/browse/FAT-4889)
[current karate test results](https://jenkins-aws.indexdata.com/job/Testing/job/Scheduled%20Karate%20Tests/641/cucumber-html-reports/report-feature_797601987.html)
