### PR TITLE
FAT-6493: actualize match rules JSON according to SRM response

### DIFF
--- a/data-import/src/main/resources/folijet/data-import/samples/samples_for_upload/default-marc-bib-rules.json
+++ b/data-import/src/main/resources/folijet/data-import/samples/samples_for_upload/default-marc-bib-rules.json
@@ -1,33 +1,33 @@
 {
   "001": [
     {
+      "rules": [
+      ],
       "target": "hrid",
-      "description": "The human readable ID",
-      "subfield": [],
-      "rules": []
+      "subfield": [
+      ],
+      "description": "The human readable ID"
     },
     {
-      "target": "modeOfIssuanceId",
-      "description": "",
-      "subfield": [],
       "rules": [
         {
-          "description": "Issuance mode based on 7 leader`s byte",
           "conditions": [
             {
-              "type": "set_issuance_mode_id",
-              "LDR": true
+              "LDR": true,
+              "type": "set_issuance_mode_id"
             }
-          ]
+          ],
+          "description": "Issuance mode based on 7 leader`s byte"
         }
-      ]
+      ],
+      "target": "modeOfIssuanceId",
+      "subfield": [
+      ],
+      "description": ""
     }
   ],
   "008": [
     {
-      "target": "instanceTypeId",
-      "description": "Default Unspecified Instance type in case when no 336 field present",
-      "subfield": [],
       "rules": [
         {
           "conditions": [
@@ -39,48 +39,49 @@
             }
           ]
         }
-      ]
+      ],
+      "target": "instanceTypeId",
+      "subfield": [
+      ],
+      "description": "Default Unspecified Instance type in case when no 336 field present"
     },
     {
-      "target": "source",
-      "description": "Source of instance record",
-      "subfield": [],
       "rules": [
         {
-          "conditions": [],
-          "value": "MARC21"
+          "value": "MARC21",
+          "conditions": [
+          ]
         }
-      ]
+      ],
+      "target": "source",
+      "subfield": [
+      ],
+      "description": "Source of instance record"
     },
     {
-      "target": "languages",
-      "description": "Language code",
-      "subfield": [],
       "rules": [
         {
           "conditions": [
             {
               "type": "char_select",
               "parameter": {
-                "from": 35,
-                "to": 38
+                "to": 38,
+                "from": 35
               }
             }
           ]
         }
-      ]
+      ],
+      "target": "languages",
+      "subfield": [
+      ],
+      "description": "Language code"
     }
   ],
   "010": [
     {
-      "entityPerRepeatedSubfield": true,
       "entity": [
         {
-          "target": "identifiers.identifierTypeId",
-          "description": "Type for LCCN",
-          "subfield": [
-            "a"
-          ],
           "rules": [
             {
               "conditions": [
@@ -92,14 +93,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "identifiers.value",
-          "description": "LCCN",
+          ],
+          "target": "identifiers.identifierTypeId",
           "subfield": [
             "a"
           ],
+          "description": "Type for LCCN"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -108,21 +109,21 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "identifiers.value",
+          "subfield": [
+            "a"
+          ],
+          "description": "LCCN"
         }
-      ]
+      ],
+      "entityPerRepeatedSubfield": true
     }
   ],
   "019": [
     {
-      "entityPerRepeatedSubfield": true,
       "entity": [
         {
-          "target": "identifiers.identifierTypeId",
-          "description": "Type for Cancelled system control number",
-          "subfield": [
-            "a"
-          ],
           "rules": [
             {
               "conditions": [
@@ -134,14 +135,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "identifiers.value",
-          "description": "Cancelled system control number",
+          ],
+          "target": "identifiers.identifierTypeId",
           "subfield": [
             "a"
           ],
+          "description": "Type for Cancelled system control number"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -150,21 +151,21 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "identifiers.value",
+          "subfield": [
+            "a"
+          ],
+          "description": "Cancelled system control number"
         }
-      ]
+      ],
+      "entityPerRepeatedSubfield": true
     }
   ],
   "020": [
     {
-      "entityPerRepeatedSubfield": true,
       "entity": [
         {
-          "target": "identifiers.identifierTypeId",
-          "description": "Type for Valid ISBN",
-          "subfield": [
-            "a"
-          ],
           "rules": [
             {
               "conditions": [
@@ -176,14 +177,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "identifiers.value",
-          "description": "Valid ISBN",
+          ],
+          "target": "identifiers.identifierTypeId",
           "subfield": [
             "a"
           ],
+          "description": "Type for Valid ISBN"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -191,7 +192,8 @@
                   "type": "concat_subfields_by_name, remove_ending_punc,trim",
                   "parameter": {
                     "subfieldsToConcat": [
-                      "c", "q"
+                      "c",
+                      "q"
                     ],
                     "subfieldsToStopConcat": [
                       "z"
@@ -200,19 +202,19 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "identifiers.value",
+          "subfield": [
+            "a"
+          ],
+          "description": "Valid ISBN"
         }
-      ]
+      ],
+      "entityPerRepeatedSubfield": true
     },
     {
-      "entityPerRepeatedSubfield": true,
       "entity": [
         {
-          "target": "identifiers.identifierTypeId",
-          "description": "Type for Invalid ISBN",
-          "subfield": [
-            "z"
-          ],
           "rules": [
             {
               "conditions": [
@@ -224,14 +226,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "identifiers.value",
-          "description": "Invalid ISBN",
+          ],
+          "target": "identifiers.identifierTypeId",
           "subfield": [
             "z"
           ],
+          "description": "Type for Invalid ISBN"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -239,7 +241,8 @@
                   "type": "concat_subfields_by_name, remove_ending_punc,trim",
                   "parameter": {
                     "subfieldsToConcat": [
-                      "q", "c"
+                      "q",
+                      "c"
                     ],
                     "subfieldsToStopConcat": [
                       "a"
@@ -248,21 +251,21 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "identifiers.value",
+          "subfield": [
+            "z"
+          ],
+          "description": "Invalid ISBN"
         }
-      ]
+      ],
+      "entityPerRepeatedSubfield": true
     }
   ],
   "022": [
     {
-      "entityPerRepeatedSubfield": true,
       "entity": [
         {
-          "target": "identifiers.identifierTypeId",
-          "description": "Type for ISSN",
-          "subfield": [
-            "a"
-          ],
           "rules": [
             {
               "conditions": [
@@ -274,14 +277,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "identifiers.value",
-          "description": "ISSN",
+          ],
+          "target": "identifiers.identifierTypeId",
           "subfield": [
             "a"
           ],
+          "description": "Type for ISSN"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -290,21 +293,19 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "identifiers.value",
+          "subfield": [
+            "a"
+          ],
+          "description": "ISSN"
         }
-      ]
+      ],
+      "entityPerRepeatedSubfield": true
     },
     {
-      "entityPerRepeatedSubfield": true,
       "entity": [
         {
-          "target": "identifiers.identifierTypeId",
-          "description": "Type for Invalid ISSN",
-          "subfield": [
-            "y",
-            "z",
-            "m"
-          ],
           "rules": [
             {
               "conditions": [
@@ -316,16 +317,16 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "identifiers.value",
-          "description": "Invalid ISSN",
+          ],
+          "target": "identifiers.identifierTypeId",
           "subfield": [
             "y",
             "z",
             "m"
           ],
+          "description": "Type for Invalid ISSN"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -334,19 +335,21 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "identifiers.value",
+          "subfield": [
+            "y",
+            "z",
+            "m"
+          ],
+          "description": "Invalid ISSN"
         }
-      ]
+      ],
+      "entityPerRepeatedSubfield": true
     },
     {
-      "entityPerRepeatedSubfield": true,
       "entity": [
         {
-          "target": "identifiers.identifierTypeId",
-          "description": "Type for Linking ISSN",
-          "subfield": [
-            "l"
-          ],
           "rules": [
             {
               "conditions": [
@@ -358,14 +361,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "identifiers.value",
-          "description": "Linking ISSN",
+          ],
+          "target": "identifiers.identifierTypeId",
           "subfield": [
             "l"
           ],
+          "description": "Type for Linking ISSN"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -374,26 +377,21 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "identifiers.value",
+          "subfield": [
+            "l"
+          ],
+          "description": "Linking ISSN"
         }
-      ]
+      ],
+      "entityPerRepeatedSubfield": true
     }
   ],
   "024": [
     {
       "entity": [
         {
-          "target": "identifiers.identifierTypeId",
-          "description": "Type for Other Standard Identifier",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "a",
-            "c",
-            "d",
-            "q",
-            "z",
-            "2"
-          ],
           "rules": [
             {
               "conditions": [
@@ -405,12 +403,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "identifiers.value",
-          "description": "Other Standard Identifier",
-          "applyRulesOnConcatenatedData": true,
+          ],
+          "target": "identifiers.identifierTypeId",
           "subfield": [
             "a",
             "c",
@@ -419,6 +413,10 @@
             "z",
             "2"
           ],
+          "description": "Type for Other Standard Identifier",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -427,22 +425,24 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "identifiers.value",
+          "subfield": [
+            "a",
+            "c",
+            "d",
+            "q",
+            "z",
+            "2"
+          ],
+          "description": "Other Standard Identifier",
+          "applyRulesOnConcatenatedData": true
         }
       ]
     },
     {
-      "indicators": {
-        "ind1": "2",
-        "ind2": "*"
-      },
       "entity": [
         {
-          "target": "identifiers.identifierTypeId",
-          "description": "Type for Resource identifier types",
-          "subfield": [
-            "a"
-          ],
           "rules": [
             {
               "conditions": [
@@ -454,14 +454,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "identifiers.value",
-          "description": "ISMN",
+          ],
+          "target": "identifiers.identifierTypeId",
           "subfield": [
             "a"
           ],
+          "description": "Type for Resource identifier types"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -475,23 +475,22 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "identifiers.value",
+          "subfield": [
+            "a"
+          ],
+          "description": "ISMN"
         }
-      ]
-    },
-    {
+      ],
       "indicators": {
         "ind1": "2",
         "ind2": "*"
-      },
-      "entityPerRepeatedSubfield": true,
+      }
+    },
+    {
       "entity": [
         {
-          "target": "identifiers.identifierTypeId",
-          "description": "Type for Resource identifier types",
-          "subfield": [
-            "z"
-          ],
           "rules": [
             {
               "conditions": [
@@ -503,14 +502,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "identifiers.value",
-          "description": "Invalid ISMN",
+          ],
+          "target": "identifiers.identifierTypeId",
           "subfield": [
             "z"
           ],
+          "description": "Type for Resource identifier types"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -524,22 +523,23 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "identifiers.value",
+          "subfield": [
+            "z"
+          ],
+          "description": "Invalid ISMN"
         }
-      ]
-    },
-    {
+      ],
       "indicators": {
-        "ind1": "1",
+        "ind1": "2",
         "ind2": "*"
       },
+      "entityPerRepeatedSubfield": true
+    },
+    {
       "entity": [
         {
-          "target": "identifiers.identifierTypeId",
-          "description": "Type for Resource identifier types",
-          "subfield": [
-            "a"
-          ],
           "rules": [
             {
               "conditions": [
@@ -551,14 +551,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "identifiers.value",
-          "description": "UPC",
+          ],
+          "target": "identifiers.identifierTypeId",
           "subfield": [
             "a"
           ],
+          "description": "Type for Resource identifier types"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -572,23 +572,22 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "identifiers.value",
+          "subfield": [
+            "a"
+          ],
+          "description": "UPC"
         }
-      ]
-    },
-    {
+      ],
       "indicators": {
         "ind1": "1",
         "ind2": "*"
-      },
-      "entityPerRepeatedSubfield": true,
+      }
+    },
+    {
       "entity": [
         {
-          "target": "identifiers.identifierTypeId",
-          "description": "Type for Resource identifier types",
-          "subfield": [
-            "z"
-          ],
           "rules": [
             {
               "conditions": [
@@ -600,14 +599,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "identifiers.value",
-          "description": "Invalid UPC",
+          ],
+          "target": "identifiers.identifierTypeId",
           "subfield": [
             "z"
           ],
+          "description": "Type for Resource identifier types"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -621,23 +620,25 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "identifiers.value",
+          "subfield": [
+            "z"
+          ],
+          "description": "Invalid UPC"
         }
-      ]
+      ],
+      "indicators": {
+        "ind1": "1",
+        "ind2": "*"
+      },
+      "entityPerRepeatedSubfield": true
     }
   ],
   "028": [
     {
       "entity": [
         {
-          "target": "identifiers.identifierTypeId",
-          "description": "Type for Publisher Number",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "a",
-            "b",
-            "q"
-          ],
           "rules": [
             {
               "conditions": [
@@ -649,17 +650,17 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "identifiers.value",
-          "description": "Publisher Number",
-          "applyRulesOnConcatenatedData": true,
+          ],
+          "target": "identifiers.identifierTypeId",
           "subfield": [
             "a",
             "b",
             "q"
           ],
+          "description": "Type for Publisher Number",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -668,21 +669,23 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "identifiers.value",
+          "subfield": [
+            "a",
+            "b",
+            "q"
+          ],
+          "description": "Publisher Number",
+          "applyRulesOnConcatenatedData": true
         }
       ]
     }
   ],
   "035": [
     {
-      "entityPerRepeatedSubfield": true,
       "entity": [
         {
-          "target": "identifiers.identifierTypeId",
-          "description": "Type for System Control Number",
-          "subfield": [
-            "a"
-          ],
           "rules": [
             {
               "conditions": [
@@ -698,26 +701,26 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "identifiers.identifierTypeId",
+          "subfield": [
+            "a"
+          ],
+          "description": "Type for System Control Number"
         },
         {
           "target": "identifiers.value",
-          "description": "System Control Number",
           "subfield": [
             "a"
-          ]
+          ],
+          "description": "System Control Number"
         }
-      ]
+      ],
+      "entityPerRepeatedSubfield": true
     },
     {
-      "entityPerRepeatedSubfield": true,
       "entity": [
         {
-          "target": "identifiers.identifierTypeId",
-          "description": "Type for Cancelled system control number",
-          "subfield": [
-            "z"
-          ],
           "rules": [
             {
               "conditions": [
@@ -729,14 +732,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "identifiers.value",
-          "description": "Cancelled system control number",
+          ],
+          "target": "identifiers.identifierTypeId",
           "subfield": [
             "z"
           ],
+          "description": "Type for Cancelled system control number"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -745,39 +748,39 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "identifiers.value",
+          "subfield": [
+            "z"
+          ],
+          "description": "Cancelled system control number"
         }
-      ]
+      ],
+      "entityPerRepeatedSubfield": true
     }
   ],
   "041": [
     {
-      "entityPerRepeatedSubfield": true,
       "entity": [
         {
           "target": "languages",
-          "description": "Language code",
           "subfield": [
             "a"
           ],
+          "description": "Language code",
           "subFieldSplit": {
             "type": "split_every",
             "value": "3"
           }
         }
-      ]
+      ],
+      "entityPerRepeatedSubfield": true
     }
   ],
   "050": [
     {
-      "entityPerRepeatedSubfield": true,
       "entity": [
         {
-          "target": "classifications.classificationTypeId",
-          "description": "Type for LC classification",
-          "subfield": [
-            "a"
-          ],
           "rules": [
             {
               "conditions": [
@@ -789,14 +792,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "classifications.classificationNumber",
-          "description": "LC classification",
+          ],
+          "target": "classifications.classificationTypeId",
           "subfield": [
             "a"
           ],
+          "description": "Type for LC classification"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -810,21 +813,21 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "classifications.classificationNumber",
+          "subfield": [
+            "a"
+          ],
+          "description": "LC classification"
         }
-      ]
+      ],
+      "entityPerRepeatedSubfield": true
     }
   ],
   "060": [
     {
-      "entityPerRepeatedSubfield": true,
       "entity": [
         {
-          "target": "classifications.classificationTypeId",
-          "description": "Type for NLM classification",
-          "subfield": [
-            "a"
-          ],
           "rules": [
             {
               "conditions": [
@@ -836,14 +839,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "classifications.classificationNumber",
-          "description": "NLM classification",
+          ],
+          "target": "classifications.classificationTypeId",
           "subfield": [
             "a"
           ],
+          "description": "Type for NLM classification"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -857,21 +860,21 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "classifications.classificationNumber",
+          "subfield": [
+            "a"
+          ],
+          "description": "NLM classification"
         }
-      ]
+      ],
+      "entityPerRepeatedSubfield": true
     }
   ],
   "074": [
     {
-      "entityPerRepeatedSubfield": true,
       "entity": [
         {
-          "target": "identifiers.identifierTypeId",
-          "description": "Type for GPO Item Number",
-          "subfield": [
-            "a"
-          ],
           "rules": [
             {
               "conditions": [
@@ -883,14 +886,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "identifiers.value",
-          "description": "GPO Item Number",
+          ],
+          "target": "identifiers.identifierTypeId",
           "subfield": [
             "a"
           ],
+          "description": "Type for GPO Item Number"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -899,19 +902,19 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "identifiers.value",
+          "subfield": [
+            "a"
+          ],
+          "description": "GPO Item Number"
         }
-      ]
+      ],
+      "entityPerRepeatedSubfield": true
     },
     {
-      "entityPerRepeatedSubfield": true,
       "entity": [
         {
-          "target": "identifiers.identifierTypeId",
-          "description": "Type for Cancelled GPO Item Number",
-          "subfield": [
-            "z"
-          ],
           "rules": [
             {
               "conditions": [
@@ -923,14 +926,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "identifiers.value",
-          "description": "Cancelled GPO Item Number",
+          ],
+          "target": "identifiers.identifierTypeId",
           "subfield": [
             "z"
           ],
+          "description": "Type for Cancelled GPO Item Number"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -939,22 +942,21 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "identifiers.value",
+          "subfield": [
+            "z"
+          ],
+          "description": "Cancelled GPO Item Number"
         }
-      ]
+      ],
+      "entityPerRepeatedSubfield": true
     }
   ],
   "080": [
     {
       "entity": [
         {
-          "target": "classifications.classificationTypeId",
-          "description": "Type for UDC classification",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "a",
-            "b"
-          ],
           "rules": [
             {
               "conditions": [
@@ -966,30 +968,31 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "classifications.classificationNumber",
-          "description": "UDC classification",
-          "applyRulesOnConcatenatedData": true,
+          ],
+          "target": "classifications.classificationTypeId",
           "subfield": [
             "a",
             "b"
-          ]
+          ],
+          "description": "Type for UDC classification",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "target": "classifications.classificationNumber",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "description": "UDC classification",
+          "applyRulesOnConcatenatedData": true
         }
       ]
     }
   ],
   "082": [
     {
-      "entityPerRepeatedSubfield": true,
       "entity": [
         {
-          "target": "classifications.classificationTypeId",
-          "description": "Type for Dewey classification",
-          "subfield": [
-            "a"
-          ],
           "rules": [
             {
               "conditions": [
@@ -1001,14 +1004,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "classifications.classificationNumber",
-          "description": "Dewey classification",
+          ],
+          "target": "classifications.classificationTypeId",
           "subfield": [
             "a"
           ],
+          "description": "Type for Dewey classification"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -1023,22 +1026,21 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "classifications.classificationNumber",
+          "subfield": [
+            "a"
+          ],
+          "description": "Dewey classification"
         }
-      ]
+      ],
+      "entityPerRepeatedSubfield": true
     }
   ],
   "086": [
     {
-      "entityPerRepeatedSubfield": true,
       "entity": [
         {
-          "target": "classifications.classificationTypeId",
-          "description": "Type for gov doc classification",
-          "subfield": [
-            "a",
-            "z"
-          ],
           "rules": [
             {
               "conditions": [
@@ -1050,29 +1052,30 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "classifications.classificationNumber",
-          "description": "Gov doc classification",
+          ],
+          "target": "classifications.classificationTypeId",
           "subfield": [
             "a",
             "z"
-          ]
+          ],
+          "description": "Type for gov doc classification"
+        },
+        {
+          "target": "classifications.classificationNumber",
+          "subfield": [
+            "a",
+            "z"
+          ],
+          "description": "Gov doc classification"
         }
-      ]
+      ],
+      "entityPerRepeatedSubfield": true
     }
   ],
   "090": [
     {
-      "entityPerRepeatedSubfield": true,
       "entity": [
         {
-          "target": "classifications.classificationTypeId",
-          "description": "Type for LC classification",
-          "subfield": [
-            "a"
-          ],
           "rules": [
             {
               "conditions": [
@@ -1084,14 +1087,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "classifications.classificationNumber",
-          "description": "LC classification",
+          ],
+          "target": "classifications.classificationTypeId",
           "subfield": [
             "a"
           ],
+          "description": "Type for LC classification"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -1105,9 +1108,15 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "classifications.classificationNumber",
+          "subfield": [
+            "a"
+          ],
+          "description": "LC classification"
         }
-      ]
+      ],
+      "entityPerRepeatedSubfield": true
     }
   ],
   "100": [
@@ -1115,18 +1124,13 @@
       "entity": [
         {
           "target": "contributors.authorityId",
-          "description": "Authority ID that controlling the contributor",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.contributorNameTypeId",
-          "description": "Type for Personal Name",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-          ],
           "rules": [
             {
               "conditions": [
@@ -1138,7 +1142,12 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "contributors.contributorNameTypeId",
+          "subfield": [
+          ],
+          "description": "Type for Personal Name",
+          "applyRulesOnConcatenatedData": true
         },
         {
           "rules": [
@@ -1170,21 +1179,30 @@
           "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.primary",
-          "description": "Primary contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-          ],
           "rules": [
             {
-              "conditions": [],
-              "value": "true"
+              "value": "true",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "contributors.primary",
+          "subfield": [
+          ],
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true
         },
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_punctuation"
+                }
+              ]
+            }
+          ],
           "target": "contributors.name",
-          "description": "Personal Name",
           "subfield": [
             "a",
             "b",
@@ -1201,16 +1219,8 @@
             "t",
             "u"
           ],
-          "applyRulesOnConcatenatedData": true,
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
-            }
-          ]
+          "description": "Personal Name",
+          "applyRulesOnConcatenatedData": true
         }
       ]
     }
@@ -1220,18 +1230,13 @@
       "entity": [
         {
           "target": "contributors.authorityId",
-          "description": "Authority ID that controlling the contributor",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.contributorNameTypeId",
-          "description": "Type for Corporate Name",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-          ],
           "rules": [
             {
               "conditions": [
@@ -1243,7 +1248,12 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "contributors.contributorNameTypeId",
+          "subfield": [
+          ],
+          "description": "Type for Corporate Name",
+          "applyRulesOnConcatenatedData": true
         },
         {
           "rules": [
@@ -1275,21 +1285,30 @@
           "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.primary",
-          "description": "Primary contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-          ],
           "rules": [
             {
-              "conditions": [],
-              "value": "true"
+              "value": "true",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "contributors.primary",
+          "subfield": [
+          ],
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true
         },
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_punctuation"
+                }
+              ]
+            }
+          ],
           "target": "contributors.name",
-          "description": "Corporate Name",
           "subfield": [
             "a",
             "b",
@@ -1304,16 +1323,8 @@
             "t",
             "u"
           ],
-          "applyRulesOnConcatenatedData": true,
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
-            }
-          ]
+          "description": "Corporate Name",
+          "applyRulesOnConcatenatedData": true
         }
       ]
     }
@@ -1323,18 +1334,13 @@
       "entity": [
         {
           "target": "contributors.authorityId",
-          "description": "Authority ID that controlling the contributor",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.contributorNameTypeId",
-          "description": "Type for Meeting Name",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-          ],
           "rules": [
             {
               "conditions": [
@@ -1346,7 +1352,12 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "contributors.contributorNameTypeId",
+          "subfield": [
+          ],
+          "description": "Type for Meeting Name",
+          "applyRulesOnConcatenatedData": true
         },
         {
           "rules": [
@@ -1378,21 +1389,30 @@
           "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.primary",
-          "description": "Primary contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-          ],
           "rules": [
             {
-              "conditions": [],
-              "value": "true"
+              "value": "true",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "contributors.primary",
+          "subfield": [
+          ],
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true
         },
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_punctuation"
+                }
+              ]
+            }
+          ],
           "target": "contributors.name",
-          "description": "Meeting Name",
           "subfield": [
             "a",
             "b",
@@ -1407,16 +1427,8 @@
             "t",
             "u"
           ],
-          "applyRulesOnConcatenatedData": true,
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
-            }
-          ]
+          "description": "Meeting Name",
+          "applyRulesOnConcatenatedData": true
         }
       ]
     }
@@ -1425,25 +1437,6 @@
     {
       "entity": [
         {
-          "target": "alternativeTitles.alternativeTitleTypeId",
-          "description": "Alternative Title id",
-          "subfield": [
-            "a",
-            "n",
-            "p",
-            "d",
-            "f",
-            "g",
-            "h",
-            "k",
-            "l",
-            "m",
-            "o",
-            "r",
-            "s",
-            "t"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -1455,11 +1448,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "alternativeTitles.alternativeTitle",
-          "description": "Alternative Title",
+          ],
+          "target": "alternativeTitles.alternativeTitleTypeId",
           "subfield": [
             "a",
             "n",
@@ -1476,7 +1466,10 @@
             "s",
             "t"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Alternative Title id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -1485,14 +1478,33 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "alternativeTitles.alternativeTitle",
+          "subfield": [
+            "a",
+            "n",
+            "p",
+            "d",
+            "f",
+            "g",
+            "h",
+            "k",
+            "l",
+            "m",
+            "o",
+            "r",
+            "s",
+            "t"
+          ],
+          "description": "Alternative Title",
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "alternativeTitles.authorityId",
-          "description": "Authority ID that controlling the alternative title",
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the alternative title"
         }
       ]
     }
@@ -1501,24 +1513,6 @@
     {
       "entity": [
         {
-          "target": "alternativeTitles.alternativeTitleTypeId",
-          "description": "Alternative Title id",
-          "subfield": [
-            "a",
-            "n",
-            "p",
-            "d",
-            "f",
-            "g",
-            "h",
-            "k",
-            "l",
-            "m",
-            "o",
-            "r",
-            "s"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -1530,11 +1524,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "alternativeTitles.alternativeTitle",
-          "description": "Alternative Title",
+          ],
+          "target": "alternativeTitles.alternativeTitleTypeId",
           "subfield": [
             "a",
             "n",
@@ -1550,7 +1541,10 @@
             "r",
             "s"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Alternative Title id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -1559,14 +1553,32 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "alternativeTitles.alternativeTitle",
+          "subfield": [
+            "a",
+            "n",
+            "p",
+            "d",
+            "f",
+            "g",
+            "h",
+            "k",
+            "l",
+            "m",
+            "o",
+            "r",
+            "s"
+          ],
+          "description": "Alternative Title",
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "alternativeTitles.authorityId",
-          "description": "Authority ID that controlling the alternative title",
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the alternative title"
         }
       ]
     }
@@ -1574,8 +1586,6 @@
   "245": [
     {
       "target": "title",
-      "description": "Resource Title",
-      "applyRulesOnConcatenatedData": true,
       "subfield": [
         "a",
         "n",
@@ -1587,18 +1597,11 @@
         "h",
         "k",
         "s"
-      ]
+      ],
+      "description": "Resource Title",
+      "applyRulesOnConcatenatedData": true
     },
     {
-      "target": "indexTitle",
-      "description": "Index title",
-      "applyRulesOnConcatenatedData": true,
-      "subfield": [
-        "a",
-        "n",
-        "p",
-        "b"
-      ],
       "rules": [
         {
           "conditions": [
@@ -1607,26 +1610,22 @@
             }
           ]
         }
-      ]
+      ],
+      "target": "indexTitle",
+      "subfield": [
+        "a",
+        "n",
+        "p",
+        "b"
+      ],
+      "description": "Index title",
+      "applyRulesOnConcatenatedData": true
     }
   ],
   "246": [
     {
       "entity": [
         {
-          "target": "alternativeTitles.alternativeTitleTypeId",
-          "description": "Alternative Title id",
-          "subfield": [
-            "a",
-            "n",
-            "p",
-            "b",
-            "f",
-            "g",
-            "h",
-            "5"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -1638,11 +1637,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "alternativeTitles.alternativeTitle",
-          "description": "Alternative Title",
+          ],
+          "target": "alternativeTitles.alternativeTitleTypeId",
           "subfield": [
             "a",
             "n",
@@ -1653,7 +1649,10 @@
             "h",
             "5"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Alternative Title id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -1662,24 +1661,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "alternativeTitles.authorityId",
-          "description": "Authority ID that controlling the alternative title",
-          "subfield": [
-            "9"
-          ]
-        }
-      ]
-    }
-  ],
-  "247": [
-    {
-      "entity": [
-        {
-          "target": "alternativeTitles.alternativeTitleTypeId",
-          "description": "Alternative Title id",
+          ],
+          "target": "alternativeTitles.alternativeTitle",
           "subfield": [
             "a",
             "n",
@@ -1688,9 +1671,25 @@
             "f",
             "g",
             "h",
-            "x"
+            "5"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Alternative Title",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "target": "alternativeTitles.authorityId",
+          "subfield": [
+            "9"
+          ],
+          "description": "Authority ID that controlling the alternative title"
+        }
+      ]
+    }
+  ],
+  "247": [
+    {
+      "entity": [
+        {
           "rules": [
             {
               "conditions": [
@@ -1702,11 +1701,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "alternativeTitles.alternativeTitle",
-          "description": "Former title",
+          ],
+          "target": "alternativeTitles.alternativeTitleTypeId",
           "subfield": [
             "a",
             "n",
@@ -1717,7 +1713,10 @@
             "h",
             "x"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Alternative Title id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -1726,27 +1725,33 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "alternativeTitles.alternativeTitle",
+          "subfield": [
+            "a",
+            "n",
+            "p",
+            "b",
+            "f",
+            "g",
+            "h",
+            "x"
+          ],
+          "description": "Former title",
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "alternativeTitles.authorityId",
-          "description": "Authority ID that controlling the alternative title",
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the alternative title"
         }
       ]
     }
   ],
   "250": [
     {
-      "target": "editions",
-      "description": "Edition",
-      "subfield": [
-        "a",
-        "b"
-      ],
-      "applyRulesOnConcatenatedData": true,
       "rules": [
         {
           "conditions": [
@@ -1755,25 +1760,20 @@
             }
           ]
         }
-      ]
+      ],
+      "target": "editions",
+      "subfield": [
+        "a",
+        "b"
+      ],
+      "description": "Edition",
+      "applyRulesOnConcatenatedData": true
     }
   ],
   "255": [
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -1785,11 +1785,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Cartographic Mathematical Data",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -1799,7 +1796,10 @@
             "f",
             "g"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -1808,11 +1808,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -1822,31 +1819,34 @@
             "f",
             "g"
           ],
+          "description": "Cartographic Mathematical Data",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
   ],
   "260": [
     {
-      "target": "publication.place",
-      "description": "Place of publication",
-      "subfield": [
-        "a"
-      ],
-      "subFieldDelimiter": [
-        {
-          "value": " ; ",
-          "subfields": [
-            "a"
-          ]
-        }
-      ],
       "rules": [
         {
           "conditions": [
@@ -1855,9 +1855,31 @@
             }
           ]
         }
+      ],
+      "target": "publication.place",
+      "subfield": [
+        "a"
+      ],
+      "description": "Place of publication",
+      "subFieldDelimiter": [
+        {
+          "value": " ; ",
+          "subfields": [
+            "a"
+          ]
+        }
       ]
     },
     {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ],
       "target": "publication.publisher",
       "subfield": [
         "b"
@@ -1869,18 +1891,18 @@
             "b"
           ]
         }
-      ],
+      ]
+    },
+    {
       "rules": [
         {
           "conditions": [
             {
-              "type": "remove_ending_punc, trim"
+              "type": "remove_ending_punc, trim, trim_period"
             }
           ]
         }
-      ]
-    },
-    {
+      ],
       "target": "publication.dateOfPublication",
       "subfield": [
         "c"
@@ -1890,15 +1912,6 @@
           "value": " ; ",
           "subfields": [
             "c"
-          ]
-        }
-      ],
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "remove_ending_punc, trim, trim_period"
-            }
           ]
         }
       ]
@@ -1906,11 +1919,20 @@
   ],
   "264": [
     {
+      "rules": [
+        {
+          "conditions": [
+            {
+              "type": "remove_ending_punc, trim"
+            }
+          ]
+        }
+      ],
       "target": "publication.place",
-      "description": "Place of publication",
       "subfield": [
         "a"
       ],
+      "description": "Place of publication",
       "subFieldDelimiter": [
         {
           "value": " ; ",
@@ -1918,7 +1940,9 @@
             "a"
           ]
         }
-      ],
+      ]
+    },
+    {
       "rules": [
         {
           "conditions": [
@@ -1927,14 +1951,12 @@
             }
           ]
         }
-      ]
-    },
-    {
+      ],
       "target": "publication.publisher",
-      "description": "Publisher of publication",
       "subfield": [
         "b"
       ],
+      "description": "Publisher of publication",
       "subFieldDelimiter": [
         {
           "value": " ; ",
@@ -1942,31 +1964,9 @@
             "b"
           ]
         }
-      ],
-      "rules": [
-        {
-          "conditions": [
-            {
-              "type": "remove_ending_punc, trim"
-            }
-          ]
-        }
       ]
     },
     {
-      "target": "publication.dateOfPublication",
-      "description": "Date of publication",
-      "subfield": [
-        "c"
-      ],
-      "subFieldDelimiter": [
-        {
-          "value": " ; ",
-          "subfields": [
-            "c"
-          ]
-        }
-      ],
       "rules": [
         {
           "conditions": [
@@ -1975,17 +1975,22 @@
             }
           ]
         }
+      ],
+      "target": "publication.dateOfPublication",
+      "subfield": [
+        "c"
+      ],
+      "description": "Date of publication",
+      "subFieldDelimiter": [
+        {
+          "value": " ; ",
+          "subfields": [
+            "c"
+          ]
+        }
       ]
     },
     {
-      "target": "publication.role",
-      "description": "Role of publication, defined by 2nd indicator",
-      "applyRulesOnConcatenatedData": true,
-      "subfield": [
-        "a",
-        "b",
-        "c"
-      ],
       "rules": [
         {
           "conditions": [
@@ -1994,7 +1999,15 @@
             }
           ]
         }
-      ]
+      ],
+      "target": "publication.role",
+      "subfield": [
+        "a",
+        "b",
+        "c"
+      ],
+      "description": "Role of publication, defined by 2nd indicator",
+      "applyRulesOnConcatenatedData": true
     }
   ],
   "300": [
@@ -2013,13 +2026,6 @@
   ],
   "310": [
     {
-      "target": "publicationFrequency",
-      "description": "Publication frequency",
-      "applyRulesOnConcatenatedData": true,
-      "subfield": [
-        "a",
-        "b"
-      ],
       "rules": [
         {
           "conditions": [
@@ -2028,18 +2034,18 @@
             }
           ]
         }
-      ]
+      ],
+      "target": "publicationFrequency",
+      "subfield": [
+        "a",
+        "b"
+      ],
+      "description": "Publication frequency",
+      "applyRulesOnConcatenatedData": true
     }
   ],
   "321": [
     {
-      "target": "publicationFrequency",
-      "description": "Publication frequency",
-      "applyRulesOnConcatenatedData": true,
-      "subfield": [
-        "a",
-        "b"
-      ],
       "rules": [
         {
           "conditions": [
@@ -2048,26 +2054,18 @@
             }
           ]
         }
-      ]
-    }
-  ],
-  "336": [
-    {
-      "target": "instanceTypeId",
-      "description": "Instance type ID",
-      "ignoreSubsequentFields": true,
-      "ignoreSubsequentSubfields": true,
-      "applyRulesOnConcatenatedData": true,
+      ],
+      "target": "publicationFrequency",
       "subfield": [
         "a",
         "b"
       ],
-      "subFieldDelimiter": [
-        {
-          "value": "~",
-          "subfields": ["a","b"]
-        }
-      ],
+      "description": "Publication frequency",
+      "applyRulesOnConcatenatedData": true
+    }
+  ],
+  "336": [
+    {
       "rules": [
         {
           "conditions": [
@@ -2079,17 +2077,29 @@
             }
           ]
         }
-      ]
+      ],
+      "target": "instanceTypeId",
+      "subfield": [
+        "a",
+        "b"
+      ],
+      "description": "Instance type ID",
+      "subFieldDelimiter": [
+        {
+          "value": "~",
+          "subfields": [
+            "a",
+            "b"
+          ]
+        }
+      ],
+      "ignoreSubsequentFields": true,
+      "ignoreSubsequentSubfields": true,
+      "applyRulesOnConcatenatedData": true
     }
   ],
   "338": [
     {
-      "target": "instanceFormatIds",
-      "description": "Instance Format ID",
-      "ignoreSubsequentSubfields": true,
-      "subfield": [
-        "b"
-      ],
       "rules": [
         {
           "conditions": [
@@ -2098,18 +2108,17 @@
             }
           ]
         }
-      ]
+      ],
+      "target": "instanceFormatIds",
+      "subfield": [
+        "b"
+      ],
+      "description": "Instance Format ID",
+      "ignoreSubsequentSubfields": true
     }
   ],
   "362": [
     {
-      "target": "publicationRange",
-      "description": "Publication range",
-      "applyRulesOnConcatenatedData": true,
-      "subfield": [
-        "a",
-        "z"
-      ],
       "rules": [
         {
           "conditions": [
@@ -2118,21 +2127,20 @@
             }
           ]
         }
-      ]
+      ],
+      "target": "publicationRange",
+      "subfield": [
+        "a",
+        "z"
+      ],
+      "description": "Publication range",
+      "applyRulesOnConcatenatedData": true
     }
   ],
   "500": [
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "3",
-            "5"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -2144,17 +2152,17 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "General Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "3",
             "5"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -2163,22 +2171,31 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "3",
             "5"
           ],
+          "description": "General Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -2187,13 +2204,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "5"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -2205,16 +2215,16 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "With Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "5"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -2223,21 +2233,29 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "5"
           ],
+          "description": "With Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -2246,17 +2264,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "g",
-            "o"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -2268,11 +2275,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Dissertation Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -2281,7 +2285,10 @@
             "g",
             "o"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -2290,11 +2297,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -2303,12 +2307,27 @@
             "g",
             "o"
           ],
+          "description": "Dissertation Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "g",
+            "o"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -2317,13 +2336,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -2335,16 +2347,16 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Bibliography, etc. Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -2353,21 +2365,29 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b"
           ],
+          "description": "Bibliography, etc. Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -2376,16 +2396,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "g",
-            "r",
-            "t",
-            "u"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -2397,11 +2407,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Formatted Contents Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "g",
@@ -2409,7 +2416,10 @@
             "t",
             "u"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -2418,11 +2428,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "g",
@@ -2430,12 +2437,26 @@
             "t",
             "u"
           ],
+          "description": "Formatted Contents Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "g",
+            "r",
+            "t",
+            "u"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -2444,21 +2465,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "u",
-            "2",
-            "3",
-            "5"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -2470,11 +2476,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Restrictions on Access Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -2487,7 +2490,10 @@
             "3",
             "5"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -2496,11 +2502,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -2513,12 +2516,31 @@
             "3",
             "5"
           ],
+          "description": "Restrictions on Access Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "u",
+            "2",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -2527,13 +2549,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -2545,16 +2560,16 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Scale Note for Graphic Material",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -2563,21 +2578,29 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b"
           ],
+          "description": "Scale Note for Graphic Material",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -2586,12 +2609,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -2603,15 +2620,15 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Creation/Production Credits Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -2620,20 +2637,27 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a"
           ],
+          "description": "Creation/Production Credits Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -2642,17 +2666,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "u",
-            "x",
-            "3"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -2664,11 +2677,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Citation/References Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -2677,7 +2687,10 @@
             "x",
             "3"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -2686,11 +2699,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -2699,12 +2709,27 @@
             "x",
             "3"
           ],
+          "description": "Citation/References Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "u",
+            "x",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -2713,12 +2738,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -2730,15 +2749,15 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Participant or Performer Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -2747,20 +2766,27 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a"
           ],
+          "description": "Participant or Performer Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -2769,13 +2795,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -2787,16 +2806,16 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Type of Report and Period Covered Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -2805,21 +2824,29 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b"
           ],
+          "description": "Type of Report and Period Covered Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -2828,25 +2855,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g",
-            "h",
-            "i",
-            "j",
-            "k",
-            "m",
-            "u",
-            "z"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -2858,11 +2866,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Data Quality Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -2879,7 +2884,10 @@
             "u",
             "z"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -2888,11 +2896,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -2909,12 +2914,35 @@
             "u",
             "z"
           ],
+          "description": "Data Quality Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "m",
+            "u",
+            "z"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -2923,12 +2951,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -2940,15 +2962,15 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Numbering Peculiarities Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -2957,20 +2979,27 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a"
           ],
+          "description": "Numbering Peculiarities Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -2979,12 +3008,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -2996,15 +3019,15 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Type of Computer File or Data Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -3013,20 +3036,27 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a"
           ],
+          "description": "Type of Computer File or Data Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -3035,17 +3065,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "d",
-            "o",
-            "p",
-            "2",
-            "3"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -3057,11 +3076,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Date/Time and Place of an Event Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "d",
@@ -3070,7 +3086,10 @@
             "2",
             "3"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -3079,11 +3098,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "d",
@@ -3092,12 +3108,27 @@
             "2",
             "3"
           ],
+          "description": "Date/Time and Place of an Event Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "d",
+            "o",
+            "p",
+            "2",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -3106,17 +3137,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "u",
-            "2",
-            "3"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -3128,11 +3148,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Summary, Etc.",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -3141,7 +3158,10 @@
             "2",
             "3"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -3150,11 +3170,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -3163,12 +3180,27 @@
             "2",
             "3"
           ],
+          "description": "Summary, Etc.",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "u",
+            "2",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -3177,14 +3209,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "3"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -3196,17 +3220,17 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Target Audience Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
             "3"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -3215,22 +3239,31 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
             "3"
           ],
+          "description": "Target Audience Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -3239,12 +3272,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -3256,15 +3283,15 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Geographic Coverage Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -3273,20 +3300,27 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a"
           ],
+          "description": "Geographic Coverage Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -3295,14 +3329,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "2",
-            "3"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -3314,17 +3340,17 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Preferred Citation of Described Materials Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "2",
             "3"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -3333,22 +3359,31 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "2",
             "3"
           ],
+          "description": "Preferred Citation of Described Materials Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "2",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -3357,12 +3392,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -3374,15 +3403,15 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Supplement Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -3391,20 +3420,27 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a"
           ],
+          "description": "Supplement Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -3413,18 +3449,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "5",
-            "x",
-            "z"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -3436,11 +3460,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Study Program Information Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -3450,7 +3471,10 @@
             "x",
             "z"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -3459,11 +3483,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -3473,12 +3494,28 @@
             "x",
             "z"
           ],
+          "description": "Study Program Information Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "5",
+            "x",
+            "z"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -3487,17 +3524,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "u",
-            "3"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -3509,11 +3535,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Additional Physical Form Available Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -3522,7 +3545,10 @@
             "u",
             "3"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -3531,11 +3557,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -3544,12 +3567,27 @@
             "u",
             "3"
           ],
+          "description": "Additional Physical Form Available Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -3558,12 +3596,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -3575,15 +3607,15 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Accessibility note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -3592,20 +3624,27 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a"
           ],
+          "description": "Accessibility note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -3614,21 +3653,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "m",
-            "n",
-            "3",
-            "5"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -3640,11 +3664,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Reproduction Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -3657,7 +3678,10 @@
             "3",
             "5"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -3666,11 +3690,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -3683,12 +3704,31 @@
             "3",
             "5"
           ],
+          "description": "Reproduction Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "m",
+            "n",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -3697,26 +3737,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "e",
-            "f",
-            "k",
-            "l",
-            "m",
-            "n",
-            "o",
-            "p",
-            "t",
-            "x",
-            "z",
-            "3"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -3728,11 +3748,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Original Version Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -3750,7 +3767,10 @@
             "z",
             "3"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -3759,11 +3779,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -3781,12 +3798,36 @@
             "z",
             "3"
           ],
+          "description": "Original Version Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "e",
+            "f",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "t",
+            "x",
+            "z",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -3795,17 +3836,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "g",
-            "3"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -3817,11 +3847,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Location of Originals/Duplicates Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -3830,7 +3857,10 @@
             "g",
             "3"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -3839,11 +3869,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -3852,12 +3879,27 @@
             "g",
             "3"
           ],
+          "description": "Location of Originals/Duplicates Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "g",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -3866,19 +3908,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g",
-            "h"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -3890,11 +3919,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Funding Information Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -3905,7 +3931,10 @@
             "g",
             "h"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -3914,11 +3943,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -3929,12 +3955,29 @@
             "g",
             "h"
           ],
+          "description": "Funding Information Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -3943,15 +3986,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "u",
-            "3",
-            "5"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -3963,18 +3997,18 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "System Details Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "u",
             "3",
             "5"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -3983,23 +4017,33 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "u",
             "3",
             "5"
           ],
+          "description": "System Details Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -4008,18 +4052,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "u",
-            "3",
-            "5"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -4031,11 +4063,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Terms Governing Use and Reproduction Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -4045,7 +4074,10 @@
             "3",
             "5"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -4054,11 +4086,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -4068,12 +4097,28 @@
             "3",
             "5"
           ],
+          "description": "Terms Governing Use and Reproduction Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -4082,22 +4127,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "h",
-            "n",
-            "o",
-            "3",
-            "5"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -4109,11 +4138,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Immediate Source of Acquisition Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -4127,7 +4153,10 @@
             "3",
             "5"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -4136,12 +4165,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
-          "applyRulesOnConcatenatedData": true,
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -4155,6 +4180,10 @@
             "3",
             "5"
           ],
+          "description": "Immediate Source of Acquisition Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -4163,7 +4192,23 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "h",
+            "n",
+            "o",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "applyRulesOnConcatenatedData": true
         }
       ]
     }
@@ -4172,32 +4217,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g",
-            "h",
-            "i",
-            "j",
-            "k",
-            "l",
-            "m",
-            "n",
-            "o",
-            "p",
-            "q",
-            "r",
-            "s",
-            "u",
-            "3"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -4209,11 +4228,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Information Relating to Copyright Status",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -4237,7 +4253,10 @@
             "u",
             "3"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -4246,12 +4265,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
-          "applyRulesOnConcatenatedData": true,
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -4275,6 +4290,10 @@
             "u",
             "3"
           ],
+          "description": "Information Relating to Copyright Status",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -4283,7 +4302,33 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "q",
+            "r",
+            "s",
+            "u",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "applyRulesOnConcatenatedData": true
         }
       ]
     }
@@ -4292,18 +4337,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "n",
-            "3"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -4315,11 +4348,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Location of Other Archival Materials Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -4329,7 +4359,10 @@
             "n",
             "3"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -4338,11 +4371,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -4352,12 +4382,28 @@
             "n",
             "3"
           ],
+          "description": "Location of Other Archival Materials Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "n",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -4366,14 +4412,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "u"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -4385,17 +4423,17 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Biographical or Historical Data",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
             "u"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -4404,22 +4442,31 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
             "u"
           ],
+          "description": "Biographical or Historical Data",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "u"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -4428,14 +4475,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "3"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -4447,17 +4486,17 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Language Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
             "3"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -4466,22 +4505,31 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
             "3"
           ],
+          "description": "Language Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -4490,12 +4538,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -4507,15 +4549,15 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Former Title Complexity Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -4524,20 +4566,27 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a"
           ],
+          "description": "Former Title Complexity Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -4546,12 +4595,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -4563,15 +4606,15 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Issuing Body Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -4580,20 +4623,27 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a"
           ],
+          "description": "Issuing Body Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -4602,29 +4652,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "g",
-            "h",
-            "i",
-            "j",
-            "k",
-            "l",
-            "m",
-            "n",
-            "o",
-            "p",
-            "u",
-            "z"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -4636,11 +4663,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Entity and Attribute Information Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -4661,7 +4685,10 @@
             "u",
             "z"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -4670,11 +4697,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -4695,12 +4719,39 @@
             "u",
             "z"
           ],
+          "description": "Entity and Attribute Information Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "g",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "m",
+            "n",
+            "o",
+            "p",
+            "u",
+            "z"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -4709,17 +4760,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "u",
-            "3"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -4731,11 +4771,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Cumulative Index/Finding Aids Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -4744,7 +4781,10 @@
             "u",
             "3"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -4753,11 +4793,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -4766,12 +4803,27 @@
             "u",
             "3"
           ],
+          "description": "Cumulative Index/Finding Aids Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "u",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -4780,13 +4832,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "z"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -4798,16 +4843,16 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Information About Documentation Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "z"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -4816,21 +4861,29 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "z"
           ],
+          "description": "Information About Documentation Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "z"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -4839,15 +4892,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "u",
-            "3",
-            "5"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -4859,18 +4903,18 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Ownership and Custodial History",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "u",
             "3",
             "5"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -4879,18 +4923,18 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
-          "applyRulesOnConcatenatedData": true,
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "u",
             "3",
             "5"
           ],
+          "description": "Ownership and Custodial History",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -4899,7 +4943,16 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "applyRulesOnConcatenatedData": true
         }
       ]
     }
@@ -4908,18 +4961,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "3",
-            "5"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -4931,11 +4972,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Copy and Version Identification Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -4945,7 +4983,10 @@
             "3",
             "5"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -4954,11 +4995,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -4968,12 +5006,28 @@
             "3",
             "5"
           ],
+          "description": "Copy and Version Identification Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -4982,15 +5036,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "u",
-            "3",
-            "5"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -5002,18 +5047,18 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Binding Information",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "u",
             "3",
             "5"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -5022,23 +5067,33 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "u",
             "3",
             "5"
           ],
+          "description": "Binding Information",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "u",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -5047,17 +5102,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "3"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -5069,11 +5113,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Case File Characteristics Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -5082,7 +5123,10 @@
             "e",
             "3"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -5091,11 +5135,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -5104,12 +5145,27 @@
             "e",
             "3"
           ],
+          "description": "Case File Characteristics Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -5118,14 +5174,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "2"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -5137,17 +5185,17 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Methodology Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
             "2"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -5156,22 +5204,31 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
             "2"
           ],
+          "description": "Methodology Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "2"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -5180,12 +5237,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -5197,15 +5248,15 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Linking Entry Complexity Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -5214,20 +5265,27 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a"
           ],
+          "description": "Linking Entry Complexity Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -5236,14 +5294,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "z",
-            "3"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -5255,17 +5305,17 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Publications About Described Materials Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "z",
             "3"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -5274,22 +5324,31 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "z",
             "3"
           ],
+          "description": "Publications About Described Materials Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "z",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -5298,30 +5357,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "c",
-            "d",
-            "e",
-            "f",
-            "h",
-            "i",
-            "j",
-            "k",
-            "l",
-            "n",
-            "o",
-            "u",
-            "x",
-            "z",
-            "2",
-            "3",
-            "5"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -5333,11 +5368,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Action Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
@@ -5359,7 +5391,10 @@
             "3",
             "5"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -5368,12 +5403,8 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
-          "applyRulesOnConcatenatedData": true,
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
@@ -5395,6 +5426,10 @@
             "3",
             "5"
           ],
+          "description": "Action Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -5403,7 +5438,31 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "c",
+            "d",
+            "e",
+            "f",
+            "h",
+            "i",
+            "j",
+            "k",
+            "l",
+            "n",
+            "o",
+            "u",
+            "x",
+            "z",
+            "2",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff",
+          "applyRulesOnConcatenatedData": true
         }
       ]
     }
@@ -5412,15 +5471,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "b",
-            "3",
-            "5"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -5432,18 +5482,18 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Accumulation and Frequency of Use Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "b",
             "3",
             "5"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -5452,23 +5502,33 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "b",
             "3",
             "5"
           ],
+          "description": "Accumulation and Frequency of Use Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "b",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -5477,14 +5537,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "3",
-            "5"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -5496,17 +5548,17 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Exhibitions Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "3",
             "5"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -5515,22 +5567,31 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "3",
             "5"
           ],
+          "description": "Exhibitions Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "3",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -5539,13 +5600,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "3"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -5557,16 +5611,16 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Awards Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "3"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -5575,21 +5629,29 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "3"
           ],
+          "description": "Awards Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "3"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -5598,13 +5660,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a",
-            "5"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -5616,16 +5671,16 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Source of Description Note",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a",
             "5"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -5634,21 +5689,29 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If true, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a",
             "5"
           ],
+          "description": "Source of Description Note",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a",
+            "5"
+          ],
+          "description": "If true, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -5657,12 +5720,6 @@
     {
       "entity": [
         {
-          "target": "notes.instanceNoteTypeId",
-          "description": "Instance note type id",
-          "subfield": [
-            "a"
-          ],
-          "applyRulesOnConcatenatedData": true,
           "rules": [
             {
               "conditions": [
@@ -5674,15 +5731,15 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.note",
-          "description": "Local notes",
+          ],
+          "target": "notes.instanceNoteTypeId",
           "subfield": [
             "a"
           ],
-          "applyRulesOnConcatenatedData": true,
+          "description": "Instance note type id",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -5691,14 +5748,15 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "notes.staffOnly",
-          "description": "If the 1st indicator equals 0, determines that the note should not be visible for others than staff",
+          ],
+          "target": "notes.note",
           "subfield": [
             "a"
           ],
+          "description": "Local notes",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -5707,7 +5765,12 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "notes.staffOnly",
+          "subfield": [
+            "a"
+          ],
+          "description": "If the 1st indicator equals 0, determines that the note should not be visible for others than staff"
         }
       ]
     }
@@ -5716,9 +5779,16 @@
     {
       "entity": [
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
           "target": "subjects.value",
-          "description": "Subject Headings",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "a",
             "b",
@@ -5745,15 +5815,7 @@
             "y",
             "z"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
-            }
-          ],
+          "description": "Subject Headings",
           "subFieldDelimiter": [
             {
               "value": " ",
@@ -5788,16 +5850,18 @@
             },
             {
               "value": "--",
-              "subfields": []
+              "subfields": [
+              ]
             }
-          ]
+          ],
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "subjects.authorityId",
-          "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the subject"
         }
       ]
     }
@@ -5806,9 +5870,16 @@
     {
       "entity": [
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
           "target": "subjects.value",
-          "description": "Subject Headings",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "a",
             "b",
@@ -5833,15 +5904,7 @@
             "y",
             "z"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
-            }
-          ],
+          "description": "Subject Headings",
           "subFieldDelimiter": [
             {
               "value": " ",
@@ -5873,16 +5936,18 @@
             },
             {
               "value": "--",
-              "subfields": []
+              "subfields": [
+              ]
             }
-          ]
+          ],
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "subjects.authorityId",
-          "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the subject"
         }
       ]
     }
@@ -5891,9 +5956,16 @@
     {
       "entity": [
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
           "target": "subjects.value",
-          "description": "Subject Headings",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "a",
             "c",
@@ -5916,15 +5988,7 @@
             "y",
             "z"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
-            }
-          ],
+          "description": "Subject Headings",
           "subFieldDelimiter": [
             {
               "value": " ",
@@ -5958,16 +6022,18 @@
             },
             {
               "value": "--",
-              "subfields": []
+              "subfields": [
+              ]
             }
-          ]
+          ],
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "subjects.authorityId",
-          "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the subject"
         }
       ]
     }
@@ -5976,9 +6042,16 @@
     {
       "entity": [
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
           "target": "subjects.value",
-          "description": "Subject Headings",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "a",
             "d",
@@ -6000,15 +6073,7 @@
             "y",
             "z"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
-            }
-          ],
+          "description": "Subject Headings",
           "subFieldDelimiter": [
             {
               "value": " ",
@@ -6038,16 +6103,18 @@
             },
             {
               "value": "--",
-              "subfields": []
+              "subfields": [
+              ]
             }
-          ]
+          ],
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "subjects.authorityId",
-          "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the subject"
         }
       ]
     }
@@ -6056,9 +6123,16 @@
     {
       "entity": [
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
           "target": "subjects.value",
-          "description": "Subject Headings",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "a",
             "c",
@@ -6069,15 +6143,7 @@
             "z",
             "v"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
-            }
-          ],
+          "description": "Subject Headings",
           "subFieldDelimiter": [
             {
               "value": "--",
@@ -6094,16 +6160,18 @@
             },
             {
               "value": "--",
-              "subfields": []
+              "subfields": [
+              ]
             }
-          ]
+          ],
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "subjects.authorityId",
-          "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the subject"
         }
       ]
     }
@@ -6112,9 +6180,16 @@
     {
       "entity": [
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
           "target": "subjects.value",
-          "description": "Subject Headings",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "a",
             "x",
@@ -6122,15 +6197,7 @@
             "z",
             "v"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
-            }
-          ],
+          "description": "Subject Headings",
           "subFieldDelimiter": [
             {
               "value": "--",
@@ -6142,14 +6209,15 @@
                 "v"
               ]
             }
-          ]
+          ],
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "subjects.authorityId",
-          "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the subject"
         }
       ]
     }
@@ -6158,9 +6226,16 @@
     {
       "entity": [
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
           "target": "subjects.value",
-          "description": "Subject Headings",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "a",
             "b",
@@ -6173,15 +6248,7 @@
             "y",
             "z"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
-            }
-          ],
+          "description": "Subject Headings",
           "subFieldDelimiter": [
             {
               "value": "--",
@@ -6198,14 +6265,15 @@
                 "z"
               ]
             }
-          ]
+          ],
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "subjects.authorityId",
-          "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the subject"
         }
       ]
     }
@@ -6214,9 +6282,16 @@
     {
       "entity": [
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
           "target": "subjects.value",
-          "description": "Subject Headings",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "a",
             "e",
@@ -6226,15 +6301,7 @@
             "y",
             "z"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
-            }
-          ],
+          "description": "Subject Headings",
           "subFieldDelimiter": [
             {
               "value": "--",
@@ -6248,14 +6315,15 @@
                 "z"
               ]
             }
-          ]
+          ],
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "subjects.authorityId",
-          "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the subject"
         }
       ]
     }
@@ -6264,9 +6332,16 @@
     {
       "entity": [
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_period, trim"
+                }
+              ]
+            }
+          ],
           "target": "subjects.value",
-          "description": "Subject Headings",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "a",
             "b",
@@ -6276,15 +6351,7 @@
             "y",
             "z"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
-            }
-          ],
+          "description": "Subject Headings",
           "subFieldDelimiter": [
             {
               "value": "--",
@@ -6298,14 +6365,15 @@
                 "z"
               ]
             }
-          ]
+          ],
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "subjects.authorityId",
-          "description": "Authority ID that controlling the subject",
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the subject"
         }
       ]
     }
@@ -6315,18 +6383,13 @@
       "entity": [
         {
           "target": "contributors.authorityId",
-          "description": "Authority ID that controlling the contributor",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.contributorNameTypeId",
-          "description": "Type for Personal Name",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-          ],
           "rules": [
             {
               "conditions": [
@@ -6338,7 +6401,12 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "contributors.contributorNameTypeId",
+          "subfield": [
+          ],
+          "description": "Type for Personal Name",
+          "applyRulesOnConcatenatedData": true
         },
         {
           "rules": [
@@ -6370,21 +6438,30 @@
           "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.primary",
-          "description": "Primary contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-          ],
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "contributors.primary",
+          "subfield": [
+          ],
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true
         },
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_punctuation"
+                }
+              ]
+            }
+          ],
           "target": "contributors.name",
-          "description": "Personal Name",
           "subfield": [
             "a",
             "b",
@@ -6401,16 +6478,8 @@
             "t",
             "u"
           ],
-          "applyRulesOnConcatenatedData": true,
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
-            }
-          ]
+          "description": "Personal Name",
+          "applyRulesOnConcatenatedData": true
         }
       ]
     }
@@ -6420,18 +6489,13 @@
       "entity": [
         {
           "target": "contributors.authorityId",
-          "description": "Authority ID that controlling the contributor",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.contributorNameTypeId",
-          "description": "Type for Corporate Name",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-          ],
           "rules": [
             {
               "conditions": [
@@ -6443,7 +6507,12 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "contributors.contributorNameTypeId",
+          "subfield": [
+          ],
+          "description": "Type for Corporate Name",
+          "applyRulesOnConcatenatedData": true
         },
         {
           "rules": [
@@ -6475,21 +6544,30 @@
           "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.primary",
-          "description": "Primary contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-          ],
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "contributors.primary",
+          "subfield": [
+          ],
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true
         },
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_punctuation"
+                }
+              ]
+            }
+          ],
           "target": "contributors.name",
-          "description": "Corporate Name",
           "subfield": [
             "a",
             "b",
@@ -6504,16 +6582,8 @@
             "t",
             "u"
           ],
-          "applyRulesOnConcatenatedData": true,
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
-            }
-          ]
+          "description": "Corporate Name",
+          "applyRulesOnConcatenatedData": true
         }
       ]
     }
@@ -6523,18 +6593,13 @@
       "entity": [
         {
           "target": "contributors.authorityId",
-          "description": "Authority ID that controlling the contributor",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the contributor",
+          "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.contributorNameTypeId",
-          "description": "Type for Meeting Name",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-          ],
           "rules": [
             {
               "conditions": [
@@ -6546,7 +6611,12 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "contributors.contributorNameTypeId",
+          "subfield": [
+          ],
+          "description": "Type for Meeting Name",
+          "applyRulesOnConcatenatedData": true
         },
         {
           "rules": [
@@ -6578,21 +6648,30 @@
           "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.primary",
-          "description": "Primary contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-          ],
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "contributors.primary",
+          "subfield": [
+          ],
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true
         },
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_punctuation"
+                }
+              ]
+            }
+          ],
           "target": "contributors.name",
-          "description": "Meeting Name",
           "subfield": [
             "a",
             "b",
@@ -6607,32 +6686,104 @@
             "t",
             "u"
           ],
-          "applyRulesOnConcatenatedData": true,
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
-            }
-          ]
+          "description": "Meeting Name",
+          "applyRulesOnConcatenatedData": true
         }
       ]
     }
   ],
   "720": [
     {
+      "entity": [
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_name_type_id",
+                  "parameter": {
+                    "name": "Personal name"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorNameTypeId",
+          "subfield": [
+          ],
+          "description": "Type for Personal Name",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "set_contributor_type_id_by_code_or_name",
+                  "parameter": {
+                    "contributorCodeSubfield": "4",
+                    "contributorNameSubfield": "e"
+                  }
+                }
+              ]
+            }
+          ],
+          "target": "contributors.contributorTypeId",
+          "subfield": [
+            "4",
+            "e"
+          ],
+          "description": "Type of contributor",
+          "alternativeMapping": {
+            "target": "contributors.contributorTypeText",
+            "subfield": [
+              "e"
+            ],
+            "description": "Contributor type free text",
+            "ignoreSubsequentSubfields": true
+          },
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "value": "false",
+              "conditions": [
+              ]
+            }
+          ],
+          "target": "contributors.primary",
+          "subfield": [
+          ],
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "trim_punctuation"
+                }
+              ]
+            }
+          ],
+          "target": "contributors.name",
+          "subfield": [
+            "a"
+          ],
+          "description": "Personal Name",
+          "applyRulesOnConcatenatedData": true
+        }
+      ],
       "indicators": {
         "ind1": "1",
         "ind2": "*"
-      },
+      }
+    },
+    {
       "entity": [
         {
-          "target": "contributors.contributorNameTypeId",
-          "description": "Type for Personal Name",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [],
           "rules": [
             {
               "conditions": [
@@ -6644,16 +6795,14 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "contributors.contributorNameTypeId",
+          "subfield": [
+          ],
+          "description": "Type for Personal Name",
+          "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.contributorTypeId",
-          "description": "Type of contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "4",
-            "e"
-          ],
           "rules": [
             {
               "conditions": [
@@ -6667,35 +6816,37 @@
               ]
             }
           ],
+          "target": "contributors.contributorTypeId",
+          "subfield": [
+            "4",
+            "e"
+          ],
+          "description": "Type of contributor",
           "alternativeMapping": {
             "target": "contributors.contributorTypeText",
-            "description": "Contributor type free text",
-            "ignoreSubsequentSubfields": true,
             "subfield": [
               "e"
-            ]
-          }
+            ],
+            "description": "Contributor type free text",
+            "ignoreSubsequentSubfields": true
+          },
+          "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.primary",
-          "description": "Primary contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-          ],
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "contributors.primary",
+          "subfield": [
+          ],
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.name",
-          "description": "Personal Name",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "a"
-          ],
           "rules": [
             {
               "conditions": [
@@ -6704,107 +6855,23 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "contributors.name",
+          "subfield": [
+            "a"
+          ],
+          "description": "Personal Name",
+          "applyRulesOnConcatenatedData": true
         }
-      ]
-    },
-    {
+      ],
       "indicators": {
         "ind1": " ",
         "ind2": "*"
-      },
-      "entity": [
-        {
-          "target": "contributors.contributorNameTypeId",
-          "description": "Type for Personal Name",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_name_type_id",
-                  "parameter": {
-                    "name": "Personal name"
-                  }
-                }
-              ]
-            }
-          ]
-        },
-        {
-          "target": "contributors.contributorTypeId",
-          "description": "Type of contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "4",
-            "e"
-          ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "set_contributor_type_id_by_code_or_name",
-                  "parameter": {
-                    "contributorCodeSubfield": "4",
-                    "contributorNameSubfield": "e"
-                  }
-                }
-              ]
-            }
-          ],
-          "alternativeMapping": {
-            "target": "contributors.contributorTypeText",
-            "description": "Contributor type free text",
-            "ignoreSubsequentSubfields": true,
-            "subfield": [
-              "e"
-            ]
-          }
-        },
-        {
-          "target": "contributors.primary",
-          "description": "Primary contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-          ],
-          "rules": [
-            {
-              "conditions": [],
-              "value": "false"
-            }
-          ]
-        },
-        {
-          "target": "contributors.name",
-          "description": "Personal Name",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "a"
-          ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "trim_punctuation"
-                }
-              ]
-            }
-          ]
-        }
-      ]
+      }
     },
     {
-      "indicators": {
-        "ind1": "2",
-        "ind2": "*"
-      },
       "entity": [
         {
-          "target": "contributors.contributorNameTypeId",
-          "description": "Type for Corporate Name",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [],
           "rules": [
             {
               "conditions": [
@@ -6816,16 +6883,14 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "contributors.contributorNameTypeId",
+          "subfield": [
+          ],
+          "description": "Type for Corporate Name",
+          "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.contributorTypeId",
-          "description": "Type of contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "4",
-            "e"
-          ],
           "rules": [
             {
               "conditions": [
@@ -6839,35 +6904,37 @@
               ]
             }
           ],
+          "target": "contributors.contributorTypeId",
+          "subfield": [
+            "4",
+            "e"
+          ],
+          "description": "Type of contributor",
           "alternativeMapping": {
             "target": "contributors.contributorTypeText",
-            "description": "Contributor type free text",
-            "ignoreSubsequentSubfields": true,
             "subfield": [
               "e"
-            ]
-          }
+            ],
+            "description": "Contributor type free text",
+            "ignoreSubsequentSubfields": true
+          },
+          "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.primary",
-          "description": "Primary contributor",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-          ],
           "rules": [
             {
-              "conditions": [],
-              "value": "false"
+              "value": "false",
+              "conditions": [
+              ]
             }
-          ]
+          ],
+          "target": "contributors.primary",
+          "subfield": [
+          ],
+          "description": "Primary contributor",
+          "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "contributors.name",
-          "description": "Personal Name",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "a"
-          ],
           "rules": [
             {
               "conditions": [
@@ -6876,21 +6943,25 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "contributors.name",
+          "subfield": [
+            "a"
+          ],
+          "description": "Personal Name",
+          "applyRulesOnConcatenatedData": true
         }
-      ]
+      ],
+      "indicators": {
+        "ind1": "2",
+        "ind2": "*"
+      }
     }
   ],
   "780": [
     {
       "entity": [
         {
-          "target": "precedingTitles.title",
-          "description": "The primary title (or label) associated with the resource",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "t"
-          ],
           "rules": [
             {
               "conditions": [
@@ -6899,15 +6970,15 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "precedingTitles.title",
+          "subfield": [
+            "t"
+          ],
+          "description": "The primary title (or label) associated with the resource",
+          "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "precedingTitles.isbnId",
-          "description": "Type for Valid ISBN",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "z"
-          ],
           "rules": [
             {
               "conditions": [
@@ -6919,15 +6990,15 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "precedingTitles.isbnValue",
-          "description": "Value for Valid ISBN",
-          "applyRulesOnConcatenatedData": true,
+          ],
+          "target": "precedingTitles.isbnId",
           "subfield": [
             "z"
           ],
+          "description": "Type for Valid ISBN",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -6936,15 +7007,15 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "precedingTitles.isbnValue",
+          "subfield": [
+            "z"
+          ],
+          "description": "Value for Valid ISBN",
+          "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "precedingTitles.issnId",
-          "description": "Type for Valid ISSN",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "x"
-          ],
           "rules": [
             {
               "conditions": [
@@ -6956,15 +7027,15 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "precedingTitles.issnValue",
-          "description": "Value for Valid ISSN",
-          "applyRulesOnConcatenatedData": true,
+          ],
+          "target": "precedingTitles.issnId",
           "subfield": [
             "x"
           ],
+          "description": "Type for Valid ISSN",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -6973,7 +7044,13 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "precedingTitles.issnValue",
+          "subfield": [
+            "x"
+          ],
+          "description": "Value for Valid ISSN",
+          "applyRulesOnConcatenatedData": true
         }
       ]
     }
@@ -6982,12 +7059,6 @@
     {
       "entity": [
         {
-          "target": "succeedingTitles.title",
-          "description": "The primary title (or label) associated with the resource",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "t"
-          ],
           "rules": [
             {
               "conditions": [
@@ -6996,15 +7067,15 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "succeedingTitles.title",
+          "subfield": [
+            "t"
+          ],
+          "description": "The primary title (or label) associated with the resource",
+          "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "succeedingTitles.isbnId",
-          "description": "Type for Valid ISBN",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "z"
-          ],
           "rules": [
             {
               "conditions": [
@@ -7016,15 +7087,15 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "succeedingTitles.isbnValue",
-          "description": "Value for Valid ISBN",
-          "applyRulesOnConcatenatedData": true,
+          ],
+          "target": "succeedingTitles.isbnId",
           "subfield": [
             "z"
           ],
+          "description": "Type for Valid ISBN",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -7033,15 +7104,15 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "succeedingTitles.isbnValue",
+          "subfield": [
+            "z"
+          ],
+          "description": "Value for Valid ISBN",
+          "applyRulesOnConcatenatedData": true
         },
         {
-          "target": "succeedingTitles.issnId",
-          "description": "Type for Valid ISSN",
-          "applyRulesOnConcatenatedData": true,
-          "subfield": [
-            "x"
-          ],
           "rules": [
             {
               "conditions": [
@@ -7053,15 +7124,15 @@
                 }
               ]
             }
-          ]
-        },
-        {
-          "target": "succeedingTitles.issnValue",
-          "description": "Value for Valid ISSN",
-          "applyRulesOnConcatenatedData": true,
+          ],
+          "target": "succeedingTitles.issnId",
           "subfield": [
             "x"
           ],
+          "description": "Type for Valid ISSN",
+          "applyRulesOnConcatenatedData": true
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -7070,7 +7141,13 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "succeedingTitles.issnValue",
+          "subfield": [
+            "x"
+          ],
+          "description": "Value for Valid ISSN",
+          "applyRulesOnConcatenatedData": true
         }
       ]
     }
@@ -7079,9 +7156,16 @@
     {
       "entity": [
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
           "target": "series.value",
-          "description": "Series Statement",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "a",
             "b",
@@ -7109,22 +7193,15 @@
             "3",
             "5"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ]
+          "description": "Series Statement",
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "series.authorityId",
-          "description": "Authority ID that controlling the series",
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the series"
         }
       ]
     }
@@ -7133,9 +7210,16 @@
     {
       "entity": [
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
           "target": "series.value",
-          "description": "Series Statement",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "a",
             "b",
@@ -7161,22 +7245,15 @@
             "3",
             "5"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ]
+          "description": "Series Statement",
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "series.authorityId",
-          "description": "Authority ID that controlling the series",
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the series"
         }
       ]
     }
@@ -7185,9 +7262,16 @@
     {
       "entity": [
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
           "target": "series.value",
-          "description": "Series Statement",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "a",
             "c",
@@ -7211,22 +7295,15 @@
             "3",
             "5"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ]
+          "description": "Series Statement",
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "series.authorityId",
-          "description": "Authority ID that controlling the series",
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the series"
         }
       ]
     }
@@ -7235,9 +7312,16 @@
     {
       "entity": [
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
           "target": "series.value",
-          "description": "Series Statement",
-          "applyRulesOnConcatenatedData": true,
           "subfield": [
             "a",
             "d",
@@ -7259,22 +7343,15 @@
             "3",
             "5"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ]
+          "description": "Series Statement",
+          "applyRulesOnConcatenatedData": true
         },
         {
           "target": "series.authorityId",
-          "description": "Authority ID that controlling the series",
           "subfield": [
             "9"
-          ]
+          ],
+          "description": "Authority ID that controlling the series"
         }
       ]
     }
@@ -7283,15 +7360,6 @@
     {
       "entity": [
         {
-          "target": "electronicAccess.relationshipId",
-          "applyRulesOnConcatenatedData": true,
-          "description": "Relationship between the electronic resource at the location identified and the item described in the record as a whole",
-          "subfield": [
-            "3",
-            "y",
-            "u",
-            "z"
-          ],
           "rules": [
             {
               "conditions": [
@@ -7300,14 +7368,34 @@
                 }
               ]
             }
-          ]
+          ],
+          "target": "electronicAccess.relationshipId",
+          "subfield": [
+            "3",
+            "y",
+            "u",
+            "z"
+          ],
+          "description": "Relationship between the electronic resource at the location identified and the item described in the record as a whole",
+          "applyRulesOnConcatenatedData": true
         },
         {
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "type": "remove_ending_punc, trim"
+                }
+              ]
+            }
+          ],
           "target": "electronicAccess.uri",
-          "description": "URI",
           "subfield": [
             "u"
           ],
+          "description": "URI"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -7316,14 +7404,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
+          ],
           "target": "electronicAccess.linkText",
-          "description": "Link text",
           "subfield": [
             "y"
           ],
+          "description": "Link text"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -7332,14 +7420,14 @@
                 }
               ]
             }
-          ]
-        },
-        {
+          ],
           "target": "electronicAccess.materialsSpecification",
-          "description": "Materials Specified",
           "subfield": [
             "3"
           ],
+          "description": "Materials Specified"
+        },
+        {
           "rules": [
             {
               "conditions": [
@@ -7348,23 +7436,12 @@
                 }
               ]
             }
-          ]
-        },
-        {
+          ],
           "target": "electronicAccess.publicNote",
-          "description": "URL public note",
           "subfield": [
             "z"
           ],
-          "rules": [
-            {
-              "conditions": [
-                {
-                  "type": "remove_ending_punc, trim"
-                }
-              ]
-            }
-          ]
+          "description": "URL public note"
         }
       ]
     }
@@ -7372,29 +7449,29 @@
   "880": [
     {
       "target": "",
-      "description": "Field for target post-processing based on first 3 digits in subfield 6",
       "subfield": [
         "6"
       ],
-      "fieldReplacementBy3Digits": true,
+      "description": "Field for target post-processing based on first 3 digits in subfield 6",
       "fieldReplacementRule": [
         {
-          "sourceDigits": "100",
-          "targetField": "700"
+          "targetField": "700",
+          "sourceDigits": "100"
         },
         {
-          "sourceDigits": "110",
-          "targetField": "710"
+          "targetField": "710",
+          "sourceDigits": "110"
         },
         {
-          "sourceDigits": "111",
-          "targetField": "711"
+          "targetField": "711",
+          "sourceDigits": "111"
         },
         {
-          "sourceDigits": "245",
-          "targetField": "246"
+          "targetField": "246",
+          "sourceDigits": "245"
         }
-      ]
+      ],
+      "fieldReplacementBy3Digits": true
     }
   ]
 }


### PR DESCRIPTION
## Purpose
_To fix the Scenario: FAT-4701 check that default rules in karate tests matches what is in the SRM under test._

## Approach
_Use the actual JSON response from SRM. We see that test Scenario: FAT-4701... is not failing anymore:_
https://jenkins-aws.indexdata.com/job/Testing/job/Karate%20tests/674
![image](https://github.com/folio-org/folio-integration-tests/assets/138673581/2ab08c44-836d-434c-b10a-a14c89f2ef39)

### Learning
_[JIRA](https://issues.folio.org/browse/FAT-6493)_
