### PR TITLE
fix(authority-source-file): refactor authority-source-file.

### DIFF
--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/samples/setup-records/authority-source-file.json
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/samples/setup-records/authority-source-file.json
@@ -1,14 +1,12 @@
 {
   "id": "af045f2f-e851-4613-984c-4bc13430454a",
   "name": "LC Name Authority file (LCNAF)",
-  "codes": [
-    "n",
-    "nb",
-    "nr",
-    "no",
-    "ns"
-  ],
+  "code": "abcdefghijklmnopqrstuvwxy",
   "type": "Names",
   "baseUrl": "id.loc.gov/authorities/names/",
-  "source": "folio"
+  "source": "folio",
+  "selectable": true,
+  "hridManagement": {
+    "startNumber": 1
+  }
 }

--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/samples/setup-records/authority-source-file.json
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/samples/setup-records/authority-source-file.json
@@ -4,7 +4,6 @@
   "code": "abcdefghijklmnopqrstuvwxy",
   "type": "Names",
   "baseUrl": "id.loc.gov/authorities/names/",
-  "source": "folio",
   "selectable": true,
   "hridManagement": {
     "startNumber": 1


### PR DESCRIPTION
Previously, during setup.feature in mod-quick-marc on the "Create Authority Source File" scenario tests failed due to incorrect form of the authority-source-file.json Also, consequently "Create MARC-AUTHORITY records" and "Create Instance-Authority links" scenarios failed. This commit solves these errors by refactoring authority-source-file.json.

- Remove **codes** array.
- Add **code**, **selectable** fields.
- Add **hridManagement** object.

Closes FAT-9755
