### PR TITLE
[FAT-5974] Karate test fail in [mod-consortia]

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-consortia/features/user-tenant-associations.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-consortia/features/user-tenant-associations.feature
@@ -8,7 +8,7 @@ Feature: Consortia User Tenant associations api tests
     # create a user in 'central' tenant
     * call read(login) centralAdmin
     * call read('features/util/initData.feature@SetUpUserWithAuth') centralUser2
-    * call pause 60
+    * call pause 2000
 
     # verify there is a record for newly created user in 'user-tenants'
     * def userTenants = call read('features/util/initData.feature@GetUserTenantsRecordFilteredByUserIdAndTenantId') { userId: '#(centralUser2.id)', tenantId: '#(centralAdmin.tenant)'}


### PR DESCRIPTION
## Purpose
Resolves [FAT-5974](https://issues.folio.org/browse/FAT-5974) Karate test fail: [thunderjet/mod-consortia] ConsortiaApiTest {3} thunderjet/mod-consortia/features/tenant.feature
Related [FAT-6028](https://issues.folio.org/browse/FAT-6028) Cover Consortia User Tenant associations with karate tests

## Approach
_How does this change fulfill the purpose?_

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
