### PR TITLE
FAT-5636 (quick-marc-bib-records): Corrected linkingRuleId

### DIFF
--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-bib-records.feature
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-bib-records.feature
@@ -66,7 +66,7 @@ Feature: Test quickMARC
     * def recordId = quickMarcJson.parsedRecordId
     * def fields = quickMarcJson.fields
     * def linkContent = ' $0 ' + authorityNaturalId + ' $9 ' + linkedAuthorityId
-    * def newField = { "tag": "600", "indicators": [ "\\", "\\" ], "content":'#("$a Test note" + linkContent)', "isProtected":false, "linkDetails":{ "authorityId":#(linkedAuthorityId), "authorityNaturalId":#(authorityNaturalId), "linkingRuleId": 12, "status":"ERROR", "errorCause":"test"  } }
+    * def newField = { "tag": "600", "indicators": [ "\\", "\\" ], "content":'#("$a Test note" + linkContent)', "isProtected":false, "linkDetails":{ "authorityId":#(linkedAuthorityId), "authorityNaturalId":#(authorityNaturalId), "linkingRuleId": 8, "status":"ERROR", "errorCause":"test"  } }
     * fields.push(newField)
     * set quickMarcJson.fields = fields
     * set quickMarcJson.relatedRecordVersion = 3
@@ -77,7 +77,7 @@ Feature: Test quickMARC
     When method PUT
     Then status 202
 
-    * def newLink = { "id":3, "authorityId": #(linkedAuthorityId), "authorityNaturalId": #(authorityNaturalId), "instanceId": #(testInstanceId), "linkingRuleId": #(newField.linkingRuleId), "status":"ACTUAL" }
+    * def newLink = { "id":3, "authorityId": #(linkedAuthorityId), "authorityNaturalId": #(authorityNaturalId), "instanceId": #(testInstanceId), "linkingRuleId": #(newField.linkDetails.linkingRuleId), "status":"ACTUAL" }
 
     Given path 'links/instances', testInstanceId
     And headers headersUser


### PR DESCRIPTION
## Approach
- Put right linking rule id for `600` field
- Corrected path for ruleId 

![image](https://github.com/folio-org/folio-integration-tests/assets/88006020/7b5edd3b-f7cb-4d25-88ce-d3278dc3c0df)

### Learning
https://issues.folio.org/browse/FAT-5636

