### PR TITLE
MODELINKS-68 Extend GET /links/instances/{id} with link status

### DIFF
--- a/mod-entities-links/src/main/resources/spitfire/mod-entities-links/features/entitiesLinksTest.feature
+++ b/mod-entities-links/src/main/resources/spitfire/mod-entities-links/features/entitiesLinksTest.feature
@@ -52,6 +52,22 @@ Feature: instance-links tests
     # remove links
     * call read(utilPath + '@RemoveLinks') { extInstanceId: #(instanceId) }
 
+  @Positive
+  Scenario: Put link - Should ignore read-only fields
+    * def requestBody = read(samplePath + '/links/createLink.json')
+    And set requestBody.links[0].status = "ERROR"
+    And set requestBody.links[0].errorCause = "test"
+    # put link authority to instance
+    * call read(utilPath + '@PutInstanceLinks') { extInstanceId: #(instanceId), extRequestBody: #(requestBody) }
+
+    * call read(utilPath + '@GetInstanceLinks') { extInstanceId: #(instanceId) }
+    * def link = response.links[0];
+    And match link.status == "ACTUAL"
+    And match link.errorCause == '#notpresent'
+
+    # remove links
+    * call read(utilPath + '@RemoveLinks') { extInstanceId: #(instanceId) }
+
   @Negative
   Scenario: Put link - instanceId not matched with link
     * def randomId = uuid()


### PR DESCRIPTION
- Add test case for link status, errorCause

## Purpose
Cover changes with tests

## Approach
- Add test case for link status, errorCause

### Learning
[MODELINKS-68](https://issues.folio.org/browse/MODELINKS-68)
