### PR TITLE
FAT-6493: increase the total timeout for the job completeness polling

### DIFF
--- a/data-import/src/main/resources/folijet/data-import/features/get-completed-job-execution.feature
+++ b/data-import/src/main/resources/folijet/data-import/features/get-completed-job-execution.feature
@@ -2,7 +2,7 @@ Feature: Get job execution by id
 
   Background:
     * url baseUrl
-    * configure retry = { count: 10, interval: 30000 }
+    * configure retry = { count: 10, interval: 60000 }
 
   @getJobWhenJobStatusCompleted
   Scenario: wait until job status will be 'completed'


### PR DESCRIPTION
## Purpose
_Wait for complete of a job run._

## Approach
_Increasing the total timeout for the job completeness polling._

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
![image](https://github.com/folio-org/folio-integration-tests/assets/138673581/7a4eb85a-cc5c-421c-85af-91aacea45bed)

