### PR TITLE
FAT-6575 - Implement tests to check the concurrency issue during checkout

### DIFF
--- a/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
@@ -115,11 +115,8 @@ Feature: mod-circulation integration tests
       | 'calendar.delete'                                              |
       | 'circulation-storage.fixed-due-date-schedules.item.post'       |
       | 'circulation-storage.loan-policies.item.get'                   |
-      | 'circulation.override-patron-block'                   |
-      | 'circulation.override-renewal-block'                   |
-      |'checkout-lock-storage.item.post'                       |
-      |'circulation.override-item-limit-block'                                                        |
-
+      |'mod-settings.global.write.mod-circulation'                     |
+      |'mod-settings.entries.item.post'                                |
 
   Scenario: create tenant and users for testing
     Given call read('classpath:common/setup-users.feature')

--- a/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
@@ -115,6 +115,11 @@ Feature: mod-circulation integration tests
       | 'calendar.delete'                                              |
       | 'circulation-storage.fixed-due-date-schedules.item.post'       |
       | 'circulation-storage.loan-policies.item.get'                   |
+      | 'circulation.override-patron-block'                   |
+      | 'circulation.override-renewal-block'                   |
+      |'checkout-lock-storage.item.post'                       |
+      |'circulation.override-item-limit-block'                                                        |
+
 
   Scenario: create tenant and users for testing
     Given call read('classpath:common/setup-users.feature')

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/parallelCheckOut.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/parallelCheckOut.feature
@@ -1,0 +1,139 @@
+Feature: Parallel Checkout Tests
+  Background:
+    * url baseUrl
+    * callonce login testAdmin
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': '*/*' }
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': '*/*' }
+
+    * configure headers = headersUser
+
+    * def instanceId = call uuid1
+    * def servicePointId = call uuid1
+    * def locationId = call uuid1
+    * def holdingId = call uuid1
+    * def itemId = call uuid1
+    * def groupId = call uuid1
+    * def userId = call uuid1
+    * def ownerId = call uuid1
+    * def manualChargeId = call uuid1
+    * def paymentMethodId = call uuid1
+    * def checkOutByBarcodeId = call uuid1
+    * def parseObjectToDate = read('classpath:vega/mod-circulation/features/util/parse-object-to-date-function.js')
+    * def materialTypeId = call uuid1
+    * def materialTypeName = 'e-book1'
+
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(materialTypeId) }
+
+     # groups
+    * def firstUserGroupId = '188f025c-6e52-11ec-90d6-0242ac120013'
+    * def secondUserGroupId = 'f1a28f58-702d-48fe-b95d-daf7fd55dc37'
+    * def thirdUserGroupId = '0dfcce3e-6fb3-11ec-90d6-0242ac120013'
+    * def fourthUserGroupId = 'a58053e4-6fbc-11ec-90d6-0242ac120013'
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: '#(fourthUserGroupId)' }
+
+    # policies
+    * def loanPolicyId = call uuid1
+    * def loanPolicyMaterialId = call uuid1
+    * def lostItemFeePolicyId = call uuid1
+    * def overdueFinePoliciesId = call uuid1
+    * def patronPolicyId = call uuid1
+    * def requestPolicyId = call uuid1
+    * def requestPolicyIdForGroup = call uuid1
+    * def requestPolicyIdForGroup2 = call uuid1
+    * def requestPolicyIdForGroup3 = call uuid1
+    * def requestPolicyIdForGroup4 = call uuid1
+    * def extRequestTypesForSecondUserGroupRequestPolicy = ["Page", "Recall"]
+    * def extRequestTypesForThirdUserGroupRequestPolicy = ["Page", "Hold"]
+    * def extRequestTypesForFirstUserGroupRequestPolicy = ["Hold", "Recall"]
+
+    * def extFallbackPolicy = { loanPolicyId: #(loanPolicyId), lostItemFeePolicyId: #(lostItemFeePolicyId), overdueFinePoliciesId: #(overdueFinePoliciesId), patronPolicyId: #(patronPolicyId), requestPolicyId: #(requestPolicyId) }
+    * def extMaterialTypePolicy = { materialTypeId: #(materialTypeId), loanPolicyId: #(loanPolicyMaterialId), overdueFinePoliciesId: #(overdueFinePoliciesId), lostItemFeePolicyId: #(lostItemFeePolicyId), requestPolicyId: #(requestPolicyId), patronPolicyId: #(patronPolicyId) }
+    * def extFirstGroupPolicy = { userGroupId: #(firstUserGroupId), loanPolicyId: #(loanPolicyId), overdueFinePoliciesId: #(overdueFinePoliciesId), lostItemFeePolicyId: #(lostItemFeePolicyId), requestPolicyId: #(requestPolicyIdForGroup), patronPolicyId: #(patronPolicyId) }
+    * def extSecondGroupPolicy = { userGroupId: #(secondUserGroupId), loanPolicyId: #(loanPolicyId), overdueFinePoliciesId: #(overdueFinePoliciesId), lostItemFeePolicyId: #(lostItemFeePolicyId), requestPolicyId: #(requestPolicyIdForGroup2), patronPolicyId: #(patronPolicyId) }
+    * def extThirdGroupPolicy = { userGroupId: #(thirdUserGroupId), loanPolicyId: #(loanPolicyId), overdueFinePoliciesId: #(overdueFinePoliciesId), lostItemFeePolicyId: #(lostItemFeePolicyId), requestPolicyId: #(requestPolicyIdForGroup3), patronPolicyId: #(patronPolicyId) }
+    * def extFourthGroupPolicy = { userGroupId: #(fourthUserGroupId), loanPolicyId: #(loanPolicyId), overdueFinePoliciesId: #(overdueFinePoliciesId), lostItemFeePolicyId: #(lostItemFeePolicyId), requestPolicyId: #(requestPolicyIdForGroup4), patronPolicyId: #(patronPolicyId) }
+
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostLoanPolicyWithLimit') { extLoanPolicyId: #(loanPolicyId) }
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostLoanPolicyWithLimit') { extLoanPolicyId: #(loanPolicyMaterialId) }
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostLostPolicy') { extLostItemFeePolicyId: #(lostItemFeePolicyId) }
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostOverduePolicy') { extOverdueFinePoliciesId: #(overdueFinePoliciesId) }
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostPatronPolicy') { extPatronPolicyId: #(patronPolicyId) }
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRequestPolicy') { extRequestPolicyId: #(requestPolicyId) }
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRequestPolicy') { extRequestPolicyId: #(requestPolicyIdForGroup), extRequestTypes: #(extRequestTypesForFirstUserGroupRequestPolicy) }
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRequestPolicy') { extRequestPolicyId: #(requestPolicyIdForGroup2), extRequestTypes: #(extRequestTypesForSecondUserGroupRequestPolicy) }
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRequestPolicy') { extRequestPolicyId: #(requestPolicyIdForGroup3), extRequestTypes: #(extRequestTypesForThirdUserGroupRequestPolicy) }
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRequestPolicy') { extRequestPolicyId: #(requestPolicyIdForGroup4) }
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRulesWithMaterialTypeAndGroup') extFallbackPolicy, extMaterialTypePolicy, extFirstGroupPolicy, extSecondGroupPolicy, extThirdGroupPolicy, extFourthGroupPolicy
+
+    * def extUserId = call uuid1
+    * def extUserBarcode = 'FAT-793UBC'
+    * def extItemId = call uuid1
+    * def extItemBarcode = 'FAT-793IBC'
+
+
+    * def extItemId1 = call uuid1
+    * def extItemBarcode1 = 'FAT-593IBC'
+
+    # location and service point setup
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostLocation')
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostServicePoint')
+
+    # post an item
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostInstance')
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostHoldings')
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(extItemId), extItemBarcode: #(extItemBarcode), extMaterialTypeId: #(materialTypeId)}
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(extItemId1), extItemBarcode: #(extItemBarcode1), extMaterialTypeId: #(materialTypeId)}
+
+    # post a group and a user
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: #(groupId) }
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(extUserId), extUserBarcode: #(extUserBarcode), extGroupId: #(groupId) }
+
+  @CheckOutItem
+  Scenario: Checkout first item
+    * def extItemBarcode = 'FAT-793IBC'
+    * def extUserBarcode = 'FAT-793UBC'
+
+    * def checkOutResponse = call read('classpath:vega/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(extUserBarcode), extCheckOutItemBarcode: #(extItemBarcode) }
+#    And retry until checkOutResponse == 201
+
+#    # get the loan and verify that correct loan-policy has been applied
+#    Given path 'circulation', 'loans'
+#    And param query = '(userId==' + extUserId + ' and ' + 'itemId==' + extItemId + ')'
+#    When method GET
+#    Then status 200
+#    And match response.loans[0].id == checkOutResponse.response.id
+#    And match response.loans[0].loanPolicyId == loanPolicyMaterialId
+
+  @CheckOutSecondItem
+  Scenario: Checkout Second item
+    * def extUserId = call uuid1
+    * def extUserBarcode = 'FAT-793UBC'
+    * def extItemId = call uuid1
+    * def extItemBarcode = 'FAT-093IBC'
+    * def extInstanceTypeId = call uuid3
+    * def extInstitutionId = call uuid2
+    * def extHoldingsRecordId = call uuid3
+    * def extCampusId = call uuid1
+    * def extLibraryId = call uuid1
+    * def extInstanceId = call uuid3
+
+
+    # post an item
+
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostInstance') { extInstanceTypeId: #(extInstanceTypeId), extInstanceId: #(extInstanceId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostHoldings') { extHoldingsRecordId: #(extHoldingsRecordId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(extItemId), extItemBarcode: #(extItemBarcode), extMaterialTypeId: #(materialTypeId)}
+
+
+    # checkOut the item for the user
+    * def checkOutResponse = call read('classpath:vega/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(extUserBarcode), extCheckOutItemBarcode: #(extItemBarcode) }
+
+#    * configure retry = { count: 10, interval: 1000 }
+#    * def extUserBarcode = 'FAT-793UBC'
+#    * def extItemBarcode1 = 'FAT-593IBC'
+    # checkOut the item for the user
+
+#    * def checkOutResponse = call read('classpath:vega/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(extUserBarcode), extCheckOutItemBarcode: #(extItemBarcode1) }
+#    And retry until checkOutResponse == 201

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/parallelCheckOut.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/parallelCheckOut.feature
@@ -23,8 +23,10 @@ Feature: Parallel Checkout Tests
     * def parseObjectToDate = read('classpath:vega/mod-circulation/features/util/parse-object-to-date-function.js')
     * def materialTypeId = call uuid1
     * def materialTypeName = 'e-book1'
-
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(materialTypeId) }
+
+     # settings
+    * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostSettings')
 
      # groups
     * def firstUserGroupId = '188f025c-6e52-11ec-90d6-0242ac120013'
@@ -90,50 +92,13 @@ Feature: Parallel Checkout Tests
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostGroup') { extUserGroupId: #(groupId) }
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(extUserId), extUserBarcode: #(extUserBarcode), extGroupId: #(groupId) }
 
-  @CheckOutItem
   Scenario: Checkout first item
-    * def extItemBarcode = 'FAT-793IBC'
-    * def extUserBarcode = 'FAT-793UBC'
-
+    * print "1st item checkout start"
     * def checkOutResponse = call read('classpath:vega/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(extUserBarcode), extCheckOutItemBarcode: #(extItemBarcode) }
-#    And retry until checkOutResponse == 201
+    * print "1st item checkout end"
 
-#    # get the loan and verify that correct loan-policy has been applied
-#    Given path 'circulation', 'loans'
-#    And param query = '(userId==' + extUserId + ' and ' + 'itemId==' + extItemId + ')'
-#    When method GET
-#    Then status 200
-#    And match response.loans[0].id == checkOutResponse.response.id
-#    And match response.loans[0].loanPolicyId == loanPolicyMaterialId
 
-  @CheckOutSecondItem
   Scenario: Checkout Second item
-    * def extUserId = call uuid1
-    * def extUserBarcode = 'FAT-793UBC'
-    * def extItemId = call uuid1
-    * def extItemBarcode = 'FAT-093IBC'
-    * def extInstanceTypeId = call uuid3
-    * def extInstitutionId = call uuid2
-    * def extHoldingsRecordId = call uuid3
-    * def extCampusId = call uuid1
-    * def extLibraryId = call uuid1
-    * def extInstanceId = call uuid3
-
-
-    # post an item
-
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostInstance') { extInstanceTypeId: #(extInstanceTypeId), extInstanceId: #(extInstanceId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostHoldings') { extHoldingsRecordId: #(extHoldingsRecordId) }
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(extItemId), extItemBarcode: #(extItemBarcode), extMaterialTypeId: #(materialTypeId)}
-
-
-    # checkOut the item for the user
-    * def checkOutResponse = call read('classpath:vega/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(extUserBarcode), extCheckOutItemBarcode: #(extItemBarcode) }
-
-#    * configure retry = { count: 10, interval: 1000 }
-#    * def extUserBarcode = 'FAT-793UBC'
-#    * def extItemBarcode1 = 'FAT-593IBC'
-    # checkOut the item for the user
-
-#    * def checkOutResponse = call read('classpath:vega/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(extUserBarcode), extCheckOutItemBarcode: #(extItemBarcode1) }
-#    And retry until checkOutResponse == 201
+    * print "2nd item checkout start"
+    * def checkOutResponse = call read('classpath:vega/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(extUserBarcode), extCheckOutItemBarcode: #(extItemBarcode1) }
+    * print "2nd item checkout end"

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/parallelCheckOut.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/parallelCheckOut.feature
@@ -94,11 +94,13 @@ Feature: Parallel Checkout Tests
 
   Scenario: Checkout first item
     * print "1st item checkout start"
+    * def extItemBarcode = 'FAT-793IBC'
     * def checkOutResponse = call read('classpath:vega/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(extUserBarcode), extCheckOutItemBarcode: #(extItemBarcode) }
     * print "1st item checkout end"
 
 
   Scenario: Checkout Second item
     * print "2nd item checkout start"
+    * def extItemBarcode1 = 'FAT-593IBC'
     * def checkOutResponse = call read('classpath:vega/mod-circulation/features/util/initData.feature@PostCheckOut') { extCheckOutUserBarcode: #(extUserBarcode), extCheckOutItemBarcode: #(extItemBarcode1) }
     * print "2nd item checkout end"

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/samples/checkout-Lock-settings-request.json
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/samples/checkout-Lock-settings-request.json
@@ -1,0 +1,6 @@
+{
+  "id":"1e01066d-4bee-4cf7-926c-ba2c9c6c0098",
+  "scope": "mod-circulation",
+  "key":"checkoutLockFeature",
+  "value":"{\"checkOutLockFeatureEnabled\":true,\"noOfRetryAttempts\":50,\"retryInterval\":350,\"lockTtl\":30000}"
+}

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/samples/policies/loan-policy-entity-with-limit-request.json
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/samples/policies/loan-policy-entity-with-limit-request.json
@@ -1,0 +1,48 @@
+{
+  "id": "#(loanPolicyId)",
+  "name": "Example Loan Policy",
+  "description": "Can circulate item",
+  "loanable": true,
+  "renewable": true,
+  "loansPolicy": {
+    "profileId": "Rolling",
+    "period": {
+      "duration": 3,
+      "intervalId": "Weeks"
+    },
+    "closedLibraryDueDateManagementId": "CURRENT_DUE_DATE_TIME",
+    "itemLimit": 1
+  },
+  "renewalsPolicy": {
+    "renewFromId": "CURRENT_DUE_DATE",
+    "unlimited": true,
+    "differentPeriod": false
+  },
+  "requestManagement": {
+    "holds": {
+      "alternateRenewalLoanPeriod": {
+        "duration": 3,
+        "intervalId": "Weeks"
+      },
+      "renewItemsWithRequest": true
+    },
+    "recalls": {
+      "alternateGracePeriod": {
+        "duration": 1,
+        "intervalId": "Months"
+      },
+      "minimumGuaranteedLoanPeriod": {
+        "duration": 2,
+        "intervalId": "Weeks"
+      },
+      "recallReturnInterval": {
+        "duration": 3,
+        "intervalId": "Days"
+      },
+      "alternateRecallReturnInterval": {
+        "duration": 4,
+        "intervalId": "Hours"
+      }
+    }
+  }
+}

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/util/initData.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/util/initData.feature
@@ -187,6 +187,20 @@ Feature: init data for mod-circulation
     When method POST
     Then status 201
 
+  @PostLoanPolicyWithLimit
+  Scenario: create loan policy with limit
+    * def intLoanPolicyId = call uuid1
+
+    * def loanPolicyEntityRequest = read('samples/policies/loan-policy-entity-with-limit-request.json')
+    * loanPolicyEntityRequest.id = karate.get('extLoanPolicyId', intLoanPolicyId)
+    * loanPolicyEntityRequest.name = loanPolicyEntityRequest.name + ' ' + random_string()
+    Given path 'loan-policy-storage/loan-policies'
+    And request loanPolicyEntityRequest
+    When method POST
+    Then status 201
+
+
+
   @PostLostPolicy
   Scenario: create lost policy
     * def intLostItemPolicyId = call uuid1

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/util/initData.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/util/initData.feature
@@ -438,3 +438,11 @@ Feature: init data for mod-circulation
     And request { id: '#(id)', patronGroupId: '#(extGroupId)', conditionId: '#(pbcId)', value: '#(extValue)' }
     When method POST
     Then status 201
+
+  @PostSettings
+  Scenario: post create settings to enable checkOutLockFeature
+    * def checkoutLockSettingsRequest = read('classpath:vega/mod-circulation/features/samples/checkout-Lock-settings-request.json')
+    Given path 'settings/entries'
+    And request checkoutLockSettingsRequest
+    When method POST
+    Then status 204

--- a/mod-circulation/src/test/java/org/folio/ModCirculationTests.java
+++ b/mod-circulation/src/test/java/org/folio/ModCirculationTests.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
+
 @FolioTest(team = "vega", module = "mod-circulation")
 class ModCirculationTests extends TestBase {
 
@@ -30,5 +31,7 @@ class ModCirculationTests extends TestBase {
   @Test
   void rootTest() {
     runFeatureTest("root");
+    runFeatureTest("parallelCheckout",2);
   }
+
 }

--- a/mod-circulation/src/test/java/org/folio/ModCirculationTests.java
+++ b/mod-circulation/src/test/java/org/folio/ModCirculationTests.java
@@ -1,12 +1,17 @@
 package org.folio;
 
+import com.intuit.karate.Results;
+import com.intuit.karate.Runner;
 import org.folio.test.TestBase;
 import org.folio.test.annotation.FolioTest;
 import org.folio.test.config.TestModuleConfiguration;
 import org.folio.test.services.TestIntegrationService;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
 
 
 @FolioTest(team = "vega", module = "mod-circulation")
@@ -31,7 +36,28 @@ class ModCirculationTests extends TestBase {
   @Test
   void rootTest() {
     runFeatureTest("root");
-    runFeatureTest("parallelCheckout",2);
+  }
+
+  @Test
+  void runParallelTest() {
+    TestIntegrationService testIntegrationService = new TestIntegrationService(new TestModuleConfiguration(TEST_BASE_PATH));
+    String featureName = "parallelCheckout.feature";
+    Runner.Builder builder = Runner.path(testIntegrationService.getTestConfiguration()
+                    .getBasePath()
+                    .concat(featureName))
+            .outputHtmlReport(true)
+            .outputCucumberJson(true)
+            .outputJunitXml(true)
+            .tags("~@Ignore", "~@NoTestRail");
+    Results results = builder.parallel(2);
+    try {
+      testIntegrationService.generateReport(results.getReportDir());
+    } catch (IOException ex) {
+      logger.error("Error occurred during feature's report generation: {}", ex.getMessage());
+    }
+    testIntegrationService.addResult(featureName, results);
+    Assertions.assertEquals(1, results.getFailCount());
+    Assertions.assertTrue(results.getErrorMessages().contains("Patron has reached maximum limit of 1 items for material type"));
   }
 
 }


### PR DESCRIPTION
## Purpose
The purpose of the change is to test the fix of concurrency issue which is implemented as part of feature https://issues.folio.org/browse/UXPROD-3515 during checkout process.

## Approach
we are setting the loan limit as 1 and checking out two items in parallel. The system should allow only one item to do checkout and other item will get the Limit exceeded error when the feature is enabled. 
Note : If the feature is not enabled, behavior is inconsistent.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning

**Evidence :** Please find the behavior of the checkout by barcode API with / without feature flag enabled.


<img width="960" alt="Test_failed_without_feature flag" src="https://github.com/folio-org/folio-integration-tests/assets/125984866/292ebc91-2f89-4d01-89f9-db19d2808306">
<img width="960" alt="Test_passed_with_feature flag" src="https://github.com/folio-org/folio-integration-tests/assets/125984866/1eea1dc1-3817-4a61-a7fc-275a300465ae">
 