### PR TITLE
FAT-5425: Replace pwned password

### DIFF
--- a/mod-users-bl/src/main/resources/prokopovych/mod-users-bl/features/users-bl.feature
+++ b/mod-users-bl/src/main/resources/prokopovych/mod-users-bl/features/users-bl.feature
@@ -10,7 +10,7 @@ Feature: Test user business logic
 
   Scenario: Can login after password change
     * configure lowerCaseResponseHeaders = true
-    * def newPassword = "Passw0rd1;"
+    * def newPassword = "bFdVmjZ72D2PaMk4u2HM;"
 
     # Login the test user. This user was created in common/setup-users.feature.
     Given path 'bl-users/login'


### PR DESCRIPTION
The password
```
Passw0rd1;
```
has been added to
https://api.pwnedpasswords.com
https://haveibeenpwned.com/Passwords
on April 7, 2023 and therefore gets
rejected by https://github.com/folio-org/mod-password-validator

To make the integration test succeed we need to replace the pwned password.