### PR TITLE
FAT-8301: Fix and adjust authority tests

### DIFF
--- a/mod-entities-links/src/main/resources/spitfire/mod-entities-links/features/samples/setup-records/authority.json
+++ b/mod-entities-links/src/main/resources/spitfire/mod-entities-links/features/samples/setup-records/authority.json
@@ -37,6 +37,7 @@
     }
   ],
   "notes": [],
+  "naturalId": "nr123456",
   "metadata": {
     "createdDate": "2022-04-20T06:35:57.430+00:00",
     "createdByUserId": "b8649f0d-5fb3-5b00-ab61-dc9c7d04d914",

--- a/mod-entities-links/src/main/resources/spitfire/mod-entities-links/links-junit.feature
+++ b/mod-entities-links/src/main/resources/spitfire/mod-entities-links/links-junit.feature
@@ -16,6 +16,7 @@ Feature: mod-notes integration tests
       | name                                     |
       | 'instance-authority-links.instances.all' |
       | 'inventory-storage.all'                  |
+      | 'inventory-storage.authorities.all'      |
       | 'source-storage.all'                     |
 
   Scenario: create tenant and users for testing


### PR DESCRIPTION
## Purpose
_Fix failing tests from scheduled build for mod-entities-links from_

## Approach
_Adjust tests for Authority APIs and Instance linking to reflect the latest changes introduced in mod-entities-links, specifically those related to Authority APIs_

### Learning
[_FAT-8301_](https://issues.folio.org/browse/FAT-8301)

![image](https://github.com/folio-org/folio-integration-tests/assets/133661057/fe9124c6-2f9f-4f09-919d-adfaa49c42d9)
![image](https://github.com/folio-org/folio-integration-tests/assets/133661057/f4abc1c0-3826-42b2-829d-ae7d1e79214d)

