### PR TITLE
fix(holdings-items): remove holdingsItems field

### DIFF
--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/samples/setup-records/holdings.json
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/samples/setup-records/holdings.json
@@ -12,8 +12,6 @@
   "holdingsStatementsForIndexes": [],
   "holdingsStatementsForSupplements": [],
   "statisticalCodeIds": [],
-  "holdingsItems": [],
-  "bareHoldingsItems": [],
   "metadata": {
     "createdDate": "2022-04-20T08:21:30.124+00:00",
     "createdByUserId": "b8649f0d-5fb3-5b00-ab61-dc9c7d04d914",

--- a/mod-search/src/test/resources/samples/test-data/holdings.json
+++ b/mod-search/src/test/resources/samples/test-data/holdings.json
@@ -20,8 +20,6 @@
       "statisticalCodeIds": [
         "b5968c9e-cddc-4576-99e3-8e60aed8b0dd"
       ],
-      "holdingsItems": [],
-      "bareHoldingsItems": [],
       "tags": {
         "tagList": [ "bound-with", "urgent", "important" ]
       },
@@ -54,8 +52,6 @@
       "statisticalCodeIds": [
         "b5968c9e-cddc-4576-99e3-8e60aed8b0dd"
       ],
-      "holdingsItems": [],
-      "bareHoldingsItems": [],
       "tags": {
         "tagList": [ "bound-with", "urgent" ]
       },
@@ -87,8 +83,6 @@
       "statisticalCodeIds": [
         "3abd6fc2-b3e4-4879-b1e1-78be41769fe3"
       ],
-      "holdingsItems": [],
-      "bareHoldingsItems": [],
       "tags": {
         "tagList": [ "bound-with" ]
       },


### PR DESCRIPTION
Previously, during setup.feature in mod-quick-marc on the "Create MARC-HOLDINGS record" scenario tests failed due to the features introduced in the MODINVSTOR-1094. Also, the similar situation appeared in the create-test-data.feature in mod-search on the "Create inventory holdings" scenario. This commit solves these errors by deleting holdingsItems and bareHoldingsItems fields.

- Remove holdingsItems and bareHoldingsItems fields from the holdings.json file in mod-quick-marc and mod-search modules.

Closes FAT-9832