### PR TITLE
Add corsair rancher env

### DIFF
--- a/edge-fqm/src/main/resources/karate-config.js
+++ b/edge-fqm/src/main/resources/karate-config.js
@@ -76,6 +76,13 @@ function fn() {
     config.apikey = 'eyJzIjoiNXNlNGdnbXk1TiIsInQiOiJkaWt1IiwidSI6ImRpa3UifQ==';
     config.prototypeTenant = '${prototypeTenant}';
     karate.configure('ssl',true);
+  } else if (env == 'rancher') {
+    config.baseUrl = 'https://folio-dev-corsair-okapi.ci.folio.org:443';
+    config.admin = {
+      tenant: 'supertenant',
+      name: 'testing_admin',
+      password: 'admin'
+    };
   } else if (env != null && env.match(/^ec2-\d+/)) {
     // Config for FOLIO CI "folio-integration" public ec2- dns name
     config.baseUrl = 'http://' + env + ':9130';

--- a/mod-fqm-manager/src/main/resources/karate-config.js
+++ b/mod-fqm-manager/src/main/resources/karate-config.js
@@ -78,6 +78,13 @@ function fn() {
     }
     config.prototypeTenant = '${prototypeTenant}';
     karate.configure('ssl',true);
+  } else if (env == 'rancher') {
+    config.baseUrl = 'https://folio-dev-corsair-okapi.ci.folio.org:443';
+    config.admin = {
+      tenant: 'supertenant',
+      name: 'testing_admin',
+      password: 'admin'
+    };
   } else if (env != null && env.match(/^ec2-\d+/)) {
     // Config for FOLIO CI "folio-integration" public ec2- dns name
     config.baseUrl = 'http://' + env + ':9130';

--- a/mod-lists/src/main/resources/karate-config.js
+++ b/mod-lists/src/main/resources/karate-config.js
@@ -80,6 +80,13 @@ function fn() {
     }
     config.prototypeTenant = '${prototypeTenant}';
     karate.configure('ssl',true);
+  } else if (env == 'rancher') {
+    config.baseUrl = 'https://folio-dev-corsair-okapi.ci.folio.org:443';
+    config.admin = {
+      tenant: 'supertenant',
+      name: 'testing_admin',
+      password: 'admin'
+    };
   } else if (env != null && env.match(/^ec2-\d+/)) {
     // Config for FOLIO CI "folio-integration" public ec2- dns name
     config.baseUrl = 'http://' + env + ':9130';


### PR DESCRIPTION
This adds the corsair rancher environment as a preset option for mod-fqm-manager, mod-lists, and edge-fqm.

It can be used with something like:

```sh
mvn test -DargLine="-Dkarate.env=rancher" -pl common,testrail-integration,mod-lists
```
