### PR TITLE
MSEARCH-523 Include call number type id from Holdings in Items record when not specified

### DIFF
--- a/mod-search/src/test/resources/samples/test-data/items.json
+++ b/mod-search/src/test/resources/samples/test-data/items.json
@@ -8,7 +8,6 @@
       "itemLevelCallNumber": "TK5105.88815 . A58 2004 FT MEADE",
       "itemLevelCallNumberPrefix": "prefix-10101",
       "itemLevelCallNumberSuffix": "suffix-10101",
-      "itemLevelCallNumberTypeId": "512173a7-bd09-490e-b773-17d83f2b63fe",
       "discoverySuppress": true,
       "volume": "v1",
       "enumeration": "",

--- a/mod-search/src/test/resources/spitfire/mod-search/browse/call-number-browse.feature
+++ b/mod-search/src/test/resources/spitfire/mod-search/browse/call-number-browse.feature
@@ -207,3 +207,7 @@ Feature: Tests that browse by call-numbers
       { "shelfKey": "ZZ 3920.92", "fullCallNumber": "ZZ 920.92", "totalRecords": 1 }
     ]
     """
+    Then match karate.jsonPath(response, "$.items[*].instance.items[0].effectiveCallNumberComponents.typeId") ==
+    """
+    ["512173a7-bd09-490e-b773-17d83f2b63fe", "512173a7-bd09-490e-b773-17d83f2b63fe"]
+    """


### PR DESCRIPTION
## Purpose
Reflect mod-search changes in tests
[MSEARCH-523](https://issues.folio.org/browse/MSEARCH-523)

## Approach
- Remove call number typeId from one of items so it's inherited from holdings
- Add assertion that callNumberType is inherited from holdings in item
