### PR TITLE
FAT-9186 - Make pause before users commit preview

### DIFF
--- a/mod-bulk-operations/src/main/resources/firebird/mod-bulk-operations/features/users-positive-scenarios.feature
+++ b/mod-bulk-operations/src/main/resources/firebird/mod-bulk-operations/features/users-positive-scenarios.feature
@@ -226,6 +226,8 @@ Feature: mod bulk operations user positive scenarios
     When method POST
     Then status 200
 
+    * pause(5000)
+
     Given path 'bulk-operations', operationId, 'preview'
     And param limit = '10'
     And param step = 'COMMIT'


### PR DESCRIPTION
## Purpose
Bulk-Operations: make pause before users commit preview to let preview to be completed.

## Approach
_How does this change fulfill the purpose?_

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
