### PR TITLE
[MODCON - 87] - Covered shadow user update features

### DIFF
--- a/mod-consortia/src/main/resources/thunderjet/mod-consortia/consortia-junit.feature
+++ b/mod-consortia/src/main/resources/thunderjet/mod-consortia/consortia-junit.feature
@@ -75,15 +75,15 @@ Feature: mod-consortia integration tests
 
   Scenario: User-Tenant associations api tests
     * call read('features/user-tenant-associations.feature')
-
-  Scenario: Publish coordinator tests
-    * call read('features/publish-coordinator.feature')
-
-  Scenario: Sharing Instances api tests
-    * call read('features/sharing-instance.feature')
-
-  Scenario: Sharing Settings api tests
-    * call read('features/sharing-setting.feature')
+#
+#  Scenario: Publish coordinator tests
+#    * call read('features/publish-coordinator.feature')
+#
+#  Scenario: Sharing Instances api tests
+#    * call read('features/sharing-instance.feature')
+#
+#  Scenario: Sharing Settings api tests
+#    * call read('features/sharing-setting.feature')
 
   Scenario: Destroy created ['university', 'central'] tenants
     * call read('features/util/initData.feature@DeleteTenant') { tenant: '#(universityTenant)'}

--- a/mod-consortia/src/main/resources/thunderjet/mod-consortia/consortia-junit.feature
+++ b/mod-consortia/src/main/resources/thunderjet/mod-consortia/consortia-junit.feature
@@ -75,15 +75,15 @@ Feature: mod-consortia integration tests
 
   Scenario: User-Tenant associations api tests
     * call read('features/user-tenant-associations.feature')
-#
-#  Scenario: Publish coordinator tests
-#    * call read('features/publish-coordinator.feature')
-#
-#  Scenario: Sharing Instances api tests
-#    * call read('features/sharing-instance.feature')
-#
-#  Scenario: Sharing Settings api tests
-#    * call read('features/sharing-setting.feature')
+
+  Scenario: Publish coordinator tests
+    * call read('features/publish-coordinator.feature')
+
+  Scenario: Sharing Instances api tests
+    * call read('features/sharing-instance.feature')
+
+  Scenario: Sharing Settings api tests
+    * call read('features/sharing-setting.feature')
 
   Scenario: Destroy created ['university', 'central'] tenants
     * call read('features/util/initData.feature@DeleteTenant') { tenant: '#(universityTenant)'}

--- a/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/publish-coordinator.feature
+++ b/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/publish-coordinator.feature
@@ -7,12 +7,12 @@ Feature: Consortia publish coordinator tests
     * configure headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json' }
     * def tagLabel = 'cons-test'
     * def tagDescription = 'consortia karate test tag'
-    * def departmentId = 'c1a80e50-45a9-430c-a25e-e0adcc28ff6f'
+    * def departmentId = '6b757b4c-202f-4187-a674-e16ab07f5e25'
     * def wrongConsortiumId = 'a051a9f0-3512-11ee-be56-0242ac120002'
-    * def name = 'Accounting'
-    * def updateName = 'Management'
-    * def code = 'XXX'
-    * def updateCode = 'YYY'
+    * def name = 'Accounting12345'
+    * def updateName = 'Management1234'
+    * def code = 'XX1'
+    * def updateCode = 'YY1'
     * def source = 'System'
 
   @Positive
@@ -138,6 +138,7 @@ Feature: Consortia publish coordinator tests
             "#(centralTenant)",
             "#(universityTenant)",
             "#(collegeTenant)"
+
         ],
         "payload": {
             "id": "#(departmentId)",
@@ -192,17 +193,17 @@ Feature: Consortia publish coordinator tests
     When method GET
     Then status 200
     * def centralResponse = karate.toString(response.publicationResults[0])
-    * match centralResponse contains 'c1a80e50-45a9-430c-a25e-e0adcc28ff6f'
-    * match centralResponse contains 'Accounting'
-    * match centralResponse contains 'XXX'
+    * match centralResponse contains '6b757b4c-202f-4187-a674-e16ab07f5e25'
+    * match centralResponse contains 'Accounting12345'
+    * match centralResponse contains 'XX1'
     * def universityResponse = karate.toString(response.publicationResults[1])
-    * match universityResponse contains 'c1a80e50-45a9-430c-a25e-e0adcc28ff6f'
-    * match universityResponse contains 'Accounting'
-    * match universityResponse contains 'XXX'
+    * match universityResponse contains '6b757b4c-202f-4187-a674-e16ab07f5e25'
+    * match universityResponse contains 'Accounting12345'
+    * match universityResponse contains 'XX1'
     * def collegeResponse = karate.toString(response.publicationResults[2])
-    * match collegeResponse contains 'c1a80e50-45a9-430c-a25e-e0adcc28ff6f'
-    * match collegeResponse contains 'Accounting'
-    * match collegeResponse contains 'XXX'
+    * match collegeResponse contains '6b757b4c-202f-4187-a674-e16ab07f5e25'
+    * match collegeResponse contains 'Accounting12345'
+    * match collegeResponse contains 'XX1'
 
   @Positive
   Scenario: Sending PUT request to update and check results
@@ -212,7 +213,7 @@ Feature: Consortia publish coordinator tests
     And request
     """
       {
-          "url": "/departments/c1a80e50-45a9-430c-a25e-e0adcc28ff6f",
+          "url": "/departments/6b757b4c-202f-4187-a674-e16ab07f5e25",
           "method": "PUT",
           "tenants": [
               "#(centralTenant)",
@@ -267,7 +268,7 @@ Feature: Consortia publish coordinator tests
     And match response.name == updateName
     And match response.code == updateCode
 
-    # 4.3 Check from tags endpoint that tag is created in college tenant
+#   4.3 Check from tags endpoint that tag is created in college tenant
     Given path 'departments', departmentId
     And header x-okapi-tenant = collegeTenant
     When method GET
@@ -284,7 +285,7 @@ Feature: Consortia publish coordinator tests
     And request
     """
       {
-          "url": "/departments/c1a80e50-45a9-430c-a25e-e0adcc28ff6f",
+          "url": "/departments/6b757b4c-202f-4187-a674-e16ab07f5e25",
           "method": "DELETE",
           "tenants": [
               "#(centralTenant)",
@@ -391,12 +392,13 @@ Feature: Consortia publish coordinator tests
     When method GET
     Then status 200
     * def centralResponse = karate.toString(response.publicationResults[0])
-    * match centralResponse contains 'c1a80e50-45a9-430c-a25e-e0adcc28ff6f'
-    * match centralResponse contains 'Accounting'
-    * match centralResponse contains 'XXX'
-    * def universityResponse = response.publicationResults[1]
-    * match universityResponse.statusCode == 422
+    * match centralResponse contains '6b757b4c-202f-4187-a674-e16ab07f5e25'
+    * match centralResponse contains 'Accounting12345'
+    * match centralResponse contains 'XX1'
+    * def universityResponse = karate.toString(response.publicationResults[1])
+    * match karate.toString(universityResponse) contains '422'
+    * match response.publicationResults[1].statusCode == 400
     * def collegeResponse = karate.toString(response.publicationResults[2])
-    * match collegeResponse contains 'c1a80e50-45a9-430c-a25e-e0adcc28ff6f'
-    * match collegeResponse contains 'Accounting'
-    * match collegeResponse contains 'XXX'
+    * match collegeResponse contains '6b757b4c-202f-4187-a674-e16ab07f5e25'
+    * match collegeResponse contains 'Accounting12345'
+    * match collegeResponse contains 'XX1'

--- a/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/sharing-setting.feature
+++ b/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/sharing-setting.feature
@@ -303,7 +303,7 @@ Feature: Consortia Sharing Settings api tests
     And request
     """
     {
-        "id": "#(departmentId)",
+        "id": "#(settingId)",
         "name": "#(name)",
         "code": "#(code)",
         "usageNumber": 10,

--- a/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/sharing-setting.feature
+++ b/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/sharing-setting.feature
@@ -13,9 +13,17 @@ Feature: Consortia Sharing Settings api tests
     * def updateCode = 'YYY'
     * def source = 'System'
 
+  # Currently, we have three tenants 1) centralTenant, 2) universityTenant, 3) collegeTenant. 
+  # We will test these below cases:
+  #   0. All Negative cases  
+  #   1. Share new settings for 3 tenants - POST method for publication request
+  #   2. Update existing settings for 3 tenants - PUT method for publication request
+  #   3. Delete existing settings for 3 tenants - DELETE method for publication request
+  #   4. The case of error occurred one of three tenants while sharing settings
+
   @Negative
-  Scenario: Attempt to POST a sharingSetting with invalid request body or non-existing path id
-    # Case for 404
+  Scenario: Attempt to POST a sharingSetting with invalid request body or non-existing path id for 3 tenants
+    # Cases for 404
     # attempt to create a sharingSetting for non-existing consortium
     Given path 'consortia', wrongConsortiumId, 'sharing/settings'
     And header x-okapi-tenant = centralTenant
@@ -36,6 +44,20 @@ Feature: Consortia Sharing Settings api tests
     When method POST
     Then status 404
     And match response == { errors: [{message: 'Object with consortiumId [a051a9f0-3512-11ee-be56-0242ac120002] was not found', type: '-1', code: 'NOT_FOUND_ERROR'}] }
+
+    # 1. Delete sharing setting for both centralTenant and universityTenant
+    Given path 'consortia', consortiumId, 'sharing/settings', settingId
+    And header x-okapi-tenant = centralTenant
+    And request
+    """
+    {
+      settingId: '#(settingId)',
+      url: '/departments',
+    }
+    """
+    When method DELETE
+    Then status 404
+    And match response == { errors: [{message: 'Object with settingId [cf23adf0-61ba-4887-bf82-956c4aae2260] was not found', type: '-1', code: 'NOT_FOUND_ERROR'}] }
 
     # Cases for 400
     # attempt to create a sharingSetting with request which has mismatch settingId with id in payload
@@ -101,8 +123,8 @@ Feature: Consortia Sharing Settings api tests
     And match response == { errors: [{message: "'url' validation failed. must not be null", type: '-1', code: 'sharingSettingRequestValidationError'}] }
 
   @Positive
-  Scenario: POST request to start sharing setting and and check request details
-    #1. Create sharing setting for both centralTenant and universityTenant
+  Scenario: POST request to start sharing setting and and check request details for 3 tenants
+    # 1. Create sharing setting for 3 tenants: centralTenant, universityTenant and collegeTenant
     Given path 'consortia', consortiumId, 'sharing/settings'
     And header x-okapi-tenant = centralTenant
     And request
@@ -124,7 +146,7 @@ Feature: Consortia Sharing Settings api tests
     And match response == {createSettingsPCId: '#notnull'}
     * def createSettingsPCId = response.createSettingsPCId
 
-    #2. Check details from publication request by using response createSettingsPCId
+    # 2. Check details from publication request by using response createSettingsPCId
     Given path 'consortia', consortiumId, 'publications', createSettingsPCId
     And header x-okapi-tenant = centralTenant
     And retry until response.status == 'COMPLETE'
@@ -133,7 +155,7 @@ Feature: Consortia Sharing Settings api tests
     And match response.status == 'COMPLETE'
     And print response.request
 
-    #3. Check created object from database for central tenant by using request id(#settingId) and url(#/departments)
+    # 3.1. Check created object from database for CENTRAL TENANT by using request id(#settingId) and url(#/departments)
     Given path 'departments', settingId
     And header x-okapi-tenant = centralTenant
     When method GET
@@ -143,7 +165,7 @@ Feature: Consortia Sharing Settings api tests
     And match response.code == '#(code)'
     And match response.source == 'consortium'
 
-    #4. Check created object from database for university tenant by using request id(#settingId) and url(#/departments)
+    # 3.2. Check created object from database for UNIVERSITY TENANT by using request id(#settingId) and url(#/departments)
     Given path 'departments', settingId
     And header x-okapi-tenant = universityTenant
     When method GET
@@ -152,10 +174,20 @@ Feature: Consortia Sharing Settings api tests
     And match response.name == '#(name)'
     And match response.code == '#(code)'
     And match response.source == 'consortium'
+    
+    # 3.3. Check created object from database for COLLEGE TENANT by using request id(#settingId) and url(#/departments)
+    Given path 'departments', settingId
+    And header x-okapi-tenant = collegeTenant
+    When method GET
+    Then status 200
+    And match response.id == '#(settingId)'
+    And match response.name == '#(name)'
+    And match response.code == '#(code)'
+    And match response.source == 'consortium'
 
   @Positive
-  Scenario: POST request to UPDATE existing sharing setting and check request details
-    #1. Update sharing setting for both centralTenant and universityTenant
+  Scenario: POST request to UPDATE existing sharing setting and check request details for 3 tenants
+    # 1. Update sharing setting for 3 tenants: centralTenant, universityTenant and collegeTenant
     Given path 'consortia', consortiumId, 'sharing/settings'
     And header x-okapi-tenant = centralTenant
     And request
@@ -177,7 +209,7 @@ Feature: Consortia Sharing Settings api tests
     And match response == {updateSettingsPCId: '#notnull'}
     * def updateSettingsPCId = response.updateSettingsPCId
 
-    #2. Check details from publication request by using response updateSettingsPCId
+    # 2. Check details from publication request by using response updateSettingsPCId
     Given path 'consortia', consortiumId, 'publications', updateSettingsPCId
     And header x-okapi-tenant = centralTenant
     And retry until response.status == 'COMPLETE'
@@ -186,7 +218,7 @@ Feature: Consortia Sharing Settings api tests
     And match response.status == 'COMPLETE'
     And print response.request
 
-    #3. Check updated object from database for central tenant by using request id(#settingId) and url(#/departments)
+    # 3.1. Check updated object from database for CENTRAL TENANT by using request id(#settingId) and url(#/departments)
     Given path 'departments', settingId
     And header x-okapi-tenant = centralTenant
     When method GET
@@ -196,7 +228,7 @@ Feature: Consortia Sharing Settings api tests
     And match response.code == '#(updateCode)'
     And match response.source == 'consortium'
 
-    #4. Check updated object from database for university tenant by using request id(#settingId) and url(#/departments)
+    # 3.2. Check updated object from database for UNIVERSITY TENANT by using request id(#settingId) and url(#/departments)
     Given path 'departments', settingId
     And header x-okapi-tenant = universityTenant
     When method GET
@@ -206,9 +238,19 @@ Feature: Consortia Sharing Settings api tests
     And match response.code == '#(updateCode)'
     And match response.source == 'consortium'
 
+    # 3.3. Check updated object from database for COLLEGE TENANT by using request id(#settingId) and url(#/departments)
+    Given path 'departments', settingId
+    And header x-okapi-tenant = collegeTenant
+    When method GET
+    Then status 200
+    And match response.id == '#(settingId)'
+    And match response.name == '#(updateName)'
+    And match response.code == '#(updateCode)'
+    And match response.source == 'consortium'
+
   @Positive
-  Scenario: DELETE request to delete existing shared settings and check request details
-    #1. Delete sharing setting for both centralTenant and universityTenant
+  Scenario: DELETE request to delete existing shared settings and check request details of 3 tenants
+    # 1. Delete sharing setting for 3 tenants: centralTenant, universityTenant and collegeTenant
     Given path 'consortia', consortiumId, 'sharing/settings', settingId
     And header x-okapi-tenant = centralTenant
     And request
@@ -223,7 +265,7 @@ Feature: Consortia Sharing Settings api tests
     And match response == {pcId: '#notnull'}
     * def pcId = response.pcId
 
-    #2. Check details from publication request by using response pc ('IN_PROGRESS' status should be 'COMPLETE')
+    # 2. Check details from publication request by using response pc ('IN_PROGRESS' status should be 'COMPLETE')
     Given path 'consortia', consortiumId, 'publications', pcId
     And header x-okapi-tenant = centralTenant
     And retry until response.status == 'COMPLETE'
@@ -231,14 +273,92 @@ Feature: Consortia Sharing Settings api tests
     Then status 200
     And match response.status == 'COMPLETE'
 
-    #3. Check removed object from database for central tenant by using request id(#settingId) and url(#/departments)
+    # 3.1. Check removed object from database for CENTRAL TENANT by using request id(#settingId) and url(#/departments)
     Given path 'departments', settingId
     And header x-okapi-tenant = centralTenant
     When method GET
     Then status 404
 
-    #4. Check removed object from database for university tenant by using request id(#settingId) and url(#/departments)
+    # 3.2. Check removed object from database for UNIVERSITY TENANT by using request id(#settingId) and url(#/departments)
     Given path 'departments', settingId
     And header x-okapi-tenant = universityTenant
     When method GET
     Then status 404
+
+    # 3.3. Check removed object from database for COLLEGE TENANT by using request id(#settingId) and url(#/departments)
+    Given path 'departments', settingId
+    And header x-okapi-tenant = collegeTenant
+    When method GET
+    Then status 404
+
+  @Negative
+  Scenario: Verify publication status to Error, in case of publication request fails for one of three tenants
+    # In order to create this situation, we create a department object in universityTenant,
+    # and then, it throw 422 exception (because of having same name, code), when we save object for this tenant.
+    # As a result, one of them will fail and others will completed. Last status of publication request should be ERROR
+
+    # 1. We will create department object in second tenant
+    Given path 'departments'
+    And header x-okapi-tenant = universityTenant
+    And request
+    """
+    {
+        "id": "#(departmentId)",
+        "name": "#(name)",
+        "code": "#(code)",
+        "usageNumber": 10,
+        "source": "#(source)"
+    }
+    """
+    When method POST
+    Then status 201
+
+    # 2. Create sharing setting for 3 tenants: centralTenant, universityTenant and collegeTenant
+    Given path 'consortia', consortiumId, 'sharing/settings'
+    And header x-okapi-tenant = centralTenant
+    And request
+    """
+    {
+      settingId: '#(settingId)',
+      url: '/departments',
+      payload: {
+          id: '#(settingId)',
+          name: '#(name)',
+          code: '#(code)',
+          usageNumber: 5,
+          source: '#(source)'
+      }
+    }
+    """
+    When method POST
+    Then status 201
+    And match response == {createSettingsPCId: '#notnull'}
+    * def createSettingsPCId = response.createSettingsPCId
+
+    # 3. Check details from publication request by using response createSettingsPCId
+    Given path 'consortia', consortiumId, 'publications', createSettingsPCId
+    And header x-okapi-tenant = centralTenant
+    And retry until response.status == 'ERROR'
+    When method GET
+    Then status 200
+    And match response.status == 'ERROR'
+    And print response.request
+
+    # 4. Check created object from database for central tenant by using request id(#settingId) and url(#/departments)
+    # Central and college tenant sharing settings should not be affected by error of university tenant tenant
+    Given path 'departments', settingId
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    And match response.id == '#(settingId)'
+    And match response.name == '#(name)'
+    And match response.code == '#(code)'
+    And match response.source == 'consortium'
+
+    # 5. Check results of publication request which should be 422 error code
+    Given path 'consortia', consortiumId, 'publications', createSettingsPCId, 'results'
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    * def universityResponse = response.publicationResults[1]
+    * match universityResponse.statusCode == 422

--- a/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/tenant.feature
+++ b/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/tenant.feature
@@ -103,11 +103,12 @@ Feature: Tenant object in mod-consortia api tests
     Then status 201
     And match response == { id: '#(centralTenant)', code: 'ABC', name: 'Central tenants name', isCentral: true }
 
-    # check a status of tenant and it should be IN_PROGRESS because university tenant has a user to create affiliations
+    # check a status of tenant. it should finish syncing affiliations and be status COMPLETED
     Given path 'consortia', consortiumId, 'tenants', centralTenant
+    And retry until response.setupStatus == 'COMPLETED'
     When method GET
     Then status 200
-    And match response.setupStatus == 'IN_PROGRESS'
+    And match response.setupStatus == 'COMPLETED'
 
     # get tenants of the consortium (after posting 'central' tenant)
     Given path 'consortia', consortiumId, 'tenants'
@@ -120,13 +121,6 @@ Feature: Tenant object in mod-consortia api tests
     When method GET
     Then status 200
     And match response.centralTenantId == centralTenant
-
-    # check a status of tenant. it should finish syncing affiliations and be status COMPLETED
-    Given path 'consortia', consortiumId, 'tenants', centralTenant
-    And retry until response.setupStatus == 'COMPLETED'
-    When method GET
-    Then status 200
-    And match response.setupStatus == 'COMPLETED'
 
   @Negative
   # At this point we have one record in consortium = { id: '#(centralTenant)', code: 'ABC', name: 'Central tenants name', isCentral: true }
@@ -279,10 +273,11 @@ Feature: Tenant object in mod-consortia api tests
     And match response == { id: '#(universityTenant)', code: 'XYZ', name: 'University tenants name', isCentral: false }
 
     # check a status of tenant and it should be IN_PROGRESS or COMPLETED because tenant has a user to create affiliations
-    Given path 'consortia', consortiumId, 'tenants', centralTenant
+    Given path 'consortia', consortiumId, 'tenants', universityTenant
+    And retry until response.setupStatus == 'COMPLETED'
     When method GET
     Then status 200
-    And match response.setupStatus == 'IN_PROGRESS' || response.setupStatus == 'COMPLETED'
+    And match response.setupStatus == 'COMPLETED'
 
     # get tenants by consortiumId - should get two tenants
     Given path 'consortia', consortiumId, 'tenants'
@@ -308,10 +303,3 @@ Feature: Tenant object in mod-consortia api tests
     Then status 200
     And match response.totalRecords == 1
     And match response.userTenants[0].tenantId == universityTenant
-
-    # check a status of tenant. it should finish syncing affiliations and be status COMPLETED
-    Given path 'consortia', consortiumId, 'tenants', centralTenant
-    And retry until response.setupStatus == 'COMPLETED'
-    When method GET
-    Then status 200
-    And match response.setupStatus == 'COMPLETED'

--- a/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/user-tenant-associations.feature
+++ b/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/user-tenant-associations.feature
@@ -730,8 +730,8 @@ Feature: Consortia User Tenant associations api tests
     When method PUT
     Then status 204
 
-    # 4.1. Then we will verify updated firstName, lastName
-    # 4.2. We should also verify there is no other personal info such as email, middleName..
+    # 4. Then we will verify updated firstName, lastName
+    # We should also verify there is no other personal info such as email, middleName..
     Given path 'users', userId
     And header x-okapi-tenant = universityTenant
     When method GET
@@ -757,6 +757,6 @@ Feature: Consortia User Tenant associations api tests
     # 7. Check permission with shadow user id
     Given path 'perms/users'
     And header x-okapi-tenant = universityTenant
-    And param query = 'userId=' +
+    And param query = 'userId=' + userId
     When method GET
     Then status 404

--- a/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/user-tenant-associations.feature
+++ b/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/user-tenant-associations.feature
@@ -689,7 +689,7 @@ Feature: Consortia User Tenant associations api tests
     Then status 201
 
     # 2. Then, we create a affiliation with university tenant. it create a shadow user in universityTenant
-    Given path 'consortium', consortiumId, 'user-tenants'
+    Given path 'consortia', consortiumId, 'user-tenants'
     And header x-okapi-tenant = centralTenant
     And request
     """


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/MODCON-87
## Approach
Covered shadow user update features

- Shadow user has new custom field 'originalTenantId' to indicate where real user lives
- Shadow user has only firstName and lastName in personal object, no other fields in personal populated
- When editing firstName or lastName for real user - all shadow users should have synced firstName and lastName
- When deleting real user now we have logic to delete all shadow users, we need to check also that all permission users for these shadow users also deleted

Publish coordinator tests

- Modify existing test to use 3 tenants
- Add negative tests that all or some tenants produce error during PC request 
- Currently we have tests only for POST method, need to add tests for GET, PUT, DELETE

Sharing setting tests
- Add tests to share new setting in 3 tenants
- Add tests to update sharing setting in 3 tenants
- Add tests to delete sharing setting in 3 tenants
- (If time allows) Add tests to update setting to local if deletion was failed