### PR TITLE
fix(mod-kb-ebsco-java): change selected filter to true

### DIFF
--- a/mod-kb-ebsco-java/src/main/resources/karate-config.js
+++ b/mod-kb-ebsco-java/src/main/resources/karate-config.js
@@ -3,7 +3,7 @@ function fn() {
   karate.configure('logPrettyRequest', true);
   karate.configure('logPrettyResponse', true);
 
-  var retryConfig = { count: 20, interval: 30000 }
+  var retryConfig = { count: 20, interval: 50000 }
   karate.configure('retry', retryConfig)
 
   var env = karate.env;

--- a/mod-kb-ebsco-java/src/main/resources/spitfire/mod-kb-ebsco-java/features/providers.feature
+++ b/mod-kb-ebsco-java/src/main/resources/spitfire/mod-kb-ebsco-java/features/providers.feature
@@ -46,10 +46,10 @@ Feature: Providers
 
   Scenario: GET selected Packages associated with a given Provider with 200 on success
     Given path '/eholdings/providers/', existProvider.data.id, 'packages'
-    And param filter[selected] = 'false'
+    And param filter[selected] = 'true'
     When method GET
     Then status 200
-    And match response.data[0].attributes.isSelected == false
+    And match response.data[0].attributes.isSelected == true
 
 #   ================= negative test cases =================
 


### PR DESCRIPTION
## Purpose
Fix Karate test fail

## Approach
Changed the 'selected' filter to 'true' instead of false because there are no records with selected=false.

### Learning
https://issues.folio.org/browse/FAT-9722
![Screenshot 2023-12-18 at 17 56 32](https://github.com/folio-org/folio-integration-tests/assets/58312204/13b59d9d-54d1-4972-bd87-f6c4fec7c9b5)
