### PR TITLE
[MODORDERS-913] - Encumbrance became "Release" when changing fund distribution in order with related paid invoice having NOT checked "Release encumbrance" option

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/moving_expended_value_to_newly_created_encumbrance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/moving_expended_value_to_newly_created_encumbrance.feature
@@ -210,7 +210,7 @@ Feature: Moving expended amount when editing fund distribution for POL
     When method GET
     Then status 200
     And match $.amount == 0
-    And match $.encumbrance.status == 'Released'
+    And match $.encumbrance.status == 'Unreleased'
     And match $.encumbrance.amountExpended == 1
     And match $.encumbrance.amountAwaitingPayment == 0
 


### PR DESCRIPTION
## Purpose
Status was depend on amount of old encumbrance while moving process. Now it will keep old encumbrance status
Related business logic PR: https://github.com/folio-org/mod-orders/pull/762

## Approach
_How does this change fulfill the purpose?_

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
