### PR TITLE
[MODINVOICE-474] Invoice line encumbrance links updated with fiscal year

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
@@ -139,5 +139,8 @@ Feature: cross-module integration tests
   Scenario: Open order after approving invoice
     Given call read('features/open-order-after-approving-invoice.feature')
 
+  Scenario: Update encumbrance links with fiscal year
+    Given call read('features/update-encumbrance-links-with-fiscal-year.feature')
+
   Scenario: wipe data
     Given call read('classpath:common/destroy-data.feature')

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/update-encumbrance-links-with-fiscal-year.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/update-encumbrance-links-with-fiscal-year.feature
@@ -1,0 +1,187 @@
+# and https://issues.folio.org/browse/MODINVOICE-474
+@parallel=false
+Feature: Update encumbrance links with fiscal year
+
+  Background:
+    * print karate.info.scenarioName
+    * url baseUrl
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json' }
+
+    * configure headers = headersUser
+
+    * callonce variables
+
+    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
+    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-audit-order-line.feature')
+    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
+    * def createInvoice = read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature')
+    * def createInvoiceLine = read('classpath:thunderjet/mod-invoice/reusable/create-invoice-line.feature')
+    * def createFiscalYear = read('classpath:thunderjet/mod-finance/reusable/createFiscalYear.feature')
+    * def createTransaction = read('classpath:thunderjet/mod-finance/reusable/createTransaction.feature')
+
+    * def currentYear = callonce getCurrentYear
+    * def currentStart = currentYear + '-01-01T00:00:00Z'
+    * def currentEnd = currentYear + '-12-30T23:59:59Z'
+    * def pastFiscalYearId = callonce uuid1
+    * def currentFiscalYearId = callonce uuid2
+    * def ledgerId = callonce uuid3
+    * def fundId = callonce uuid4
+    * def pastBudgetId = callonce uuid5
+    * def currentBudgetId = callonce uuid6
+
+
+  Scenario: Create finances
+    * configure headers = headersAdmin
+    * def v = call createFiscalYear { id: #(pastFiscalYearId), code: 'INVTEST2020', periodStart: '2020-01-01T00:00:00Z', periodEnd: '2020-12-30T23:59:59Z', series: 'INVTEST' }
+    * def v = call createFiscalYear { id: #(currentFiscalYearId), code: #('INVTEST' + currentYear), periodStart: #(currentStart), periodEnd: #(currentEnd), series: 'INVTEST' }
+    * def v = call createLedger { id: #(ledgerId), fiscalYearId: #(pastFiscalYearId), restrictEncumbrance: false, restrictExpenditures: false }
+    * def v = call createFund { 'id': '#(fundId)', ledgerId: #(ledgerId) }
+    * def v = call createBudget { 'id': '#(pastBudgetId)', 'allocated': 100, 'fundId': '#(fundId)', 'status': 'Active', fiscalYearId: #(pastFiscalYearId) }
+    * def v = call createBudget { 'id': '#(currentBudgetId)', 'allocated': 100, 'fundId': '#(fundId)', 'status': 'Active', fiscalYearId: #(currentFiscalYearId) }
+
+
+  Scenario: Using invoice in past fiscal year, create an invoice line, encumbrance link is changed to past fiscal year
+    * def orderId = call uuid
+    * def poLineId = call uuid
+    * def invoiceId = call uuid
+    * def invoiceLineId = call uuid
+    * def pastEncumbranceId = call uuid
+
+    * print "Create the order and order line"
+    * def v = call createOrder { id: #(orderId) }
+    * def v = call createOrderLine { id: #(poLineId), orderId: #(orderId), fundId: #(fundId) }
+    * def v = call openOrder { orderId: #(orderId) }
+
+    * print "Get the current encumbrance id"
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+    * def poLine = $
+    * def currentEncumbranceId = poLine.fundDistribution[0].encumbrance
+
+    * print "Create the past encumbrance"
+    * configure headers = headersAdmin
+    Given path 'finance/order-transaction-summaries', orderId
+    And request
+    """
+      {
+        "id": "#(orderId)",
+        "numTransactions": 1
+      }
+    """
+    When method PUT
+    Then status 204
+    * def v = call createTransaction { id: #(pastEncumbranceId), transactionType: 'Encumbrance', fiscalYearId: #(pastFiscalYearId), fundId: #(fundId), amount: 10.0, orderId: #(orderId), poLineId: #(poLineId) }
+    * configure headers = headersUser
+
+    * print "Create an invoice in the past fiscal year"
+    * def v = call createInvoice { id: #(invoiceId), fiscalYearId: #(pastFiscalYearId) }
+
+    * print "Add an invoice line linked to a po line, using the encumbrance in the current fiscal year"
+    * def v = call createInvoiceLine { invoiceLineId: #(invoiceLineId), invoiceId: #(invoiceId), poLineId: #(poLineId), fundId: #(fundId), encumbranceId: #(currentEncumbranceId), total: 10 }
+
+    * print "Check the encumbrance link was changed to use the past fiscal year encumbrance"
+    Given path 'invoice/invoice-lines', invoiceLineId
+    When method GET
+    Then status 200
+    And match $.fundDistributions[0].encumbrance == pastEncumbranceId
+
+
+  Scenario: Change invoice to use past fiscal year and then current fiscal year, encumbrance links are updated
+    * def orderId = call uuid
+    * def poLineId1 = call uuid
+    * def poLineId2 = call uuid
+    * def invoiceId = call uuid
+    * def invoiceLineId1 = call uuid
+    * def invoiceLineId2 = call uuid
+    * def pastEncumbranceId = call uuid
+
+    * print "Create the order and order lines"
+    * def v = call createOrder { id: #(orderId) }
+    * def v = call createOrderLine { id: #(poLineId1), orderId: #(orderId), fundId: #(fundId) }
+    * def v = call createOrderLine { id: #(poLineId2), orderId: #(orderId), fundId: #(fundId) }
+    * def v = call openOrder { orderId: #(orderId) }
+
+    * print "Get the current encumbrance ids"
+    Given path 'orders/order-lines', poLineId1
+    When method GET
+    Then status 200
+    * def poLine = $
+    * def currentEncumbranceId1 = poLine.fundDistribution[0].encumbrance
+    Given path 'orders/order-lines', poLineId2
+    When method GET
+    Then status 200
+    * def poLine = $
+    * def currentEncumbranceId2 = poLine.fundDistribution[0].encumbrance
+
+    * print "Create one past encumbrance"
+    * configure headers = headersAdmin
+    Given path 'finance/order-transaction-summaries', orderId
+    And request
+    """
+      {
+        "id": "#(orderId)",
+        "numTransactions": 1
+      }
+    """
+    When method PUT
+    Then status 204
+    * def v = call createTransaction { id: #(pastEncumbranceId), transactionType: 'Encumbrance', fiscalYearId: #(pastFiscalYearId), fundId: #(fundId), amount: 10.0, orderId: #(orderId), poLineId: #(poLineId1) }
+    * configure headers = headersUser
+
+    * print "Create an invoice in the current fiscal year"
+    * def v = call createInvoice { id: #(invoiceId) }
+
+    * print "Add invoice lines linked to the po lines, using the encumbrances in the current fiscal year"
+    * def v = call createInvoiceLine { invoiceLineId: #(invoiceLineId1), invoiceId: #(invoiceId), poLineId: #(poLineId1), fundId: #(fundId), encumbranceId: #(currentEncumbranceId1), total: 10 }
+    * def v = call createInvoiceLine { invoiceLineId: #(invoiceLineId2), invoiceId: #(invoiceId), poLineId: #(poLineId2), fundId: #(fundId), encumbranceId: #(currentEncumbranceId2), total: 10 }
+
+    * print "Change the invoice to use the past fiscal year"
+    Given path 'invoice/invoices', invoiceId
+    When method GET
+    Then status 200
+    * def invoice = $
+    * set invoice.fiscalYearId = pastFiscalYearId
+    Given path 'invoice/invoices', invoiceId
+    And request invoice
+    When method PUT
+    Then status 204
+
+    * print "Check the encumbrance links were changed to use the past fiscal year encumbrances"
+    Given path 'invoice/invoice-lines', invoiceLineId1
+    When method GET
+    Then status 200
+    And match $.fundDistributions[0].encumbrance == pastEncumbranceId
+    Given path 'invoice/invoice-lines', invoiceLineId2
+    When method GET
+    Then status 200
+    And match $.fundDistributions[0].encumbrance == '#notpresent'
+
+    * print "Change the invoice to use the current fiscal year"
+    Given path 'invoice/invoices', invoiceId
+    When method GET
+    Then status 200
+    * def invoice = $
+    * set invoice.fiscalYearId = currentFiscalYearId
+    Given path 'invoice/invoices', invoiceId
+    And request invoice
+    When method PUT
+    Then status 204
+
+    * print "Check the encumbrance links were changed to use the current fiscal year encumbrances"
+    Given path 'invoice/invoice-lines', invoiceLineId1
+    When method GET
+    Then status 200
+    And match $.fundDistributions[0].encumbrance == currentEncumbranceId1
+    Given path 'invoice/invoice-lines', invoiceLineId2
+    When method GET
+    Then status 200
+    And match $.fundDistributions[0].encumbrance == currentEncumbranceId2
+

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-expense-classes.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-expense-classes.feature
@@ -158,7 +158,7 @@ Feature: Budget expense classes
 
     * def statusExpenseClassesForCreate = [{'expenseClassId': '#(globalElecExpenseClassId)'}]
     * def statusExpenseClassesForUpdate = [{'expenseClassId': '#(globalElecExpenseClassId)'}, {'expenseClassId': '#(globalPrnExpenseClassId)'}]
-    * call createBudget { 'id': '#(budgetIdWithExpenseClassesWithTransactions)', 'fundId': '#(fundIdWithExpenseClassesWithTransactions)', 'allocated': 10000, 'statusExpenseClasses': '#(statusExpenseClassesForCreate)'}
+    * def v = call createBudget { 'id': '#(budgetIdWithExpenseClassesWithTransactions)', 'fundId': '#(fundIdWithExpenseClassesWithTransactions)', 'allocated': 10000, 'statusExpenseClasses': '#(statusExpenseClassesForCreate)'}
 
 
     Given path 'finance-storage/order-transaction-summaries'
@@ -184,12 +184,12 @@ Feature: Budget expense classes
     When method POST
     Then status 201
 
-    * call createTransaction { 'fundId': '#(fundIdWithExpenseClassesWithTransactions)', 'amount': 11.0, 'expenseClassId': '#(globalElecExpenseClassId)', 'orderId': '#(orderId)', 'transactionType': 'Encumbrance'}
-    * call createTransaction { 'fundId': '#(fundIdWithExpenseClassesWithTransactions)', 'amount':  54.11, 'expenseClassId': '#(globalElecExpenseClassId)', 'orderId': '#(orderId)', 'transactionType': 'Encumbrance'}
-    * call createTransaction { 'fundId': '#(fundIdWithExpenseClassesWithTransactions)', 'amount':  1004.11, 'expenseClassId': null, 'orderId': '#(orderId)', 'transactionType': 'Encumbrance'}
-    * call createTransaction { 'fundId': '#(fundIdWithExpenseClassesWithTransactions)', 'amount':  12, 'expenseClassId': '#(globalElecExpenseClassId)', 'invoiceId': '#(invoiceId)', 'transactionType': 'Pending payment'}
-    * call createTransaction { 'fundId': '#(fundIdWithExpenseClassesWithTransactions)', 'amount':  -11.4, 'expenseClassId': '#(globalElecExpenseClassId)', 'invoiceId': '#(invoiceId)', 'transactionType': 'Pending payment'}
-    * call createTransaction { 'fundId': '#(fundIdWithExpenseClassesWithTransactions)', 'amount':  1102, 'expenseClassId': null, 'invoiceId': '#(invoiceId)', 'transactionType': 'Pending payment'}
+    * def v = call createTransaction { 'fundId': '#(fundIdWithExpenseClassesWithTransactions)', 'amount': 11.0, 'expenseClassId': '#(globalElecExpenseClassId)', 'orderId': '#(orderId)', 'transactionType': 'Encumbrance', 'poLineId': '#(uuid())' }
+    * def v = call createTransaction { 'fundId': '#(fundIdWithExpenseClassesWithTransactions)', 'amount':  54.11, 'expenseClassId': '#(globalElecExpenseClassId)', 'orderId': '#(orderId)', 'transactionType': 'Encumbrance', 'poLineId': '#(uuid())' }
+    * def v = call createTransaction { 'fundId': '#(fundIdWithExpenseClassesWithTransactions)', 'amount':  1004.11, 'expenseClassId': null, 'orderId': '#(orderId)', 'transactionType': 'Encumbrance', 'poLineId': '#(uuid())' }
+    * def v = call createTransaction { 'fundId': '#(fundIdWithExpenseClassesWithTransactions)', 'amount':  12, 'expenseClassId': '#(globalElecExpenseClassId)', 'invoiceId': '#(invoiceId)', 'transactionType': 'Pending payment'}
+    * def v = call createTransaction { 'fundId': '#(fundIdWithExpenseClassesWithTransactions)', 'amount':  -11.4, 'expenseClassId': '#(globalElecExpenseClassId)', 'invoiceId': '#(invoiceId)', 'transactionType': 'Pending payment'}
+    * def v = call createTransaction { 'fundId': '#(fundIdWithExpenseClassesWithTransactions)', 'amount':  1102, 'expenseClassId': null, 'invoiceId': '#(invoiceId)', 'transactionType': 'Pending payment'}
 
     Given path '/finance/budgets/', budgetIdWithExpenseClassesWithTransactions, 'expense-classes-totals'
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/group-expense-classes.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/group-expense-classes.feature
@@ -187,7 +187,7 @@ Feature: Group expense classes
     * def invoiceId = <invoiceId>
     * def fundId = <fundId>
 
-    * call createTransaction { 'fundId': '#(fundId)', 'amount': #(amount), 'expenseClassId': #(expenseClassId), 'orderId': #(orderId), 'invoiceId': #(invoiceId)}
+    * call createTransaction { 'fundId': '#(fundId)', 'amount': #(amount), 'expenseClassId': #(expenseClassId), 'orderId': #(orderId), 'invoiceId': #(invoiceId), 'poLineId': '#(uuid())'}
 
     Examples:
       |  amount     | fundId                                      | transactionType   | expenseClassId           | invoiceId  |

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createTransaction.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createTransaction.feature
@@ -2,17 +2,22 @@ Feature: transaction
 
   Background:
     * url baseUrl
-    * def poLineId = callonce uuid
 
   Scenario: createTransaction
+    * def id = karate.get('id', null)
+    * def poLineId = karate.get('poLineId', null)
     * def fiscalYearId = karate.get('fiscalYearId', globalFiscalYearId)
     * def sourceInvoiceId = karate.get('invoiceId', null)
     * def sourcePurchaseOrderId = karate.get('orderId', null)
+    * def expenseClassId = karate.get('expenseClassId', null)
+    * def transactionEncumbrance = { initialAmountEncumbered: #(amount), status: 'Unreleased', sourcePurchaseOrderId: #(sourcePurchaseOrderId), sourcePoLineId: #(poLineId), orderType: 'One-Time', subscription: false, reEncumber: false }
+    * def transactionEncumbrance = transactionType == 'Encumbrance' ? transactionEncumbrance : null
 
     Given path 'finance-storage/transactions'
     And request
     """
     {
+      "id": "#(id)",
       "amount": "#(amount)",
       "currency": "USD",
       "fromFundId": "#(fundId)",
@@ -22,15 +27,7 @@ Feature: transaction
       "source": "User",
       "sourceInvoiceId": "#(sourceInvoiceId)",
       "expenseClassId": "#(expenseClassId)",
-      "encumbrance": {
-        "initialAmountEncumbered": #(amount),
-        "status": "Unreleased",
-        "sourcePurchaseOrderId": "#(sourcePurchaseOrderId)",
-        "sourcePoLineId": "#(poLineId)",
-        "orderType": "One-Time",
-        "subscription": false,
-        "reEncumber": false
-       }
+      "encumbrance": #(transactionEncumbrance)
     }
     """
     When method POST

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/reusable/create-invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/reusable/create-invoice.feature
@@ -6,7 +6,9 @@ Feature: Create invoice
 
   Scenario: createInvoice
     * def invoice = read('classpath:samples/mod-invoice/invoices/global/invoice.json')
+    * def fiscalYearId = karate.get('fiscalYearId', null)
     * set invoice.id = id
+    * set invoice.fiscalYearId = fiscalYearId
 
     Given path 'invoice/invoices'
     And request invoice

--- a/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
+++ b/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
@@ -164,6 +164,11 @@ public class CrossModulesApiTest extends TestBase {
     runFeatureTest("open-order-after-approving-invoice");
   }
 
+  @Test
+  void updateEncumbranceLinksWithFiscalYear() {
+    runFeatureTest("update-encumbrance-links-with-fiscal-year");
+  }
+
   @BeforeAll
   public void crossModuleApiTestBeforeAll() {
     runFeature("classpath:thunderjet/cross-modules/cross-modules-junit.feature");


### PR DESCRIPTION
## Purpose
[MODINVOICE-474](https://issues.folio.org/browse/MODINVOICE-474) - Update the encumbrance when using a past fiscal year

## Approach
New cross-module feature. Updated other files to make it easier to create transactions and create an invoice with a fiscal year id.

Review together with the [mod-invoice PR](https://github.com/folio-org/mod-invoice/pull/409).