### PR TITLE
[MODFIN-316] Removed unnecessary permissions

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules-junit.feature
@@ -25,8 +25,6 @@ Feature: cross-module integration tests
       | 'orders.item.approve'      |
       | 'orders.item.reopen'       |
       | 'orders.item.unopen'       |
-      | 'finance-storage.ledger-rollovers-errors.item.post'     |
-      | 'finance-storage.ledger-rollovers-errors.item.delete'   |
 
   Scenario: create tenant and users for testing
     Given call read('classpath:common/setup-users.feature')

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
@@ -32,8 +32,6 @@ Feature: cross-module integration tests
       | 'orders.item.approve'      |
       | 'orders.item.reopen'       |
       | 'orders.item.unopen'       |
-      | 'finance-storage.ledger-rollovers-errors.item.post'     |
-      | 'finance-storage.ledger-rollovers-errors.item.delete'   |
 
     # Looks like already exist, but if not pleas uncomment
     #* table desiredPermissions

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders-junit.feature
@@ -32,8 +32,6 @@ Feature: mod-orders integration tests
       | 'orders.item.unopen'                   |
       | 'invoice.all'                          |
       | 'audit.all'                            |
-      | 'finance-storage.ledger-rollovers-errors.item.post'     |
-      | 'finance-storage.ledger-rollovers-errors.item.delete'   |
 
 # Looks like already exist, but if not pleas uncomment
 #    * table desiredPermissions

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
@@ -39,8 +39,6 @@ Feature: mod-orders integration tests
       | 'orders.item.unopen'                   |
       | 'inventory-storage.holdings.collection.get' |
       | 'inventory-storage.items.collection.get'    |
-      | 'finance-storage.ledger-rollovers-errors.item.post'     |
-      | 'finance-storage.ledger-rollovers-errors.item.delete'   |
 
 # Looks like already exist, but if not pleas uncomment
 #    * table desiredPermissions


### PR DESCRIPTION
## Purpose
[MODFIN-316](https://issues.folio.org/browse/MODFIN-316) - Provide proxy endpoints to add and delete ledger rollover error in the business layer

## Approach
Removed unnecessary permissions

See related [PR](https://github.com/folio-org/mod-finance/pull/204) in mod-finance.