### PR TITLE
FAT-5839 - Provided mod-entities-links for deployment before tests run

### DIFF
--- a/mod-source-record-manager/src/main/resources/folijet/mod-source-record-manager/source-record-manager.feature
+++ b/mod-source-record-manager/src/main/resources/folijet/mod-source-record-manager/source-record-manager.feature
@@ -6,6 +6,7 @@ Feature: mod-source-record-storage integration tests
       | name                        |
       | 'mod-login'                 |
       | 'mod-permissions'           |
+      | 'mod-entities-links'        |
       | 'mod-source-record-manager' |
       | 'mod-inventory-storage'     |
 


### PR DESCRIPTION
defined mod-entities-links for modules deployment to provide mapping parameters by /mapping-metadata/type/{recordType} endpoint

## Learning
https://issues.folio.org/browse/FAT-5839