### PR TITLE
[FAT-8556] - Added personal object details while creating the user.

### DIFF
--- a/mod-audit/src/main/resources/global/initTest.feature
+++ b/mod-audit/src/main/resources/global/initTest.feature
@@ -191,7 +191,8 @@ Feature: create user, item, service point
     "barcode": "#(userBarcode)",
     "active": true,
     "type": "patron",
-    "patronGroup": "#(userGroupId)"
+    "patronGroup": "#(userGroupId)",
+    "personal": {"firstName":"Test1","lastName":"Audit API Tests"}
     }
     """
     When method POST


### PR DESCRIPTION
## Purpose
_Describe the purpose of the pull request._
The purpose of this PR is to fix the failing test cases for mod-audit.

## Approach
_How does this change fulfill the purpose?_
The personal data should be specified during user creation without which NPE was thrown.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
