### PR TITLE
[MODORDERS-514] Close order including lines

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/close-order-including-lines.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/close-order-including-lines.feature
@@ -1,0 +1,78 @@
+@parallel=false
+Feature: Close order including lines
+
+  Background:
+    * print karate.info.scenarioName
+    * url baseUrl
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': '*/*' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*' }
+
+    * configure headers = headersUser
+
+    * callonce variables
+
+    * def fundId = callonce uuid1
+    * def budgetId = callonce uuid2
+    * def orderId = callonce uuid3
+    * def poLineId = callonce uuid4
+
+    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
+    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
+    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
+
+
+  Scenario: Prepare finances
+    * configure headers = headersAdmin
+    * def v = call createFund { id: #(fundId) }
+    * def v = call createBudget { id: #(budgetId), fundId: #(fundId), allocated: 100 }
+
+
+  Scenario: Create an order
+    * def v = call createOrder { id: #(orderId) }
+
+
+  Scenario: Create an order line
+    * def v = call createOrderLine { id: #(poLineId), orderId: #(orderId), fundId: #(fundId) }
+
+
+  Scenario: Open the order
+    * def v = call openOrder { orderId: #(orderId) }
+
+
+  Scenario: Close the order without removing the lines
+    Given path 'orders/composite-orders', orderId
+    When method GET
+    Then status 200
+
+    * def order = $
+    * set order.workflowStatus = 'Closed'
+
+    Given path 'orders/composite-orders', orderId
+    And request order
+    When method PUT
+    Then status 204
+
+
+  Scenario: Check the order was closed
+    Given path 'orders/composite-orders', orderId
+    When method GET
+    Then status 200
+    And match $.workflowStatus == 'Closed'
+
+
+  Scenario: Check the encumbrance after closing the order
+    Given path 'finance/transactions'
+    And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId
+    When method GET
+    Then status 200
+    And match $.totalRecords == 1
+    * def transaction = $.transactions[0]
+    And assert transaction.amount == 0.0
+    And assert transaction.encumbrance.initialAmountEncumbered == 1.0
+    And assert transaction.encumbrance.status == 'Released'

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
@@ -214,8 +214,11 @@ Feature: mod-orders integration tests
   Scenario: Receive 20 pieces
     Given call read("features/receive-20-pieces.feature")
 
-  Scenario: Encumbrance released when order closes
+  Scenario: Reopen order with 50 lines
     Given call read("features/reopen-order-with-50-lines.feature")
+
+  Scenario: Close order including lines
+    Given call read("features/close-order-including-lines.feature")
 
   Scenario: wipe data
     Given call read('classpath:common/destroy-data.feature')

--- a/acquisitions/src/test/java/org/folio/OrdersApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersApiTest.java
@@ -273,6 +273,11 @@ public class OrdersApiTest extends TestBase {
     runFeatureTest("reopen-order-with-50-lines");
   }
 
+  @Test
+  void closeOrderIncludingLines() {
+    runFeatureTest("close-order-including-lines");
+  }
+
   @BeforeAll
   public void ordersApiTestBeforeAll() {
     runFeature("classpath:thunderjet/mod-orders/orders-junit.feature");


### PR DESCRIPTION
## Purpose
[MODORDERS-514](https://issues.folio.org/browse/MODORDERS-514) - Closing a composite order can fail silently when lines are included

## Approach
New test closing a composite order including the lines.
