### PR TITLE
FAT-7865: Fix error message spelling for pickup service point validation

### DIFF
--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
@@ -1693,7 +1693,7 @@ Feature: Requests tests
     * def newRequestPolicyId = call uuid1
     * def firstServicePointId = call uuid1
     * def secondServicePointId = call uuid1
-    * def expectedErrorMessage = 'One or more Pickup Locations are no longer available'
+    * def expectedErrorMessage = 'One or more Pickup locations are no longer available'
     * def expectedErrorCode = 'REQUEST_PICKUP_SERVICE_POINT_IS_NOT_ALLOWED'
 
     # prepare domain objects

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/tlr-requests.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/tlr-requests.feature
@@ -465,7 +465,7 @@ Feature: Title level request tests
     * def newRequestPolicyId = call uuid1
     * def firstServicePointId = call uuid1
     * def secondServicePointId = call uuid1
-    * def expectedErrorMessage = 'One or more Pickup Locations are no longer available'
+    * def expectedErrorMessage = 'One or more Pickup locations are no longer available'
     * def expectedErrorCode = 'REQUEST_PICKUP_SERVICE_POINT_IS_NOT_ALLOWED'
 
     # prepare domain objects


### PR DESCRIPTION
## Purpose
Fix error message spelling for pickup service point validation.
Resolves [FAT-7865](https://issues.folio.org/browse/FAT-7865).

## Approach
_How does this change fulfill the purpose?_

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
