### PR TITLE
[MODORDERS-865] - Rewrite the orders rollover interaction in an asynchronous way

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/moving_expended_value_to_newly_created_encumbrance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/moving_expended_value_to_newly_created_encumbrance.feature
@@ -271,6 +271,15 @@ Feature: Moving expended amount when editing fund distribution for POL
     Then status 201
 
 
+  Scenario: Wait for rollover to end
+    * configure retry = { count: 10, interval: 500 }
+    Given path 'finance/ledger-rollovers-progress'
+    And param query = 'ledgerRolloverId==' + previewExpendedRolloverId
+    And retry until response.ledgerFiscalYearRolloverProgresses[0].overallRolloverStatus != 'In Progress'
+    When method GET
+    Then status 200
+
+
   Scenario Outline: Check new budgets after preview rollover based on Expended
     * def fundId = <fundId>
 


### PR DESCRIPTION
## Purpose
Due to test failing after rewriting orders rollover processing in an async way

## Approach

- Added retry to wait for end of overall rollover

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
[MODORDERS-865](https://issues.folio.org/browse/MODORDERS-865)
