### PR TITLE
[MODORDERS-915, MODORDERS-920] - NPE in OrderReEncumberService.java:245, An error appears after rollover when open order/order line having two fund distributions related to different ledgers

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
@@ -143,5 +143,8 @@ Feature: cross-module integration tests
   Scenario: Update encumbrance links with fiscal year
     Given call read('features/update-encumbrance-links-with-fiscal-year.feature')
 
+  Scenario: Check order re-encumber after preview rollover
+    Given call read('features/check-order-re-encumber-after-preview-rollover.feature')
+
   Scenario: wipe data
     Given call read('classpath:common/destroy-data.feature')

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-order-re-encumber-after-preview-rollover.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-order-re-encumber-after-preview-rollover.feature
@@ -7,7 +7,7 @@ Feature: Check order re-encumber after preview rollover
   # 2) create and open order
   # 3) re-encumber order from step 2 and get 'encumbrancesForReEncumberNotFound' error code
   # 4) make preview rollover fiscalYearId1 -> fiscalYearId2
-  # 5) make sure that preview rollover was successfully
+  # 5) make sure that preview rollover was failed
   # 6) retry step 3 and make sure that preview rollover wasn't affected to results of re-encumber
 
   Background:
@@ -300,15 +300,6 @@ Feature: Check order re-encumber after preview rollover
             "setAllowances": false,
             "allowableEncumbrance": 100,
             "allowableExpenditure": 100
-          },
-          {
-            "fundTypeId": "#(books)",
-            "rolloverAllocation": true,
-            "adjustAllocation": 10,
-            "rolloverBudgetValue": "None",
-            "setAllowances": false,
-            "allowableEncumbrance": 100,
-            "allowableExpenditure": 100
           }
         ],
         "encumbrancesRollover": [
@@ -343,7 +334,7 @@ Feature: Check order re-encumber after preview rollover
     Given path 'finance/ledger-rollovers-logs', rolloverId
     When method GET
     Then status 200
-    And match response.rolloverStatus == 'Success'
+    And match response.rolloverStatus == 'Error'
     And match response.ledgerRolloverType == 'Preview'
 
     Examples:
@@ -358,10 +349,7 @@ Feature: Check order re-encumber after preview rollover
     And param query = 'ledgerRolloverId==' + rolloverId
     When method GET
     Then status 200
-    And match response.ledgerFiscalYearRolloverProgresses[0].budgetsClosingRolloverStatus == 'Success'
-    And match response.ledgerFiscalYearRolloverProgresses[0].ordersRolloverStatus == 'Success'
-    And match response.ledgerFiscalYearRolloverProgresses[0].financialRolloverStatus == 'Success'
-    And match response.ledgerFiscalYearRolloverProgresses[0].overallRolloverStatus == 'Success'
+    And match response.ledgerFiscalYearRolloverProgresses[0].overallRolloverStatus == 'Error'
 
     Examples:
       | rolloverId  |

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-order-re-encumber-after-preview-rollover.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-order-re-encumber-after-preview-rollover.feature
@@ -1,0 +1,373 @@
+# For https://issues.folio.org/browse/MODORDERS-915
+# and https://issues.folio.org/browse/MODORDERS-920
+@parallel=false
+Feature: Check order re-encumber after preview rollover
+
+  Background:
+    * url baseUrl
+    # uncomment below line for development
+    #* callonce dev {tenant: 'test_finance1'}
+    * callonce loginAdmin testAdmin
+    * def okapitokenAdmin = okapitoken
+
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json, text/plain'  }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json, text/plain'  }
+
+    * configure headers = headersAdmin
+
+    * callonce variables
+
+    * def fromFiscalYearId = callonce uuid1
+    * def toFiscalYearId = callonce uuid2
+
+    * def rolloverLedger1 = callonce uuid3
+
+    * def books = callonce uuid4
+
+    * def law = callonce uuid5
+
+    * def law2020 = callonce uuid6
+
+    * def encumberRemaining = callonce uuid7
+
+    * def encumberRemainingLine = callonce uuid8
+
+    * def rolloverId1 = callonce uuid9
+
+    * def codePrefix = callonce random_string
+    * def fromYear = callonce getCurrentYear
+    * def toYear = parseInt(fromYear) + 1
+
+
+  Scenario Outline: prepare fiscal year with <fiscalYearId> for rollover
+    * def fiscalYearId = <fiscalYearId>
+    * def code = <code>
+
+    Given path 'finance/fiscal-years'
+    And request
+    """
+    {
+      "id": '#(fiscalYearId)',
+      "name": '#(codePrefix + code)',
+      "code": '#(codePrefix + code)',
+      "periodStart": '#(code + "-01-01T00:00:00Z")',
+      "periodEnd": '#(code + "-12-30T23:59:59Z")'
+    }
+    """
+    When method POST
+    Then status 201
+
+    Examples:
+      | fiscalYearId     | code     |
+      | fromFiscalYearId | fromYear |
+      | toFiscalYearId   | toYear   |
+
+
+  Scenario Outline: prepare ledger with <ledgerId> for rollover
+    * def ledgerId = <ledgerId>
+
+    Given path 'finance/ledgers'
+    And request
+    """
+    {
+      "id": "#(ledgerId)",
+      "ledgerStatus": "Active",
+      "name": "#(ledgerId)",
+      "code": "#(ledgerId)",
+      "fiscalYearOneId":"#(fromFiscalYearId)"
+    }
+    """
+    When method POST
+    Then status 201
+
+    Examples:
+      | ledgerId          |
+      | rolloverLedger1   |
+
+
+  Scenario Outline: prepare fund types with <fundTypeId>, <name> for rollover
+    * def fundTypeId = <fundTypeId>
+    * def name = <name>
+
+    Given path 'finance/fund-types'
+    And request
+    """
+    {
+      "id": "#(fundTypeId)",
+      "name": "#(codePrefix + name)"
+    }
+    """
+    When method POST
+    Then status 201
+
+    Examples:
+      | fundTypeId | name         |
+      | books      | 'Books'      |
+
+
+  Scenario Outline: prepare fund with <fundId>, <ledgerId> for rollover
+    * configure headers = headersAdmin
+    * def fundId = <fundId>
+    * def ledgerId = <ledgerId>
+    * def fundCode = <fundCode>
+    * def fundTypeId = <fundTypeId>
+
+    Given path 'finance-storage/funds'
+    And request
+    """
+    {
+      "id": "#(fundId)",
+      "code": "#(codePrefix + fundCode)",
+      "description": "Fund #(codePrefix + fundCode) for rollover API Tests",
+      "externalAccountNo": "#(fundId)",
+      "fundStatus": <status>,
+      "ledgerId": "#(ledgerId)",
+      "name": "Fund #(codePrefix + fundCode) for rollover API Tests",
+      "fundTypeId": "#(fundTypeId)"
+    }
+    """
+    When method POST
+    Then status 201
+
+    Examples:
+      | fundId        | ledgerId         | fundCode     | fundTypeId | status     |
+      | law           | rolloverLedger1   | 'LAW'        | books      | 'Active'   |
+
+
+  Scenario Outline: prepare budget with <fundId>, <fiscalYearId> for rollover
+    * def id = <id>
+    * def fundId = <fundId>
+    * def fiscalYearId = <fiscalYearId>
+    * def allocated = <allocated>
+    * def expenseClasses = <expenseClasses>
+
+    Given path 'finance/budgets'
+
+    * def budget =
+    """
+    {
+      "id": "#(id)",
+      "budgetStatus": "Active",
+      "fundId": "#(fundId)",
+      "name": "#(id)",
+      "fiscalYearId":"#(fiscalYearId)",
+      "allocated": #(allocated)
+    }
+    """
+
+    * if (<allowableEncumbrance> != null) karate.set('budget', '$.allowableEncumbrance', <allowableEncumbrance>)
+    * if (<allowableExpenditure> != null) karate.set('budget', '$.allowableExpenditure', <allowableExpenditure>)
+    * set budget.statusExpenseClasses = karate.map(expenseClasses, function(exp){return {'expenseClassId': exp}})
+
+    And request budget
+    When method POST
+    Then status 201
+
+    Given path 'finance/funds', fundId
+    And method GET
+    Then status 200
+
+    * def fundRS = $
+
+    Given path 'finance/funds', fundId
+    When request fundRS
+    And method PUT
+    Then status 204
+
+    Examples:
+      | id                 | fundId        | fiscalYearId     | allocated | allowableExpenditure | allowableEncumbrance | expenseClasses                                            |
+      | law2020            | law           | fromFiscalYearId | 100       | 100                  | 100                  | [#(globalElecExpenseClassId)]                             |
+
+
+  Scenario Outline: Create open orders with 1 fund distribution
+    * configure headers = headersAdmin
+
+    * def orderId = <orderId>
+    * def poLineId = <poLineId>
+    * def fundId = <fundId>
+    * def ongoing = <orderType> == 'Ongoing' ? {"isSubscription": <subscription>, "interval": 182, "renewalDate": "2022-12-03T00:00:00.000+00:00"} : null
+
+    Given path 'orders/composite-orders'
+    And request
+    """
+    {
+      "id": '#(orderId)',
+      "vendor": '#(globalVendorId)',
+      "workflowStatus": "Open",
+      "orderType": <orderType>,
+      "reEncumber": <reEncumber>,
+      "ongoing": #(ongoing),
+      "compositePoLines": [
+        {
+          "id": "#(poLineId)",
+          "acquisitionMethod": "#(globalPurchaseAcqMethodId)",
+          "cost": {
+            "listUnitPrice": "<amount>",
+            "quantityPhysical": 1,
+            "currency": "USD"
+          },
+          "fundDistribution": [
+            {
+              "fundId": "#(fundId)",
+              "distributionType": "percentage",
+              "value": 100
+            }
+          ],
+          "orderFormat": "Physical Resource",
+          "physical": {
+            "createInventory": "None"
+          },
+          "purchaseOrderId": "#(orderId)",
+          "source": "User",
+          "titleOrPackage": "#(poLineId)"
+        }
+      ]
+
+    }
+    """
+    When method POST
+    Then status 201
+
+    Examples:
+      | orderId           | poLineId              | fundId        | orderType  | subscription | reEncumber | amount |
+      | encumberRemaining | encumberRemainingLine | law           | 'One-Time' | false        | true       | 10     |
+
+
+  Scenario Outline: Open order
+    * configure headers = headersAdmin
+
+    * def orderId = <orderId>
+    Given path 'orders/composite-orders', orderId
+    When method GET
+    Then status 200
+
+    * def order = response
+    * set order.workflowStatus = 'Open'
+
+    Given path 'orders/composite-orders', orderId
+    And request order
+    When method PUT
+    Then status 204
+
+    Examples:
+      | orderId           |
+      | encumberRemaining |
+
+
+  Scenario Outline: Re encumber before preview rollover
+    * def orderId = <orderId>
+    Given path 'orders/composite-orders', orderId, '/re-encumber'
+    When method POST
+    Then status 409
+    And match $.errors[0].code == 'encumbrancesForReEncumberNotFound'
+
+    Examples:
+      | orderId           |
+      | encumberRemaining |
+
+
+  Scenario Outline: Start rollover <rolloverId> for ledger <ledgerId>
+    * def ledgerId = <ledgerId>
+    * def rolloverId = <rolloverId>
+    * configure headers = headersUser
+    Given path 'finance/ledger-rollovers'
+    And request
+    """
+      {
+        "id": "#(rolloverId)",
+        "ledgerId": "#(ledgerId)",
+        "fromFiscalYearId": "#(fromFiscalYearId)",
+        "toFiscalYearId": "#(toFiscalYearId)",
+        "restrictEncumbrance": true,
+        "restrictExpenditures": true,
+        "needCloseBudgets": false,
+        "rolloverType": "Preview",
+        "budgetsRollover": [
+          {
+            "rolloverAllocation": false,
+            "adjustAllocation": 0,
+            "rolloverBudgetValue": "None",
+            "setAllowances": false,
+            "allowableEncumbrance": 100,
+            "allowableExpenditure": 100
+          },
+          {
+            "fundTypeId": "#(books)",
+            "rolloverAllocation": true,
+            "adjustAllocation": 10,
+            "rolloverBudgetValue": "None",
+            "setAllowances": false,
+            "allowableEncumbrance": 100,
+            "allowableExpenditure": 100
+          }
+        ],
+        "encumbrancesRollover": [
+          {
+            "orderType": "Ongoing",
+            "basedOn": "Remaining",
+            "increaseBy": 0
+          },
+          {
+            "orderType": "Ongoing-Subscription",
+            "basedOn": "Remaining",
+            "increaseBy": 0
+          },
+          {
+            "orderType": "One-time",
+            "basedOn": "Remaining",
+            "increaseBy": 0
+          }
+        ]
+      }
+    """
+    When method POST
+    Then status 201
+
+    Examples:
+      | ledgerId        | rolloverId  |
+      | rolloverLedger1 | rolloverId1 |
+
+
+  Scenario Outline: Check rollover logs for rolloverId=<rolloverId>
+    * def rolloverId = <rolloverId>
+    Given path 'finance/ledger-rollovers-logs', rolloverId
+    When method GET
+    Then status 200
+    And match response.rolloverStatus == 'Success'
+    And match response.ledgerRolloverType == 'Preview'
+
+    Examples:
+      | rolloverId  |
+      | rolloverId1 |
+
+
+  Scenario Outline: Check rollover statuses rolloverId=<rolloverId>
+    * def rolloverId = <rolloverId>
+
+    Given path 'finance/ledger-rollovers-progress'
+    And param query = 'ledgerRolloverId==' + rolloverId
+    When method GET
+    Then status 200
+    And match response.ledgerFiscalYearRolloverProgresses[0].budgetsClosingRolloverStatus == 'Success'
+    And match response.ledgerFiscalYearRolloverProgresses[0].ordersRolloverStatus == 'Success'
+    And match response.ledgerFiscalYearRolloverProgresses[0].financialRolloverStatus == 'Success'
+    And match response.ledgerFiscalYearRolloverProgresses[0].overallRolloverStatus == 'Success'
+
+    Examples:
+      | rolloverId  |
+      | rolloverId1 |
+
+
+  Scenario Outline: Re encumber after preview rollover
+    * def orderId = <orderId>
+    Given path 'orders/composite-orders', orderId, '/re-encumber'
+    When method POST
+    Then status 409
+    And match $.errors[0].code == 'encumbrancesForReEncumberNotFound'
+
+    Examples:
+      | orderId           |
+      | encumberRemaining |

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-order-re-encumber-after-preview-rollover.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-order-re-encumber-after-preview-rollover.feature
@@ -3,6 +3,13 @@
 @parallel=false
 Feature: Check order re-encumber after preview rollover
 
+  # 1) prepare finance part to rollover
+  # 2) create and open order
+  # 3) re-encumber order from step 2 and get 'encumbrancesForReEncumberNotFound' error code
+  # 4) make preview rollover fiscalYearId1 -> fiscalYearId2
+  # 5) make sure that preview rollover was successfully
+  # 6) retry step 3 and make sure that preview rollover wasn't affected to results of re-encumber
+
   Background:
     * url baseUrl
     # uncomment below line for development

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-skip-previous-year-encumbrance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-skip-previous-year-encumbrance.feature
@@ -2,10 +2,10 @@
 Feature: Ledger fiscal year sequential rollovers (skip previous year encumbrance)
 
   # 1) create 3 sequential fiscal years: fiscalYearId1, fiscalYearId2, fiscalYearId3. fiscalYearId1 contains current date
-  # 3) rollover fiscalYearId1 -> fiscalYearId2
+  # 2) rollover fiscalYearId1 -> fiscalYearId2
   # 3) change fiscalYear for encumbrance from fiscalYearId1 to fiscalYearId2
   # 4) update fiscalYearId1 to end before current date and fiscalYearId2 to include current date (to make it current fiscal year)
-  # 6) rollover fiscalYearId2 -> fiscalYearId3
+  # 5) rollover fiscalYearId2 -> fiscalYearId3
 
   Background:
     * url baseUrl

--- a/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
+++ b/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
@@ -169,6 +169,11 @@ public class CrossModulesApiTest extends TestBase {
     runFeatureTest("update-encumbrance-links-with-fiscal-year");
   }
 
+  @Test
+  void checkOrderReEncumberAfterPreviewRollover() {
+    runFeatureTest("check-order-re-encumber-after-preview-rollover");
+  }
+
   @BeforeAll
   public void crossModuleApiTestBeforeAll() {
     runFeature("classpath:thunderjet/cross-modules/cross-modules-junit.feature");


### PR DESCRIPTION
## Purpose
Check both tickets in one scenario using re-encumber feature and preview rollover

## Approach

- Check re-encumber for newly created order to make sure that filter to check empty re encumber holder works
- Check re-encumber after preview rollover to check that rollover with preview result doesn't take into account when building re-encumber holders

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
[MODORDERS-915](https://issues.folio.org/browse/MODORDERS-915)
[MODORDERS-920](https://issues.folio.org/browse/MODORDERS-920)
