### PR TITLE
FAT-7004: renaming material type

### DIFF
--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/util/initData.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/util/initData.feature
@@ -143,6 +143,7 @@ Feature: init data for mod-circulation
   @PostMaterialType
   Scenario: create material type
     * def intMaterialTypeId = call uuid1
+    * def materialTypeName = call random_string
     * def materialTypeEntityRequest = read('samples/item/material-type-entity-request.json')
     * materialTypeEntityRequest.id = karate.get('extMaterialTypeId', intMaterialTypeId)
     * materialTypeEntityRequest.name = karate.get('extMaterialTypeName', materialTypeName)


### PR DESCRIPTION
This error is being caused by a name collision between tests in root.feature and initData.feature.  Both are trying to create a material type with the name "Book."  But you cannot have two material types with identical names.  So I've changed the initData.feature test to use a random string as the material type name.  the root.feature test relies more on the name, which is present in sample data files, so changing it there would have ripple effects on other tests.