### PR TITLE
FAT-9193 Fixed verification of JobExecution metadata after user renaming

### DIFF
--- a/mod-source-record-manager/src/main/resources/folijet/mod-source-record-manager/features/job-execution.feature
+++ b/mod-source-record-manager/src/main/resources/folijet/mod-source-record-manager/features/job-execution.feature
@@ -261,7 +261,7 @@ Feature: Source-Record-Manager
     When method GET
     Then status 200
     And match response.status == 'PARSING_IN_PROGRESS'
-    And match response.runBy.firstName == 'Admin'
+    And match response.runBy.firstName != null
     And match response.progress.total == rawRecordDto.recordsMetadata.total
     And match response.startedDate != null
 


### PR DESCRIPTION
## Purpose
User was renamed that caused test failure. We just need to verify that it is not null
