### PR TITLE
[MODORDERS-927] - Implement interception and update of invalid ISBNs during the POL update process

### DIFF
--- a/acquisitions/src/main/resources/global/inventory.feature
+++ b/acquisitions/src/main/resources/global/inventory.feature
@@ -30,6 +30,18 @@ Feature: global inventory
     When method POST
     Then status 201
 
+  Scenario: create identifier types ISBN
+    Given path 'identifier-types'
+    And request
+    """
+    {
+      "id": "e6633d72-a51a-45bb-9385-9a257848e686",
+      "name": "Invalid ISBN"
+    }
+    """
+    When method POST
+    Then status 201
+
   Scenario: create instance types
     Given path 'instance-types'
     And request

--- a/acquisitions/src/main/resources/global/variables.feature
+++ b/acquisitions/src/main/resources/global/variables.feature
@@ -23,6 +23,7 @@ Feature: Global variables
   Scenario: inventory variables
     * def globalIdentifierTypeId = '6d6f642d-0010-1111-aaaa-6f7264657273'
     * def globalISBNIdentifierTypeId = '8261054f-be78-422d-bd51-4ed9f33c3422'
+    * def globalInvalidISBNIdentifierTypeId = 'e6633d72-a51a-45bb-9385-9a257848e686'
     * def globalInstanceTypeId = '6d6f642d-0000-1111-aaaa-6f7264657273'
     * def globalSecondInstanceTypeId = '30fffe0e-e985-4144-b2e2-1e8179bdb41f'
     * def globalInstanceStatusId = 'daf2681c-25af-4202-a3fa-e58fdf806183'


### PR DESCRIPTION
## Purpose
MODORDERS-658 isn't actual anymore. After implementing MODORDERS-927 productIds will be updated on PUT operation.

## Approach
- Added 'Invalid ISBN' identifier type
- Updated scenario to follow MODORDERS-927 changes

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
[MODORDERS-927](https://issues.folio.org/browse/MODORDERS-927)
