### PR TITLE
Extend pause before module setup edge-oai-pmh-junit.feature

### DIFF
--- a/edge-oai-pmh/src/main/resources/firebird/edge-oai-pmh/edge-oai-pmh-junit.feature
+++ b/edge-oai-pmh/src/main/resources/firebird/edge-oai-pmh/edge-oai-pmh-junit.feature
@@ -19,5 +19,5 @@ Feature: mod-audit integration tests
 
 
   Scenario: create tenant and users for testing
-    * pause(5000)
+    * pause(300000)
     Given call read('classpath:common/setup-users.feature')


### PR DESCRIPTION
## Purpose
Prevent failures.

## Approach
Extend pause before modules setup.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
