### PR TITLE
FAT-7774 - Bulk Operation test failures

### DIFF
--- a/mod-bulk-operations/src/main/resources/firebird/mod-bulk-operations/features/holdings.feature
+++ b/mod-bulk-operations/src/main/resources/firebird/mod-bulk-operations/features/holdings.feature
@@ -105,7 +105,7 @@ Feature: mod bulk operations holdings features
     And param step = 'EDIT'
     When method GET
     And match response.rows[0].row[6] == 'Popular Reading Collection 139'
-    And match response.rows[0].row[7] == ''
+    And match response.rows[0].row[7] == '#null'
 
     Given path 'bulk-operations', operationId, 'download'
     And param fileContentType = 'PROPOSED_CHANGES_FILE'
@@ -130,7 +130,7 @@ Feature: mod bulk operations holdings features
     And param step = 'COMMIT'
     When method GET
     And match response.rows[0].row[6] == 'Popular Reading Collection 139'
-    And match response.rows[0].row[7] == ''
+    And match response.rows[0].row[7] == '#null'
 
     Given path 'bulk-operations', operationId, 'errors'
     And param limit = '10'

--- a/mod-bulk-operations/src/main/resources/firebird/mod-bulk-operations/features/items.feature
+++ b/mod-bulk-operations/src/main/resources/firebird/mod-bulk-operations/features/items.feature
@@ -133,10 +133,10 @@ Feature: mod bulk operations items features
     When method GET
     Then status 200
     And match response.rows[0].row[33] contains 'Unknown'
-    And match response.rows[0].row[36] == ''
+    And match response.rows[0].row[36] == '#null'
     And match response.rows[0].row[37] == 'Selected'
     And match response.rows[0].row[39] == 'Annex'
-    And match response.rows[0].row[40] == ''
+    And match response.rows[0].row[40] == '#null'
 
     Given path 'bulk-operations', operationId, 'download'
     And param fileContentType = 'PROPOSED_CHANGES_FILE'
@@ -161,10 +161,10 @@ Feature: mod bulk operations items features
     And param step = 'COMMIT'
     When method GET
     And match response.rows[0].row[33] contains 'Unknown'
-    And match response.rows[0].row[36] == ''
+    And match response.rows[0].row[36] == '#null'
     And match response.rows[0].row[37] == 'Selected'
     And match response.rows[0].row[39] == 'Annex'
-    And match response.rows[0].row[40] == ''
+    And match response.rows[0].row[40] == '#null'
 
     Given path 'bulk-operations', operationId, 'errors'
     And param limit = '10'


### PR DESCRIPTION
## Purpose
Fixing [FAT-7774](https://issues.folio.org/browse/FAT-7774) - Karate test fail: [firebird/mod-bulk-operations] ModBulkOperationsApiTest {2}  firebird/mod-bulk-operations/features/items.feature

## Approach
Replacing '' to '#null' for some fields

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
