### PR TITLE
[FAT-9139] - Fixed randomly failed rollover preview test

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-preview-rollover.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-preview-rollover.feature
@@ -919,6 +919,13 @@ Feature: Ledger fiscal year rollover
     When method POST
     Then status 201
 
+    * configure retry = { count: 10, interval: 500 }
+    Given path 'finance/ledger-rollovers-progress'
+    And param query = 'ledgerRolloverId==' + rolloverId
+    And retry until response.ledgerFiscalYearRolloverProgresses[0].overallRolloverStatus != 'In Progress'
+    When method GET
+    Then status 200
+
     Examples:
       | ledgerId        | rolloverId  |
       | rolloverLedger1 | rolloverId1 |
@@ -989,20 +996,6 @@ Feature: Ledger fiscal year rollover
       | rollHist    | 'ROLLHIST'  | 'Active'    | 198       | 196.9     | 1.1         | 0            | 1.1        | null                 | null                 |
       | law2        | 'LAW2'      | 'Active'    | 88        | 88        | 0           | 0            | 0          | 160.0                | 170.0                |
       | euroHist    | 'EUROHIST'  | 'Active'    | 0         | 0         | 0           | 0            | 0          | 100.0                | 100.0                |
-
-  Scenario Outline: Wait for rollover to end
-    * def rolloverId = <rolloverId>
-    * configure retry = { count: 10, interval: 3000 }
-    Given path 'finance/ledger-rollovers-progress'
-    And param query = 'ledgerRolloverId==' + rolloverId
-    And retry until response.ledgerFiscalYearRolloverProgresses[0].overallRolloverStatus != 'In Progress'
-    When method GET
-    Then status 200
-
-    Examples:
-      | rolloverId  |
-      | rolloverId1 |
-      | rolloverId2 |
 
   Scenario Outline: Check rollover logs for rolloverId=<rolloverId>
     * def rolloverId = <rolloverId>


### PR DESCRIPTION
## Purpose
Due to the fact that rollovers were not executed sequentially, it is likely that lock errors occurred. 

## Approach
It was decided to initiate a rollover only after the completion of the previous one.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
