### PR TITLE
 FAT-9629 - update pauses

### DIFF
--- a/mod-bulk-operations/src/main/resources/firebird/mod-bulk-operations/features/holdings.feature
+++ b/mod-bulk-operations/src/main/resources/firebird/mod-bulk-operations/features/holdings.feature
@@ -100,6 +100,8 @@ Feature: mod bulk operations holdings features
     When method POST
     Then status 200
 
+    * pause(10000)
+
     Given path 'bulk-operations', operationId, 'preview'
     And param limit = '10'
     And param step = 'EDIT'
@@ -238,6 +240,8 @@ Feature: mod bulk operations holdings features
     """
     When method POST
     Then status 200
+
+    * pause(5000)
 
     Given path 'bulk-operations', operationId, 'download'
     And param fileContentType = 'PROPOSED_CHANGES_FILE'
@@ -965,6 +969,8 @@ Feature: mod bulk operations holdings features
     """
     When method POST
     Then status 200
+
+    * pause(5000)
 
     Given path 'bulk-operations', operationId, 'download'
     And param fileContentType = 'PROPOSED_CHANGES_FILE'

--- a/mod-bulk-operations/src/main/resources/firebird/mod-bulk-operations/features/users-negative-scenarios.feature
+++ b/mod-bulk-operations/src/main/resources/firebird/mod-bulk-operations/features/users-negative-scenarios.feature
@@ -119,6 +119,8 @@ Feature: mod bulk operations user features negative scenarios
     When method POST
     Then status 200
 
+    * pause(10000)
+
     Given path 'bulk-operations', operationId, 'preview'
     And param limit = '10'
     And param step = 'EDIT'
@@ -260,6 +262,8 @@ Feature: mod bulk operations user features negative scenarios
     """
     When method POST
     Then status 200
+
+    * pause(10000)
 
     Given path 'bulk-operations', operationId, 'preview'
     And param limit = '10'

--- a/mod-bulk-operations/src/main/resources/firebird/mod-bulk-operations/features/users-positive-scenarios.feature
+++ b/mod-bulk-operations/src/main/resources/firebird/mod-bulk-operations/features/users-positive-scenarios.feature
@@ -103,6 +103,8 @@ Feature: mod bulk operations user positive scenarios
     When method POST
     Then status 200
 
+    * pause(10000)
+
     Given path 'bulk-operations', operationId, 'preview'
     And param limit = '10'
     And param step = 'EDIT'
@@ -127,7 +129,7 @@ Feature: mod bulk operations user positive scenarios
     When method POST
     Then status 200
 
-    * pause(5000)
+    * pause(10000)
 
     Given path 'bulk-operations', operationId, 'preview'
     And param limit = '10'
@@ -180,7 +182,7 @@ Feature: mod bulk operations user positive scenarios
     When method POST
     Then status 200
 
-    * pause(5000)
+    * pause(10000)
 
     Given path 'bulk-operations', operationId, 'preview'
     And param limit = '10'
@@ -226,7 +228,7 @@ Feature: mod bulk operations user positive scenarios
     When method POST
     Then status 200
 
-    * pause(5000)
+    * pause(10000)
 
     Given path 'bulk-operations', operationId, 'preview'
     And param limit = '10'


### PR DESCRIPTION
## Purpose
_Describe the purpose of the pull request._
[FAT-9629](https://issues.folio.org/browse/FAT-9629) - Karate test fail: [firebird/mod-bulk-operations] ModBulkOperationsApiTest

## Approach
_How does this change fulfill the purpose?_

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
