### PR TITLE
[RANCHER-971] - Moved mocked server url to karate-config.js file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,8 @@ sh ./runtests.sh ${PROJECT} ${ENVIRONMENT}
 ## Running D2IR mock server
 
 * [Mock server documentation](https://www.mock-server.com/)
-* [Mock server URL](https://folio-dev-volaris-mock-server.ci.folio.org/)
-* [Mock server dashboard](https://folio-dev-volaris-mock-server.ci.folio.org/mockserver/dashboard)
+* [Mock server URL](Configure in karate-config.js file as centralServerUrl)
+* [Mock server dashboard](centralServerUrl/mockserver/dashboard)
 * [Mock server deployment steps](https://wiki.folio.org/display/DD/D2IR+Mock+Server+Deployment+in+Rancher)
 * Mock server expectation initializer config file is located at mod-inn-reach/src/main/resources/volaris/mod-inn-reach/mocks/general/expectation_initializer.json
 

--- a/edge-inn-reach/src/main/resources/karate-config.js
+++ b/edge-inn-reach/src/main/resources/karate-config.js
@@ -11,6 +11,7 @@ function fn() {
   var config = {
     baseUrl: 'http://localhost:9130',
     edgeUrl: 'http://localhost:9703',
+    centralServerUrl: 'https://folio-dev-volaris-mock-server.ci.folio.org',
     admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
     prototypeTenant: 'diku',
 

--- a/edge-inn-reach/src/main/resources/volaris/edge-inn-reach/features/central-server.feature
+++ b/edge-inn-reach/src/main/resources/volaris/edge-inn-reach/features/central-server.feature
@@ -4,6 +4,7 @@ Feature: Central server
 
   Background:
     * url baseUrl
+    * url centralServerUrl
 
     * callonce login testUser
     * def okapitokenUser = okapitoken
@@ -17,7 +18,6 @@ Feature: Central server
     * def port = mockServer.port
 
     * def notExistedCentralServerId1 = globalCentralServerId1
-    * def centralServerUrl = 'https://folio-dev-volaris-mock-server.ci.folio.org'
 
     * def invalidCentralServerId3 = callonce uuid3
 

--- a/mod-inn-reach/src/main/resources/karate-config.js
+++ b/mod-inn-reach/src/main/resources/karate-config.js
@@ -11,6 +11,7 @@ function fn() {
   var config = {
     baseUrl: 'http://localhost:9130',
     edgeUrl: 'http://localhost:8000',
+    centralServerUrl: 'https://folio-dev-volaris-mock-server.ci.folio.org',
     admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
     prototypeTenant: 'diku',
 

--- a/mod-inn-reach/src/main/resources/volaris/mod-inn-reach/features/central-server.feature
+++ b/mod-inn-reach/src/main/resources/volaris/mod-inn-reach/features/central-server.feature
@@ -16,8 +16,6 @@ Feature: Central server
     * def port = mockServer.port
 
     * def notExistedCentralServerId1 = globalCentralServerId1
-    * def centralServerUrl = 'https://folio-dev-volaris-mock-server.ci.folio.org'
-
     * def invalidCentralServerId3 = callonce uuid3
 
   @create


### PR DESCRIPTION
## Purpose
The purpose of this PR is to move centeralServerUrl to karate-config.js file which can be configured and changed easily.

## Approach
In edge-inn-reach central-server.feature file there was need to replace the hardcoded value with configurable URL form karate.config.js file. This will be sufficient for both the central-server.feature file present in md/edge-inn-reach karate runs.

