### PR TITLE
FAT-7866: Return only one error during request policy validation

### DIFF
--- a/mod-circulation-storage/src/main/resources/vega/mod-circulation-storage/features/request-policies.feature
+++ b/mod-circulation-storage/src/main/resources/vega/mod-circulation-storage/features/request-policies.feature
@@ -26,11 +26,8 @@ Feature: Tests for Request Policies API
     Then status 422
     And match response.errors == '#[1]'
     * def error = response.errors[0]
-    And match error.message == 'Service point is not a pickup location'
+    And match error.message == 'One or more Pickup locations are no longer available'
     And match error.code == 'INVALID_ALLOWED_SERVICE_POINT'
-    And match error.parameters == '#[1]'
-    And match error.parameters[0].key contains 'servicePointId'
-    And match error.parameters[0].value contains servicePointId2
 
     # make service point #2 a pickup location
     * def servicePoint2 = postServicePointResponse2.response
@@ -57,21 +54,19 @@ Feature: Tests for Request Policies API
     Then status 422
     And match response.errors == '#[1]'
     * def error = response.errors[0]
-    And match error.message == 'Service point is not a pickup location'
+    And match error.message == 'One or more Pickup locations are no longer available'
     And match error.code == 'INVALID_ALLOWED_SERVICE_POINT'
-    And match error.parameters == '#[1]'
-    And match error.parameters[0].key contains 'servicePointId'
-    And match error.parameters[0].value contains servicePointId3
 
     # allow a non-existent service point for recall requests
     * def nonExistentServicePointId = call uuid1
     * requestPolicy.allowedServicePoints = {'Hold' : [servicePointId1, servicePointId2, servicePointId3], 'Recall' : [nonExistentServicePointId] }
 
-    # attempt to update request policy, should fail with multiple errors
+    # attempt to update request policy, should fail with same error
     Given path 'request-policy-storage', 'request-policies', requestPolicyId
     And request requestPolicy
     When method PUT
     Then status 422
-    And match response.errors == '#[2]'
-    And match response.errors[*] contains {'message': 'Service point does not exist', 'code': 'INVALID_ALLOWED_SERVICE_POINT', parameters: [ { 'key': 'servicePointId', 'value': #(nonExistentServicePointId) } ] }
-    And match response.errors[*] contains {'message': 'Service point is not a pickup location', 'code': 'INVALID_ALLOWED_SERVICE_POINT', parameters: [ { 'key': 'servicePointId', 'value': #(servicePointId3) } ] }
+    And match response.errors == '#[1]'
+    * def error = response.errors[0]
+    And match error.message == 'One or more Pickup locations are no longer available'
+    And match error.code == 'INVALID_ALLOWED_SERVICE_POINT'


### PR DESCRIPTION
## Purpose
Return only one error during request policy validation.
Resolves [FAT-7866](https://issues.folio.org/browse/FAT-7866).

## Approach
_How does this change fulfill the purpose?_

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
