### PR TITLE
Draft to use existing tenant

### DIFF
--- a/acquisitions/src/main/resources/karate-config.js
+++ b/acquisitions/src/main/resources/karate-config.js
@@ -6,8 +6,8 @@ function fn() {
   var env = karate.env;
 
   // The "testTenant" property could be specified during test runs
-  var testTenant = karate.properties['testTenant'];
-  var useExistingTenant = karate.properties['useExistingTenant'];
+  var testTenant = karate.properties['existingTenant'] ? karate.properties['existingTenant'] : karate.properties['testTenant'];
+  var useExistingTenant = karate.properties['useExistingTenant'] ? karate.properties['useExistingTenant'] : false;
 
   var config = {
     baseUrl: 'http://localhost:9130',
@@ -104,7 +104,6 @@ function fn() {
         password: '${admin.password}'
       }
       config.prototypeTenant = '${prototypeTenant}';
-      config.testTenant = '${existingTenant}';
       karate.configure('ssl',true);
     } else if (env == 'snapshot-2') {
     config.baseUrl = 'https://folio-snapshot-2-okapi.dev.folio.org:443';

--- a/acquisitions/src/main/resources/karate-config.js
+++ b/acquisitions/src/main/resources/karate-config.js
@@ -7,6 +7,7 @@ function fn() {
 
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
+  var useExistingTenant = karate.properties['useExistingTenant'];
 
   var config = {
     baseUrl: 'http://localhost:9130',
@@ -19,6 +20,7 @@ function fn() {
     prototypeTenant: 'diku',
 
     testTenant: testTenant ? testTenant: 'testTenant',
+    useExistingTenant: useExistingTenant ? useExistingTenant: false,
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},
     testUser: {tenant: testTenant, name: 'test-user', password: 'test'},
 
@@ -93,7 +95,18 @@ function fn() {
   }
   karate.repeat(100, rand);
 
-  if (env == 'snapshot-2') {
+  if(useExistingTenant) {
+      config.baseUrl = '${baseUrl}';
+      config.edgeUrl = '${edgeUrl}';
+      config.admin = {
+        tenant: '${admin.tenant}',
+        name: '${admin.name}',
+        password: '${admin.password}'
+      }
+      config.prototypeTenant = '${prototypeTenant}';
+      config.testTenant = '${existingTenant}';
+      karate.configure('ssl',true);
+    } else if (env == 'snapshot-2') {
     config.baseUrl = 'https://folio-snapshot-2-okapi.dev.folio.org:443';
     config.edgeUrl = 'https://folio-snapshot-2.dev.folio.org:8000';
     config.ftpUrl = 'ftp://ftp.ci.folio.org';

--- a/common/src/main/resources/common/destroy-data.feature
+++ b/common/src/main/resources/common/destroy-data.feature
@@ -7,7 +7,7 @@ Feature: destroy data for tenant
     * callonce login admin
 
   Scenario: purge all modules for tenant
-
+    * if (useExistingTenant) karate.abort()
     Given path '_/proxy/tenants', testUser.tenant, 'modules'
     And header Content-Type = 'application/json'
     And header Accept = 'application/json'
@@ -28,5 +28,6 @@ Feature: destroy data for tenant
     Then status 200
 
   Scenario: delete tenant
+    * if (useExistingTenant) karate.abort()
     Given call read('classpath:common/tenant.feature@delete') { tenant: '#(testUser.tenant)'}
 

--- a/common/src/main/resources/common/tenant.feature
+++ b/common/src/main/resources/common/tenant.feature
@@ -6,6 +6,7 @@ Feature: Tenants
 
   @create
   Scenario: createTenant
+    * if (useExistingTenant) karate.abort()
     Given path '_/proxy/tenants'
     And header Content-Type = 'application/json'
     And header Accept = 'application/json'
@@ -16,7 +17,7 @@ Feature: Tenants
 
   @install
   Scenario: install tenant for modules
-
+    * if (useExistingTenant) karate.abort()
     * def response = call read('classpath:common/module.feature') __arg.modules
 
     * def modulesWithVersions = $response[*].response[-1].id
@@ -37,6 +38,7 @@ Feature: Tenants
 
   @delete
   Scenario: deleteTenant
+    * if (useExistingTenant) karate.abort()
     Given path '_/proxy/tenants', __arg.tenant
     And header Content-Type = 'application/json'
     And header Accept = 'application/json'


### PR DESCRIPTION
## Purpose
We need to run Karate tests against existing tenants.

## Approach
Introduce 2 new variables called:
- _'existingTenant'_ - name of the tenant which we need to run tests against;
- _'useExistingTenant'_ - flag to notify we are using existing tenant. If this variable is _true_ then all operations that changes tenant state (posting new tenant, enabling or disabling modules for tenant, ... ) will be skipped 

### TODOS and Open Questions
- [ ] Most of the modules use features in [common](https://github.com/folio-org/folio-integration-tests/tree/master/common/src/main/resources/common) to set up the environment/tenant, but not all. So need to look through all the test files to identify if there is a request to change tenant state directly (without using 'common');
- [ ] Most of the modules use global variables for set up, and there are constraints for uniqueness, e.g. unique_name, unique_id, ... . So after running one module any other subsequent test runs will fail in set up because of these duplicate values. 
![image](https://github.com/folio-org/folio-integration-tests/assets/112848437/acae13d4-af91-40fd-948a-7bacd0d45fd5)

 
### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
