### PR TITLE
FAT-8312: Add timeout to wait and handle deleted linked authority

### DIFF
--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-linking-records.feature
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-linking-records.feature
@@ -98,6 +98,7 @@ Feature: linking-records tests
     Given path 'records-editor/records', authorityId
     When method DELETE
     Then assert responseStatus == 204 || responseStatus == 408
+    And eval if (responseStatus == 204) sleep(5000)
     And eval if (responseStatus == 408) sleep(20000)
 
     # retrieve bib srs record - should delete authority link


### PR DESCRIPTION
## Purpose
_Fix failed test case from scheduled run related to deletion of linked authority._

## Approach
_Add timeout to wait for some time in order to allow authority delete event to be processed._

### Learning
[_FAT-8312_](https://issues.folio.org/browse/FAT-8312)

![image](https://github.com/folio-org/folio-integration-tests/assets/133661057/d68c347e-2df7-462d-abed-db37da654876)
