### PR TITLE
FAT-9771: Apply changes to authority source file POST DTO

### DIFF
--- a/edge-fqm/src/main/resources/karate-config.js
+++ b/edge-fqm/src/main/resources/karate-config.js
@@ -92,12 +92,12 @@ function fn() {
     // Config for FOLIO CI "folio-integration" public ec2- dns name
     config.baseUrl = 'http://' + env + ':9130';
     config.edgeUrl = 'http://' + env + ':8000';
-    config.apikey = 'eyJzIjoiZlU4ZDNkc0pKTCIsInQiOiJkaWt1IiwidSI6ImRpa3VfYWRtaW4ifQ==';
+    config.apikey = 'eyJzIjoibTE2M0k2NTRHZ1pWOVBMdnRTa1MiLCJ0IjoiZGlrdSIsInUiOiJkaWt1X2FkbWluIn0K';
     config.admin = {
-      tenant: 'supertenant',
-      name: 'admin',
+      tenant: 'diku',
+      name: 'diku_admin',
       password: 'admin'
-    };
+    }
   }
   return config;
 }

--- a/mod-search/src/test/resources/samples/test-data/authorities/sourceFiles/AuthoritySourceFIle.json
+++ b/mod-search/src/test/resources/samples/test-data/authorities/sourceFiles/AuthoritySourceFIle.json
@@ -1,9 +1,7 @@
 {
   "id": "4e224096-cae5-4dbd-9799-30c7bbba3f54",
   "name": "Source File",
-  "codes": [
-    "first"
-  ],
+  "code": "first",
   "type": "string",
-  "source": "folio"
+  "source": "LOCAL"
 }

--- a/mod-search/src/test/resources/samples/test-data/authorities/sourceFiles/AuthoritySourceFIle.json
+++ b/mod-search/src/test/resources/samples/test-data/authorities/sourceFiles/AuthoritySourceFIle.json
@@ -2,6 +2,5 @@
   "id": "4e224096-cae5-4dbd-9799-30c7bbba3f54",
   "name": "Source File",
   "code": "first",
-  "type": "string",
-  "source": "LOCAL"
+  "type": "string"
 }

--- a/mod-search/src/test/resources/samples/test-data/authorities/sourceFiles/AuthoritySourceFIleSecond.json
+++ b/mod-search/src/test/resources/samples/test-data/authorities/sourceFiles/AuthoritySourceFIleSecond.json
@@ -2,6 +2,5 @@
   "id": "5de462a2-7a90-4467-b77f-b2057d6d69b6",
   "name": "Second Source File",
   "code": "second",
-  "type": "string",
-  "source": "LOCAL"
+  "type": "string"
 }

--- a/mod-search/src/test/resources/samples/test-data/authorities/sourceFiles/AuthoritySourceFIleSecond.json
+++ b/mod-search/src/test/resources/samples/test-data/authorities/sourceFiles/AuthoritySourceFIleSecond.json
@@ -1,9 +1,7 @@
 {
   "id": "5de462a2-7a90-4467-b77f-b2057d6d69b6",
   "name": "Second Source File",
-  "codes": [
-    "second"
-  ],
+  "code": "second",
   "type": "string",
-  "source": "folio"
+  "source": "LOCAL"
 }

--- a/mod-search/src/test/resources/samples/test-data/authorities/sourceFiles/AuthoritySourceFIleThird.json
+++ b/mod-search/src/test/resources/samples/test-data/authorities/sourceFiles/AuthoritySourceFIleThird.json
@@ -1,9 +1,7 @@
 {
   "id": "266026b6-1572-43c0-9a39-6e5d4ac20ba4",
   "name": "Third Source File",
-  "codes": [
-    "third"
-  ],
+  "code": "third",
   "type": "string",
-  "source": "folio"
+  "source": "LOCAL"
 }

--- a/mod-search/src/test/resources/samples/test-data/authorities/sourceFiles/AuthoritySourceFIleThird.json
+++ b/mod-search/src/test/resources/samples/test-data/authorities/sourceFiles/AuthoritySourceFIleThird.json
@@ -2,6 +2,5 @@
   "id": "266026b6-1572-43c0-9a39-6e5d4ac20ba4",
   "name": "Third Source File",
   "code": "third",
-  "type": "string",
-  "source": "LOCAL"
+  "type": "string"
 }


### PR DESCRIPTION
## Purpose
_Fix steps for creating Authority Source Files from initialization step in mod-search module._

## Approach
_In order to fix failing steps to create authority source files apply latest changes to authority source file POST DTO_

### Learning
[FAT-9771](https://issues.folio.org/browse/FAT-9647)

Test Run results:

![image](https://github.com/folio-org/folio-integration-tests/assets/133661057/8569d19a-02e6-48cb-9904-061860c95142)
