### PR TITLE
[FAT-5518] Longer sleep for parallel test

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/parallel-update-order-lines-different-orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/parallel-update-order-lines-different-orders.feature
@@ -99,7 +99,7 @@ Feature: Update order lines for different open orders in parallel (using the sam
     # Note: karate.afterFeature() does not report error count, so it's unusable.
     # Also in latest karate, if we call another feature with scenarios, they are not executed in parallel.
     # So we have to wait for the updates in a parallel thread before checking the budget.
-    * call pause 1000
+    * call pause 2000
 
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId


### PR DESCRIPTION
## Purpose
[FAT-5518](https://issues.folio.org/browse/FAT-5518) - Karate test fail: [thunderjet/mod-orders] OrdersApiTest {51} thunderjet/mod-orders/features/parallel-update-order-lines-different-orders.feature

## Approach
Increased the sleep, apparently the line updates can take 1.5 s.
