### PR TITLE
FAT-6135 - Ignore legacy bulk-edit features

### DIFF
--- a/mod-bulk-edit/src/main/resources/firebird/bulk-edit/bulk-edit-junit.feature
+++ b/mod-bulk-edit/src/main/resources/firebird/bulk-edit/bulk-edit-junit.feature
@@ -1,3 +1,4 @@
+@ignore
 Feature: bulk-edit integration tests
 
   Background:

--- a/mod-bulk-edit/src/main/resources/firebird/bulk-edit/bulk-edit-junit.feature
+++ b/mod-bulk-edit/src/main/resources/firebird/bulk-edit/bulk-edit-junit.feature
@@ -1,4 +1,4 @@
-@ignore
+@Ignore
 Feature: bulk-edit integration tests
 
   Background:

--- a/mod-bulk-edit/src/main/resources/firebird/bulk-edit/diku-bulk-edit-junit.feature
+++ b/mod-bulk-edit/src/main/resources/firebird/bulk-edit/diku-bulk-edit-junit.feature
@@ -1,3 +1,4 @@
+@ignore
 Feature: bulk-edit integration tests
 
   Background:

--- a/mod-bulk-edit/src/main/resources/firebird/bulk-edit/diku-bulk-edit-junit.feature
+++ b/mod-bulk-edit/src/main/resources/firebird/bulk-edit/diku-bulk-edit-junit.feature
@@ -1,4 +1,4 @@
-@ignore
+@Ignore
 Feature: bulk-edit integration tests
 
   Background:

--- a/mod-bulk-edit/src/main/resources/firebird/bulk-edit/features/bulk-edit-items-status.feature
+++ b/mod-bulk-edit/src/main/resources/firebird/bulk-edit/features/bulk-edit-items-status.feature
@@ -1,4 +1,4 @@
-@ignore
+@Ignore
 Feature: bulk-edit items update status tests
 
   Background:

--- a/mod-bulk-edit/src/main/resources/firebird/bulk-edit/features/bulk-edit-items-status.feature
+++ b/mod-bulk-edit/src/main/resources/firebird/bulk-edit/features/bulk-edit-items-status.feature
@@ -1,3 +1,4 @@
+@ignore
 Feature: bulk-edit items update status tests
 
   Background:

--- a/mod-bulk-edit/src/main/resources/firebird/bulk-edit/features/bulk-edit-items.feature
+++ b/mod-bulk-edit/src/main/resources/firebird/bulk-edit/features/bulk-edit-items.feature
@@ -1,4 +1,4 @@
-@ignore
+@Ignore
 Feature: bulk-edit items update tests
 
   Background:

--- a/mod-bulk-edit/src/main/resources/firebird/bulk-edit/features/bulk-edit-items.feature
+++ b/mod-bulk-edit/src/main/resources/firebird/bulk-edit/features/bulk-edit-items.feature
@@ -1,3 +1,4 @@
+@ignore
 Feature: bulk-edit items update tests
 
   Background:

--- a/mod-bulk-edit/src/main/resources/firebird/bulk-edit/features/bulk-edit-users.feature
+++ b/mod-bulk-edit/src/main/resources/firebird/bulk-edit/features/bulk-edit-users.feature
@@ -1,4 +1,4 @@
-@ignore
+@Ignore
 Feature: bulk-edit users update tests
 
   Background:

--- a/mod-bulk-edit/src/main/resources/firebird/bulk-edit/features/bulk-edit-users.feature
+++ b/mod-bulk-edit/src/main/resources/firebird/bulk-edit/features/bulk-edit-users.feature
@@ -1,3 +1,4 @@
+@ignore
 Feature: bulk-edit users update tests
 
   Background:

--- a/mod-bulk-edit/src/test/java/org/folio/ModBulkEditApiTest.java
+++ b/mod-bulk-edit/src/test/java/org/folio/ModBulkEditApiTest.java
@@ -4,11 +4,11 @@ import org.folio.test.TestBase;
 import org.folio.test.annotation.FolioTest;
 import org.folio.test.config.TestModuleConfiguration;
 import org.folio.test.services.TestIntegrationService;
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-@FolioTest(team = "firebird", module = "bulk-edit")
+@FolioTest(team = "firebird", module = "bulk-edit (deprecated)")
+@Deprecated(forRemoval = true)
 public class ModBulkEditApiTest extends TestBase {
 
     private static final String TEST_BASE_PATH = "classpath:firebird/bulk-edit/features/";
@@ -38,8 +38,8 @@ public class ModBulkEditApiTest extends TestBase {
         runFeatureTest("bulk-edit-items-status.feature");
     }
 
-    @AfterAll
+    //  @AfterAll - deprecation of common feature that cannot be marked as @Ignored
     public void tearDown() {
-        runFeature("classpath:common/destroy-data.feature");
+      runFeature("classpath:common/destroy-data.feature");
     }
 }


### PR DESCRIPTION
## Purpose
Bulk operation logic is covered by bulk-operations tests. Bulk-edit tests can be ignored because they cover logic in mod-data-export-spring/mod-data-export-worker that isn't used for bulk operations anymore.

## Approach
Using of @ignore annotation for legacy features.

### TODOS and Open Questions
- [ ] Do we need to remove these tests somehow from Jenkins pipeline?

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
