### PR TITLE
FAT-5274 Authority control: Wait for export modules enabling

### DIFF
--- a/mod-data-export/src/test/java/org/folio/ModDataExportApiTest.java
+++ b/mod-data-export/src/test/java/org/folio/ModDataExportApiTest.java
@@ -65,11 +65,11 @@ class ModDataExportApiTest extends TestBase {
         runFeatureTest("delete-job-execution");
     }
 
-  @Test
-  @Order(9)
-  void authUpdateHeadingsExportTest() {
-    runFeatureTest("export-auth-update-headings");
-  }
+    @Test
+    @Order(9)
+    void authUpdateHeadingsExportTest() {
+      runFeatureTest("export-auth-update-headings");
+    }
 
     @BeforeAll
     public void modDataExportTestsBeforeAll() {

--- a/mod-data-export/src/test/resources/firebird/dataexport/data-export-basic-junit.feature
+++ b/mod-data-export/src/test/resources/firebird/dataexport/data-export-basic-junit.feature
@@ -11,27 +11,24 @@ Feature: mod-orders integration tests
       | 'mod-data-export'           |
       | 'mod-login'                 |
       | 'mod-configuration'         |
-      | 'mod-source-record-manager'         |
-      | 'mod-source-record-storage'         |
+      | 'mod-source-record-manager' |
+      | 'mod-source-record-storage' |
       | 'mod-inventory-storage'     |
       | 'mod-inventory'             |
       | 'mod-entities-links'        |
       | 'mod-quick-marc'            |
 
-
-
-
     * table userPermissions
-      | name                    |
-      | 'data-export.all'       |
-      | 'configuration.all'     |
-      | 'inventory-storage.all' |
-      | 'source-storage.all'    |
-      | 'records-editor.all'    |
-      | 'metadata-provider.logs.get'                        |
-      | 'change-manager.jobexecutions.get'                  |
-      | 'converter-storage.field-protection-settings.get'   |
-      | 'inventory.instances.collection.get' |
+      | name                                                           |
+      | 'data-export.all'                                              |
+      | 'configuration.all'                                            |
+      | 'inventory-storage.all'                                        |
+      | 'source-storage.all'                                           |
+      | 'records-editor.all'                                           |
+      | 'metadata-provider.logs.get'                                   |
+      | 'change-manager.jobexecutions.get'                             |
+      | 'converter-storage.field-protection-settings.get'              |
+      | 'inventory.instances.collection.get'                           |
       | 'instance-authority-links.authority-statistics.collection.get' |
 
     * table exportModules
@@ -47,10 +44,13 @@ Feature: mod-orders integration tests
   Scenario: create tenant and users for testing
     Given call read('classpath:common/setup-users.feature')
 
-  Scenario: enable export modules and update permissions
+  Scenario: enable export modules
+    * print "get and install export modules"
     Given call read('classpath:common/tenant.feature@install') { modules: '#(exportModules)', tenant: '#(testTenant)'}
-    Given call login testAdmin
+    And pause(300000)
 
+  Scenario: update user permissions with tested modules permissions
+    * call login testAdmin
     Given path 'perms/users'
     And param query = 'userId=00000000-1111-5555-9999-999999999992'
     And headers {'x-okapi-tenant':'#(testTenant)', 'x-okapi-token':'#(okapitoken)'}
@@ -62,6 +62,7 @@ Feature: mod-orders integration tests
     And def updatedPermissions = karate.append(permissionEntry.permissions, newPermissions)
     And set permissionEntry.permissions = updatedPermissions
 
+    * print "update user permissions with export modules permissions"
     Given path 'perms/users', permissionEntry.id
     And headers {'x-okapi-tenant':'#(testTenant)', 'x-okapi-token':'#(okapitoken)'}
     And request permissionEntry

--- a/mod-data-export/src/test/resources/firebird/dataexport/features/export-auth-update-headings.feature
+++ b/mod-data-export/src/test/resources/firebird/dataexport/features/export-auth-update-headings.feature
@@ -10,7 +10,6 @@ Feature: Test Data Export Spring API
     * def filePath = 'classpath:samples/'
     * def equalsCsv = 'export-auth-update-headings.feature@EqualsCsv'
 
-
   @Ignore
   @EqualsCsv
   Scenario: Equals csv results
@@ -35,9 +34,7 @@ Feature: Test Data Export Spring API
     And def csvLineSeparator = '\n'
     And def systemLineSeparator = java.lang.System.lineSeparator()
     And match expectedCsvFile.split(systemLineSeparator) == actualCsvFile.split(csvLineSeparator)
-
     
-  # Positive cases
   @Positive
   @ExportAuthUpdateHeadings
   Scenario: UpsertJob should return job with status 201. Then get id job from response.id with status 200
@@ -54,7 +51,6 @@ Feature: Test Data Export Spring API
 
     * def jobId = $.id
     * call read(equalsCsv) {expectedFileName: 'authUpdateHeadersNoRecords.csv'}
-
 
   @Positive
   Scenario: Should update record without any errors
@@ -84,7 +80,6 @@ Feature: Test Data Export Spring API
     # export & check updated record
     * call read('export-auth-update-headings.feature@ExportAuthUpdateHeadings')
 
-
   @Positive
   Scenario: Test data-export-spring. Gets job list by limit of 1 items with status 200
     Given path 'data-export-spring/jobs'
@@ -95,7 +90,6 @@ Feature: Test Data Export Spring API
     And assert karate.sizeOf(response.jobRecords) == 1
 
 
-  # Negative cases
   @Negative
   Scenario: UpsertJob. Empty date from & to. Should fail and return job with status 400 BadRequest.
     * def requestBody = read(filePath + 'auth_update_headings.json')


### PR DESCRIPTION
## Purpose
After [MODEXPW-382 remove fetch0max-wait prop](https://github.com/folio-org/mod-data-export-worker/pull/439/files) we should wait for modules enabling

## Approach
- Pause for 5 minutes (as for bulk-edit type)
- Improve logging and code style
