### PR TITLE
FAT-5384: Switch maven from 3-openjdk-8 to 3-eclipse-temurin-17-alpine

### DIFF
--- a/.rancher-pipeline.yml
+++ b/.rancher-pipeline.yml
@@ -2,7 +2,7 @@ stages:
   - name: Run tests
     steps:
       - runScriptConfig:
-          image: maven:3-openjdk-8
+          image: maven:3-eclipse-temurin-17-alpine
           shellScript: sh ./runtests.sh ${PROJECT} ${ENVIRONMENT}
         envFrom:
           - sourceName: integration-tests


### PR DESCRIPTION
FST-55 = FAT-5384 = https://issues.folio.org/browse/FAT-5384

FOLIO supports JDK 17 since Nolana:
https://wiki.folio.org/display/TC/Nolana