### PR TITLE
Add validation Pick-up, borrowing-pickup, borrowing flow

### DIFF
--- a/common/src/main/resources/common/setup-users.feature
+++ b/common/src/main/resources/common/setup-users.feature
@@ -3,6 +3,7 @@ Feature: prepare data for api test
   Background:
     * url baseUrl
     * configure readTimeout = 3000000
+    * call pause 3000
     * configure headers = { 'Content-Type': 'application/json', 'Accept': 'application/json'  }
     * callonce login admin
     * def desiredPermissions = karate.get('desiredPermissions', [])

--- a/common/src/main/resources/common/tenant.feature
+++ b/common/src/main/resources/common/tenant.feature
@@ -2,7 +2,7 @@ Feature: Tenants
 
   Background:
     * url baseUrl
-    * configure retry = { count: 2, interval: 5000 }
+    * configure retry = { count: 5, interval: 50000 }
     * configure readTimeout = 3000000
 
   @create

--- a/common/src/main/resources/common/tenant.feature
+++ b/common/src/main/resources/common/tenant.feature
@@ -2,7 +2,7 @@ Feature: Tenants
 
   Background:
     * url baseUrl
-    * configure retry = { count: 2, interval: 5000 }
+    * configure retry = { count: 5, interval: 5000 }
     * configure readTimeout = 3000000
 
   @create

--- a/common/src/main/resources/common/tenant.feature
+++ b/common/src/main/resources/common/tenant.feature
@@ -2,7 +2,7 @@ Feature: Tenants
 
   Background:
     * url baseUrl
-    * configure retry = { count: 5, interval: 5000 }
+    * configure retry = { count: 2, interval: 5000 }
     * configure readTimeout = 3000000
 
   @create

--- a/mod-dcb/src/main/resources/volaris/mod-dcb/features/borrowing-flow.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/features/borrowing-flow.feature
@@ -190,6 +190,39 @@ Feature: Borrowing Flow Scenarios
     When method GET
     Then status 200
 
+  Scenario: Validation. If the user exist but the type is DCB, error will be thrown
+
+    * def userEntityRequest311 = read('classpath:volaris/mod-dcb/features/samples/user/user-entity-request.json')
+    * userEntityRequest311.id = patronUser
+    * userEntityRequest311.barcode = patronBarcode
+    * userEntityRequest311.type = 'dcb'
+    Given path 'users'
+    And request userEntityRequest311
+    When method POST
+    Then status 201
+
+      * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
+      * url baseUrlNew
+      * def createDCBTransactionRequest = read('classpath:volaris/mod-dcb/features/samples/transaction/create-dcb-transaction.json')
+      * createDCBTransactionRequest.item.id = itemId311
+      * createDCBTransactionRequest.item.barcode = itemBarcode311
+      * createDCBTransactionRequest.patron.id = patronUser
+      * createDCBTransactionRequest.patron.barcode = patronBarcode
+      * createDCBTransactionRequest.patron.group = patronGroupName
+      * createDCBTransactionRequest.pickup.servicePointId = servicePointId21
+      * createDCBTransactionRequest.pickup.servicePointName = servicePointName21
+      * createDCBTransactionRequest.role = 'BORROWER'
+
+      * def orgPath = '/transactions/' + dcbTransactionId311
+      * def newPath = proxyCall == true ? proxyPath+orgPath : orgPath
+
+      Given path newPath
+      And param apikey = key
+      And request createDCBTransactionRequest
+      When method POST
+      Then status 201
+      And match $.status == 'CREATED'
+
   @CreateDCBTransaction
   Scenario: Create DCB Transaction
     * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl

--- a/mod-dcb/src/main/resources/volaris/mod-dcb/features/borrowing-flow.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/features/borrowing-flow.feature
@@ -192,22 +192,13 @@ Feature: Borrowing Flow Scenarios
 
   Scenario: Validation. If the user exist but the type is DCB, error will be thrown
 
-    * def userEntityRequest311 = read('classpath:volaris/mod-dcb/features/samples/user/user-entity-request.json')
-    * userEntityRequest311.id = patronUser
-    * userEntityRequest311.barcode = patronBarcode
-    * userEntityRequest311.type = 'dcb'
-    Given path 'users'
-    And request userEntityRequest311
-    When method POST
-    Then status 201
-
       * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
       * url baseUrlNew
       * def createDCBTransactionRequest = read('classpath:volaris/mod-dcb/features/samples/transaction/create-dcb-transaction.json')
       * createDCBTransactionRequest.item.id = itemId311
       * createDCBTransactionRequest.item.barcode = itemBarcode311
-      * createDCBTransactionRequest.patron.id = patronUser
-      * createDCBTransactionRequest.patron.barcode = patronBarcode
+      * createDCBTransactionRequest.patron.id = patronId51
+      * createDCBTransactionRequest.patron.barcode = patronBarcode51
       * createDCBTransactionRequest.patron.group = patronGroupName
       * createDCBTransactionRequest.pickup.servicePointId = servicePointId21
       * createDCBTransactionRequest.pickup.servicePointName = servicePointName21

--- a/mod-dcb/src/main/resources/volaris/mod-dcb/features/borrowing-pickup.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/features/borrowing-pickup.feature
@@ -12,6 +12,187 @@ Feature: Testing Borrowing-Pickup Flow
     * configure headers = headersUser
     * callonce variables
 
+  Scenario: Validation. If the userId and barcode is not exist already, error will be thrown.
+
+    * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
+    * url baseUrlNew
+    * def createDCBTransactionRequest = read('classpath:volaris/mod-dcb/features/samples/transaction/create-dcb-transaction.json')
+    * createDCBTransactionRequest.item.id = itemId20
+    * createDCBTransactionRequest.item.barcode = itemBarcode20
+    # not existing patron id patronIdNonExisting
+    * createDCBTransactionRequest.patron.id = patronIdNonExisting
+    # not existing patron barcode patronBarcodeNonExisting
+    * createDCBTransactionRequest.patron.barcode = patronBarcodeNonExisting
+    * createDCBTransactionRequest.pickup.servicePointId = servicePointId1
+    * createDCBTransactionRequest.pickup.servicePointName = servicePointName1
+    * createDCBTransactionRequest.role = 'BORROWING-PICKUP'
+
+    * def orgPath = '/transactions/' + dcbTransactionIdValidation1
+    * def newPath = proxyCall == true ? proxyPath+orgPath : orgPath
+
+    Given path newPath
+    And param apikey = key
+    And request createDCBTransactionRequest
+    When method POST
+    Then status 404
+    And match $.errors[0].message == 'Unable to find existing user with barcode '+ patronBarcodeNonExisting + ' and id ' + patronIdNonExisting + '.'
+
+  Scenario: Validation. If the item barcode is already present in the inventory, error will be thrown.
+
+    Given call read(utilsPath+'@PostHoldings') {holdingId: '70cf22e6-789f-11ee-b962-0242ac120003'}
+    # create item with Barcode itemBarcodeAlreadyExists
+    * def materialTypeEntityRequest = read('classpath:volaris/mod-dcb/features/samples/item/material-type-entity-request.json')
+    * materialTypeEntityRequest.id = intMaterialTypeId2
+    * materialTypeEntityRequest.name = intMaterialTypeName2
+    Given path 'material-types'
+    And request materialTypeEntityRequest
+    When method POST
+    Then status 201
+
+    # create item with barcode itemBarcodeAlreadyExists
+    * def itemEntityRequest = read('classpath:volaris/mod-dcb/features/samples/item/item-entity-request.json')
+    * itemEntityRequest.barcode = itemBarcodeAlreadyExists
+    * itemEntityRequest.id = itemId8
+    * itemEntityRequest.holdingsRecordId = '70cf22e6-789f-11ee-b962-0242ac120003'
+    * itemEntityRequest.materialType.id = intMaterialTypeId2
+    * itemEntityRequest.materialType.name = intMaterialTypeName2
+    * itemEntityRequest.status.name = 'Available'
+
+    Given path 'inventory', 'items'
+    And request itemEntityRequest
+    When method POST
+    Then status 201
+
+     # create Transaction with itemBarcodeAlreadyExists
+    * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
+    * url baseUrlNew
+    * def createDCBTransactionRequest = read('classpath:volaris/mod-dcb/features/samples/transaction/create-dcb-transaction.json')
+    * createDCBTransactionRequest.item.id = itemId8
+    # item with existing barcode itemBarcodeAlreadyExists
+    * createDCBTransactionRequest.item.barcode = itemBarcodeAlreadyExists
+    * createDCBTransactionRequest.patron.id = patronId1
+    * createDCBTransactionRequest.patron.barcode = patronBarcode1
+    * createDCBTransactionRequest.pickup.servicePointId = servicePointId1
+    * createDCBTransactionRequest.pickup.servicePointName = servicePointName1
+    * createDCBTransactionRequest.role = 'BORROWING-PICKUP'
+
+    * def orgPath = '/transactions/' + dcbTransactionIdValidation2
+    * def newPath = proxyCall == true ? proxyPath+orgPath : orgPath
+
+    Given path newPath
+    And param apikey = key
+    And request createDCBTransactionRequest
+    When method POST
+    Then status 409
+    And match $.errors[0].message == 'Unable to create item with barcode ' + itemBarcodeAlreadyExists + ' as it exists in inventory '
+
+  Scenario: Validation. If item is not present in inventory, new virtual item will be created.
+
+    * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
+    * url baseUrlNew
+    * def createDCBTransactionRequest = read('classpath:volaris/mod-dcb/features/samples/transaction/create-dcb-transaction.json')
+    # item with id itemId30 and itemBarcode30 will be created automatically
+    * createDCBTransactionRequest.item.id = itemId30
+    * createDCBTransactionRequest.item.barcode = itemBarcode30
+    * createDCBTransactionRequest.patron.id = patronId1
+    * createDCBTransactionRequest.patron.barcode = patronBarcode1
+    * createDCBTransactionRequest.pickup.servicePointId = servicePointId1
+    * createDCBTransactionRequest.pickup.servicePointName = servicePointName1
+    * createDCBTransactionRequest.role = 'BORROWING-PICKUP'
+
+    * def orgPath = '/transactions/' + dcbTransactionIdValidation6
+    * def newPath = proxyCall == true ? proxyPath+orgPath : orgPath
+
+    Given path newPath
+    And param apikey = key
+    And request createDCBTransactionRequest
+    When method POST
+    Then status 201
+    And match $.status == 'CREATED'
+
+    Given path 'request-storage', 'requests'
+    Given param query = '(item.barcode= ' + itemBarcode30 + ' and itemId = ' + itemId30 + ' )'
+    When method GET
+    Then status 200
+    And match $.totalRecords == 1
+    And match $.requests[0].status == 'Open - Not yet filled'
+    * def requestId = $.requests[0].id
+
+    # Cancel transaction in order to reuse the same item id and item barcode.
+    * def cancelRequestEntityRequest = read('classpath:volaris/mod-dcb/features/samples/request/cancel-request-entity-request.json')
+    * cancelRequestEntityRequest.cancellationReasonId = cancellationReasonId
+    * cancelRequestEntityRequest.cancelledByUserId = patronId1
+    * cancelRequestEntityRequest.requesterId = patronId1
+    * cancelRequestEntityRequest.requestLevel = 'Item'
+    * cancelRequestEntityRequest.requestType = extRequestType
+    * cancelRequestEntityRequest.holdingsRecordId = holdingId
+    * cancelRequestEntityRequest.itemId = itemId30
+    * cancelRequestEntityRequest.pickupServicePointId = servicePointId1
+
+    Given path 'circulation', 'requests', requestId
+    And request cancelRequestEntityRequest
+    When method PUT
+    Then status 204
+
+    Given path 'circulation', 'requests', requestId
+    When method GET
+    Then status 200
+    And match $.status == 'Closed - Cancelled'
+
+    Given path 'transactions' , dcbTransactionIdValidation6 , 'status'
+    When method GET
+    Then status 200
+    And match $.status == 'CANCELLED'
+    And match $.role == 'BORROWING-PICKUP'
+
+  Scenario: Validation. If virtual item already exists, it will be reused. Make sure same id and barcode should be used. itemId30 reused
+
+    * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
+    * url baseUrlNew
+    * def createDCBTransactionRequest = read('classpath:volaris/mod-dcb/features/samples/transaction/create-dcb-transaction.json')
+    # item with id itemId30 and itemBarcode30 will be created automatically
+    * createDCBTransactionRequest.item.id = itemId30
+    * createDCBTransactionRequest.item.barcode = itemBarcode30
+    * createDCBTransactionRequest.patron.id = patronId1
+    * createDCBTransactionRequest.patron.barcode = patronBarcode1
+    * createDCBTransactionRequest.pickup.servicePointId = servicePointId1
+    * createDCBTransactionRequest.pickup.servicePointName = servicePointName1
+    * createDCBTransactionRequest.role = 'BORROWING-PICKUP'
+
+    * def orgPath = '/transactions/' + dcbTransactionIdValidation7
+    * def newPath = proxyCall == true ? proxyPath+orgPath : orgPath
+
+    Given path newPath
+    And param apikey = key
+    And request createDCBTransactionRequest
+    When method POST
+    Then status 201
+    And match $.status == 'CREATED'
+
+  Scenario: Validation. Material type in the request should be present in inventory or else error will be thrown.
+
+        # create item with not existing material type
+    * def itemEntityRequest = read('classpath:volaris/mod-dcb/features/samples/item/item-entity-request.json')
+    * itemEntityRequest.barcode = itemBarcode7
+    * itemEntityRequest.id = itemId5
+    # not existing material type
+    * itemEntityRequest.materialType.id = intMaterialTypeIdNonExisting
+    * itemEntityRequest.status.name = 'Available'
+
+    Given path 'inventory', 'items'
+    And request itemEntityRequest
+    When method POST
+    Then status 422
+    And match $.errors[0].message == 'Cannot set item.materialtypeid = ' + intMaterialTypeIdNonExisting + ' because it does not exist in material_type.id.'
+
+    # If the material type is not given in the request, then we check for default material type as book in inventory, if it doesn't exist, we throw the error.
+    * def materialTypeEntityRequest = read('classpath:volaris/mod-dcb/features/samples/item/material-type-entity-request.json')
+    * materialTypeEntityRequest.name = 'book'
+    Given path 'material-types'
+    And request materialTypeEntityRequest
+    When method GET
+    Then status 200
+
   @CreateDCBTransaction
   Scenario: Create DCB Transaction
     * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl

--- a/mod-dcb/src/main/resources/volaris/mod-dcb/features/pickup-flow.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/features/pickup-flow.feature
@@ -12,6 +12,183 @@ Feature: Pickup Flow Scenarios
     * configure headers = headersUser
     * callonce variables
 
+  Scenario: Validation. Patron group should be validated at the time of user creation.
+
+    * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
+    * url baseUrlNew
+    * def createDCBTransactionRequest = read('classpath:volaris/mod-dcb/features/samples/transaction/create-dcb-transaction.json')
+    * createDCBTransactionRequest.item.id = itemId80
+    * createDCBTransactionRequest.item.barcode = itemBarcode80
+    #
+    * createDCBTransactionRequest.patron.id = patronIdNonExisting
+    * createDCBTransactionRequest.patron.group = patronNameNonExisting
+    * createDCBTransactionRequest.pickup.servicePointId = servicePointId1
+    * createDCBTransactionRequest.pickup.servicePointName = servicePointName1
+    * createDCBTransactionRequest.role = 'PICKUP'
+
+    * def orgPath = '/transactions/' + dcbTransactionIdValidation12
+    * def newPath = proxyCall == true ? proxyPath+orgPath : orgPath
+
+    Given path newPath
+    And param apikey = key
+    And request createDCBTransactionRequest
+    When method POST
+    Then status 404
+    And match $.errors[0].message == 'Patron group not found with name '+patronNameNonExisting + ' '
+    And match $.errors[0].code == 'NOT_FOUND_ERROR'
+
+  Scenario: Validation. If the item barcode is already present in the inventory, error will be thrown.
+
+    # create item with Barcode itemBarcodeAlreadyExists3
+    * def materialTypeEntityRequest = read('classpath:volaris/mod-dcb/features/samples/item/material-type-entity-request.json')
+    * materialTypeEntityRequest.id = intMaterialTypeId3
+    * materialTypeEntityRequest.name = intMaterialTypeName3
+    Given path 'material-types'
+    And request materialTypeEntityRequest
+    When method POST
+    Then status 201
+
+    # create item with barcode itemBarcodeAlreadyExists3
+    * def itemEntityRequest = read('classpath:volaris/mod-dcb/features/samples/item/item-entity-request.json')
+    * itemEntityRequest.barcode = itemBarcodeAlreadyExists3
+    * itemEntityRequest.id = itemId7
+    * itemEntityRequest.materialType.id = intMaterialTypeId3
+    * itemEntityRequest.status.name = 'Available'
+
+    Given path 'inventory', 'items'
+    And request itemEntityRequest
+    When method POST
+    Then status 201
+
+     # create Transaction with itemBarcodeAlreadyExists3
+    * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
+    * url baseUrlNew
+    * def createDCBTransactionRequest = read('classpath:volaris/mod-dcb/features/samples/transaction/create-dcb-transaction.json')
+    * createDCBTransactionRequest.item.id = itemId7
+    # item with existing barcode itemBarcodeAlreadyExists3
+    * createDCBTransactionRequest.item.barcode = itemBarcodeAlreadyExists3
+    * createDCBTransactionRequest.patron.id = patronId3
+    * createDCBTransactionRequest.patron.barcode = patronBarcode3
+    * createDCBTransactionRequest.pickup.servicePointId = servicePointId1
+    * createDCBTransactionRequest.pickup.servicePointName = servicePointName1
+    * createDCBTransactionRequest.role = 'PICKUP'
+
+    * def orgPath = '/transactions/' + dcbTransactionIdValidation20
+    * def newPath = proxyCall == true ? proxyPath+orgPath : orgPath
+
+    Given path newPath
+    And param apikey = key
+    And request createDCBTransactionRequest
+    When method POST
+    Then status 409
+    And match $.errors[0].message == 'Unable to create item with barcode ' + itemBarcodeAlreadyExists3 + ' as it exists in inventory '
+
+  Scenario: Validation. If item is not present in inventory, new virtual item will be created.
+
+    * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
+    * url baseUrlNew
+    * def createDCBTransactionRequest = read('classpath:volaris/mod-dcb/features/samples/transaction/create-dcb-transaction.json')
+    # item with id itemId60 and itemBarcode60 will be created automatically
+    * createDCBTransactionRequest.item.id = itemId60
+    * createDCBTransactionRequest.item.barcode = itemBarcode60
+    * createDCBTransactionRequest.patron.id = patronId3
+    * createDCBTransactionRequest.patron.barcode = patronBarcode3
+    * createDCBTransactionRequest.pickup.servicePointId = servicePointId1
+    * createDCBTransactionRequest.pickup.servicePointName = servicePointName1
+    * createDCBTransactionRequest.role = 'PICKUP'
+
+    * def orgPath = '/transactions/' + dcbTransactionIdValidation10
+    * def newPath = proxyCall == true ? proxyPath+orgPath : orgPath
+
+    Given path newPath
+    And param apikey = key
+    And request createDCBTransactionRequest
+    When method POST
+    Then status 201
+    And match $.status == 'CREATED'
+
+    Given path 'request-storage', 'requests'
+    Given param query = '(item.barcode= ' + itemBarcode60 + ' and itemId = ' + itemId60 + ' )'
+    When method GET
+    Then status 200
+    And match $.totalRecords == 1
+    And match $.requests[0].status == 'Open - Not yet filled'
+    * def requestId = $.requests[0].id
+
+    # Cancel transaction in order to reuse the same item id and item barcode.
+    * def cancelRequestEntityRequest = read('classpath:volaris/mod-dcb/features/samples/request/cancel-request-entity-request.json')
+    * cancelRequestEntityRequest.cancellationReasonId = cancellationReasonId
+    * cancelRequestEntityRequest.cancelledByUserId = patronId3
+    * cancelRequestEntityRequest.requesterId = patronId3
+    * cancelRequestEntityRequest.requestLevel = 'Item'
+    * cancelRequestEntityRequest.requestType = extRequestType
+    * cancelRequestEntityRequest.holdingsRecordId = holdingId
+    * cancelRequestEntityRequest.itemId = itemId60
+    * cancelRequestEntityRequest.pickupServicePointId = servicePointId1
+
+    Given path 'circulation', 'requests', requestId
+    And request cancelRequestEntityRequest
+    When method PUT
+    Then status 204
+
+    Given path 'circulation', 'requests', requestId
+    When method GET
+    Then status 200
+    And match $.status == 'Closed - Cancelled'
+
+    Given path 'transactions' , dcbTransactionIdValidation10 , 'status'
+    When method GET
+    Then status 200
+    And match $.status == 'CANCELLED'
+    And match $.role == 'PICKUP'
+
+  Scenario: Validation. If virtual item already exists, it will be reused. Make sure same id and barcode should be used. itemId2 reused
+
+    * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
+    * url baseUrlNew
+    * def createDCBTransactionRequest = read('classpath:volaris/mod-dcb/features/samples/transaction/create-dcb-transaction.json')
+    # item with id itemId60 and itemBarcode60 will be created automatically
+    * createDCBTransactionRequest.item.id = itemId60
+    * createDCBTransactionRequest.item.barcode = itemBarcode60
+    * createDCBTransactionRequest.patron.id = patronId3
+    * createDCBTransactionRequest.patron.barcode = patronBarcode3
+    * createDCBTransactionRequest.pickup.servicePointId = servicePointId1
+    * createDCBTransactionRequest.pickup.servicePointName = servicePointName1
+    * createDCBTransactionRequest.role = 'PICKUP'
+
+    * def orgPath = '/transactions/' + dcbTransactionIdValidation11
+    * def newPath = proxyCall == true ? proxyPath+orgPath : orgPath
+
+    Given path newPath
+    And param apikey = key
+    And request createDCBTransactionRequest
+    When method POST
+    Then status 201
+    And match $.status == 'CREATED'
+
+  Scenario: Validation. Material type in the request should be present in inventory or else error will be thrown.
+
+    # create item with not existing material type
+    * def itemEntityRequest = read('classpath:volaris/mod-dcb/features/samples/item/item-entity-request.json')
+    * itemEntityRequest.barcode = itemBarcode70
+    * itemEntityRequest.id = itemId70
+    # not existing material type
+    * itemEntityRequest.materialType.id = intMaterialTypeIdNonExisting
+    * itemEntityRequest.status.name = 'Available'
+
+    Given path 'inventory', 'items'
+    And request itemEntityRequest
+    When method POST
+    Then status 422
+    And match $.errors[0].message == 'Cannot set item.materialtypeid = ' + intMaterialTypeIdNonExisting + ' because it does not exist in material_type.id.'
+
+    # If the material type is not given in the request, then we check for default material type as book in inventory, if it doesn't exist, we throw the error.
+    * def materialTypeEntityRequest = read('classpath:volaris/mod-dcb/features/samples/item/material-type-entity-request.json')
+    * materialTypeEntityRequest.name = 'book'
+    Given path 'material-types'
+    And request materialTypeEntityRequest
+    When method GET
+    Then status 200
 
   @CreateDCBTransaction
   Scenario: Create DCB Transaction
@@ -37,6 +214,13 @@ Feature: Pickup Flow Scenarios
     Then status 201
     And match $.status == 'CREATED'
 
+  Scenario: Validation. If the userId and barcode is not exist already, new user with type DCB will be created. If it is a existing user and type is not dcb or shadow, error will be thrown.
+
+    Given path '/users/' + patronId3
+    When method GET
+    Then status 200
+    And match $.barcode == patronBarcode3
+    And match $.type == 'dcb'
 
   Scenario: Get User after creating dcb transaction
 

--- a/mod-dcb/src/main/resources/volaris/mod-dcb/global/variables.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/global/variables.feature
@@ -111,6 +111,7 @@ Feature: global variables
     * def patronBarcode31 = 'testuser987'
     * def patronBarcode41 = 'testuser98765'
     * def patronBarcode41 = 'testuser65'
+    * def patronBarcode51 = 'testuser6555'
 
 
     * def dcbTransactionId11 = '1234'
@@ -127,6 +128,7 @@ Feature: global variables
     * def itemBarcode21 = '19'
     * def itemBarcode31 = '20'
     * def itemBarcode41 = '21'
+    * def itemBarcode51 = '51'
 
     * def patronBarcode1 = 'testuser12345'
     * def itemId8 = '85cf22e6-779f-11ee-b962-1242ac120009'

--- a/mod-dcb/src/main/resources/volaris/mod-dcb/global/variables.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/global/variables.feature
@@ -103,11 +103,15 @@ Feature: global variables
     * def patronId21 = 'e58ca3a7-7674-44e5-8a1c-cdb22d0f87ce'
     * def patronId31 = 'ee6542c3-f98e-414a-94e4-caad908aebdf'
     * def patronId41 = 'ee6542c3-f98e-414a-94e4-caad908aeb00'
+    * def patronId51 = 'ee6542c4-f98e-444a-94e4-caad908aeb00'
+
 
     * def patronBarcode11 = 'testuser123'
     * def patronBarcode21 = 'testuser12345'
     * def patronBarcode31 = 'testuser987'
     * def patronBarcode41 = 'testuser98765'
+    * def patronBarcode41 = 'testuser65'
+
 
     * def dcbTransactionId11 = '1234'
     * def dcbTransactionId21 = '12345'
@@ -192,8 +196,6 @@ Feature: global variables
     * def servicePointId1 = '5d2625ef-81eb-4e61-a8a9-87c94ba3764d'
     * def servicePointName1 = 'Circ Desk 2'
 
-    * def patronUser = '2000'
-    * def patronBarcode = 'testuser98788888'
     * def dcbTransactionId311 = '987000'
     * def itemId311 = '855a17a1-e258-4973-bab6-da176010ea3c'
     * def itemBarcode311 = '201111'

--- a/mod-dcb/src/main/resources/volaris/mod-dcb/global/variables.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/global/variables.feature
@@ -191,3 +191,9 @@ Feature: global variables
 
     * def servicePointId1 = '5d2625ef-81eb-4e61-a8a9-87c94ba3764d'
     * def servicePointName1 = 'Circ Desk 2'
+
+    * def patronUser = '2000'
+    * def patronBarcode = 'testuser98788888'
+    * def dcbTransactionId311 = '987000'
+    * def itemId311 = '855a17a1-e258-4973-bab6-da176010ea3c'
+    * def itemBarcode311 = '201111'

--- a/mod-dcb/src/main/resources/volaris/mod-dcb/global/variables.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/global/variables.feature
@@ -24,6 +24,7 @@ Feature: global variables
     * def itemBarcode3 = 'newdcb12345'
     * def itemBarcode4 = 'newdcb123456'
     * def itemBarcode5 = 'newdcb1234567'
+    * def itemBarcode7 = 'newdcb1234567777'
     * def itemBarcode6 = 'newdcb1234568'
     * def itemNonExistingBarcode = 'newdcb1111'
     * def patronId = 'ad2164c7-ba3d-1bc2-a12c-e35ceccbfaf2'
@@ -122,3 +123,71 @@ Feature: global variables
     * def itemBarcode21 = '19'
     * def itemBarcode31 = '20'
     * def itemBarcode41 = '21'
+
+    * def patronBarcode1 = 'testuser12345'
+    * def itemId8 = '85cf22e6-779f-11ee-b962-1242ac120009'
+    * def patronBarcode2 = 'testuser987'
+
+
+    #
+    * def intMaterialTypeIdNonExisting = 'ea614699-73d8-11ee-b962-0242ac120009'
+    * def intMaterialTypeId1 = '40cf22e6-779f-11ee-b963-0242ac120004'
+    * def intMaterialTypeId2 = '10cf22e6-779f-11ee-b963-0242ac120004'
+    * def intMaterialTypeId3 = '42cf22e6-779f-11ee-b963-0242ac120004'
+
+    * def intMaterialTypeName1 = 'name23'
+    * def intMaterialTypeName2 = 'name22'
+    * def intMaterialTypeName3 = 'name33'
+
+    * def itemBarcodeAlreadyExists = '320'
+    * def itemBarcodeAlreadyExists2 = '325'
+    * def itemBarcodeAlreadyExists3 = '333'
+
+    * def itemNonExistingBarcode = 'newdcb1111'
+
+    * def dcbTransactionIdValidation1 = '10'
+    * def dcbTransactionIdValidation2 = '20'
+    * def dcbTransactionIdValidation3 = '30'
+    * def dcbTransactionIdValidation4 = '40'
+    * def dcbTransactionIdValidation5 = '50'
+    * def dcbTransactionIdValidation6 = '60'
+    * def dcbTransactionIdValidation7 = '70'
+    * def dcbTransactionIdValidation8 = '80'
+    * def dcbTransactionIdValidation9 = '90'
+    * def dcbTransactionIdValidation10 = '1000'
+    * def dcbTransactionIdValidation11 = '110'
+    * def dcbTransactionIdValidation12 = '120'
+    * def dcbTransactionIdValidation20 = '200'
+
+    * def patronIdNonExisting = 'ee6542c3-f98e-414a-94e4-caad908aeb01'
+    * def patronBarcodeNonExisting = 'testuser10'
+
+    * def itemId20 = '965a17a1-e258-4973-bab6-da176010ea4c'
+    * def itemId30 = '345a17a1-e258-4973-bab6-da176010ea4c'
+    * def itemId40 = '495a17a1-e258-4973-bab6-da176010ea4c'
+    * def itemId50 = '495a17a1-e258-4973-bab6-da176010ea4c'
+    * def itemId60 = '695a17a1-e258-4973-bab6-da176010ea4c'
+    * def itemId70 = '795a17a1-e258-4973-bab6-da176010ea4c'
+    * def itemId80 = '895a17a1-e258-4973-bab6-da176010ea4c'
+
+
+    * def itemBarcode20 = '2055'
+    * def itemBarcode30 = '3055'
+    * def itemBarcode40 = '4055'
+    * def itemBarcode50 = '5055'
+    * def itemBarcode60 = '6055'
+    * def itemBarcode70 = '7055'
+    * def itemBarcode80 = '8055'
+
+    * def patronNameNonExisting = 'patronIdNonExisting'
+    * def itemId7 = '70cf22e6-779f-11ee-b962-1242ac120009'
+    * def patronId3 = 'ee6542c3-f98e-414a-94e4-caad908aeb00'
+    * def utilsPath = 'classpath:volaris/mod-dcb/reusable/pre-requisites.feature'
+    * def patronId1 = 'e58ca3a7-7674-44e5-8a1c-cdb22d0f87ce'
+    * def itemId5 = '6c497cc0-77b7-11ee-b962-0242ac120002'
+    * def patronId2 = 'ee6542c3-f98e-414a-94e4-caad908aebdf'
+    * def itemId6 = '80cf22e6-779f-11ee-b962-1242ac120009'
+    * def patronBarcode3 = 'testuser98765'
+
+    * def servicePointId1 = '5d2625ef-81eb-4e61-a8a9-87c94ba3764d'
+    * def servicePointName1 = 'Circ Desk 2'

--- a/mod-dcb/src/main/resources/volaris/mod-dcb/reusable/pre-requisites.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/reusable/pre-requisites.feature
@@ -304,6 +304,14 @@ Feature: Testing Lending Flow
     When method POST
     Then status 201
 
+    * def userEntityRequest4 = read('classpath:volaris/mod-dcb/features/samples/user/user-entity-request.json')
+    * userEntityRequest4.id = patronId51
+    * userEntityRequest4.barcode = patronBarcode51
+    Given path 'users'
+    And request userEntityRequest4
+    When method POST
+    Then status 201
+
 
   @CreateLoanPolicy
   Scenario: Create loan policy


### PR DESCRIPTION
https://issues.folio.org/browse/FAT-9712

The Karate scenarios should cover below mentioned validations.
create transaction (POST) API have the following validations.
TransactionId should be unique for every transaction or else it will throw error 
Lending flow :
1) If the userId and barcode is not exist already, new user with type DCB will be created. 
2) Patron group should be validated at the time of user creation.
3) If it is a existing user and type is not dcb or shadow, error will be thrown.
4) Item needs to be present in inventory.(Real item)
Borrowing Flow/Borrowing-Pickup Flow :
1) If the userId and barcode is not exist already, error will be thrown. 
2) If the user exist but the type is DCB, error will be thrown
3) If the item barcode is already present in the inventory, error will be thrown.
4) If item is not present in inventory, new virtual item will be created.
5) If virtual item already exists, it will be reused. Make sure same id and barcode should be used.
6) Material type in the request should be present in inventory or else error will be thrown. If the material type is not given in the request, then we check for default material type as book in inventory, if it doesn't exist, we throw the error.
 
Pickup flow :
1) If the userId and barcode is not exist already, new user with type DCB will be created. 
2) Patron group should be validated at the time of user creation.
3) If it is a existing user and type is not dcb or shadow, error will be thrown.
4) If the item barcode is already present in the inventory, error will be thrown.
5) If item is not present in inventory, new virtual item will be created.
6) If virtual item already exists, it will be reused. Make sure same id and barcode should be used.
7) Material type in the request should be present in inventory or else error will be thrown. If the material type is not given in the request, then we check for default material type as book in inventory, if it doesn't exist, we throw the error.

![Screenshot 2024-01-02 200851](https://github.com/folio-org/folio-integration-tests/assets/126637578/aa16de74-5cc1-4024-a517-8dcc78a983e9)
