### PR TITLE
[MODORDERS-984] Test po line update after unreceiving a piece

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/unreceive-piece-and-check-order-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/unreceive-piece-and-check-order-line.feature
@@ -1,0 +1,155 @@
+@parallel=false
+# for https://issues.folio.org/browse/MODORDERS-984
+Feature: Unreceive a piece and check the order line
+
+  Background:
+    * print karate.info.scenarioName
+
+    * url baseUrl
+
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json' }
+
+    * configure headers = headersUser
+
+    * callonce variables
+
+    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
+    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
+    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
+    * def createTitle = read('classpath:thunderjet/mod-orders/reusable/create-title.feature')
+    * def createPiece = read('classpath:thunderjet/mod-orders/reusable/create-piece.feature')
+
+    * def fundId = callonce uuid1
+    * def budgetId = callonce uuid2
+    * def orderId = callonce uuid3
+    * def poLineId = callonce uuid4
+    * def titleId1 = callonce uuid5
+    * def titleId2 = callonce uuid6
+    * def pieceId1 = callonce uuid7
+    * def pieceId2 = callonce uuid8
+
+
+  Scenario: Prepare finances
+    * configure headers = headersAdmin
+    * def v = call createFund { id: #(fundId) }
+    * def v = call createBudget { id: #(budgetId), fundId: #(fundId), allocated: 100 }
+
+
+  Scenario: Create an order
+    * def v = callonce createOrder { id: #(orderId) }
+
+
+  Scenario: Create a package order line
+    * def v = call createOrderLine { id: #(poLineId), orderId: #(orderId), fundId: #(fundId), isPackage: true }
+
+
+  Scenario: Open the order
+    * def v = callonce openOrder { orderId: "#(orderId)" }
+
+
+  Scenario: Create 2 titles and pieces
+    * def v = call createTitle { titleId: "#(titleId1)", poLineId: "#(poLineId)" }
+    * def v = call createPiece { pieceId: "#(pieceId1)", poLineId: "#(poLineId)", titleId: "#(titleId1)" }
+    * def v = call createTitle { titleId: "#(titleId2)", poLineId: "#(poLineId)" }
+    * def v = call createPiece { pieceId: "#(pieceId2)", poLineId: "#(poLineId)", titleId: "#(titleId2)" }
+
+
+  Scenario: Receive both pieces
+    Given path 'orders/check-in'
+    And request
+    """
+    {
+      toBeCheckedIn: [
+        {
+          checkedIn: 1,
+          checkInPieces: [
+            {
+              id: "#(pieceId1)",
+              itemStatus: "In process",
+              locationId: "#(globalLocationsId)"
+            },
+            {
+              id: "#(pieceId2)",
+              itemStatus: "In process",
+              locationId: "#(globalLocationsId)"
+            }
+          ],
+          poLineId: "#(poLineId)"
+        }
+      ],
+      totalRecords: 1
+    }
+    """
+    When method POST
+    Then status 200
+    And match $.receivingResults[0].processedSuccessfully == 2
+
+    # Wait a bit for the po line to be updated
+    * call pause 300
+
+
+  Scenario: Check the po line receipt status is Fully Received
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+    And match $.receiptStatus == 'Fully Received'
+
+
+  Scenario: Unreceive piece 1
+    # Get piece 1
+    Given path 'orders/pieces', pieceId1
+    When method GET
+    Then status 200
+    * def piece = $
+
+    # Unreceive it by changing receivingStatus and removing locationId
+    * set piece.receivingStatus = 'Expected'
+    * remove piece.locationId
+    Given path 'orders/pieces', pieceId1
+    And param deleteHoldings = false
+    And request piece
+    When method PUT
+    Then status 204
+
+    # Wait a bit for the po line to be updated
+    * call pause 300
+
+
+  Scenario: Check the po line receipt status is Partially Received
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+    And match $.receiptStatus == 'Partially Received'
+
+
+  Scenario: Unreceive piece 2
+    # Get piece 2
+    Given path 'orders/pieces', pieceId2
+    When method GET
+    Then status 200
+    * def piece = $
+
+    # Unreceive it by changing receivingStatus and removing locationId
+    * set piece.receivingStatus = 'Expected'
+    * remove piece.locationId
+    Given path 'orders/pieces', pieceId2
+    And param deleteHoldings = false
+    And request piece
+    When method PUT
+    Then status 204
+
+    # Wait a bit for the po line to be updated
+    * call pause 300
+
+
+  Scenario: Check the po line receipt status is Awaiting Receipt
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+    And match $.receiptStatus == 'Awaiting Receipt'

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
@@ -235,5 +235,8 @@ Feature: mod-orders integration tests
   Scenario: PoLine change instance connection
     Given call read("features/poline_change_instance_connection.feature")
 
+  Scenario: Unreceive a piece and check the order line
+    Given call read("features/unreceive-piece-and-check-order-line.feature")
+
   Scenario: wipe data
     Given call read('classpath:common/destroy-data.feature')

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/create-order-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/create-order-line.feature
@@ -1,11 +1,12 @@
 Feature: Create order line
-  # parameters: id, orderId, fundId, listUnitPrice
+  # parameters: id, orderId, fundId, listUnitPrice, isPackage
 
   Background:
     * url baseUrl
 
   Scenario: createOrderLine
     * def listUnitPrice = karate.get('listUnitPrice', 1.0)
+    * def isPackage = karate.get('isPackage', false)
     * def poLine = read('classpath:samples/mod-orders/orderLines/minimal-order-line.json')
     * set poLine.id = id
     * set poLine.purchaseOrderId = orderId
@@ -13,6 +14,7 @@ Feature: Create order line
     * set poLine.fundDistribution[0].code = fundId
     * set poLine.cost.listUnitPrice = listUnitPrice
     * set poLine.cost.poLineEstimatedPrice = listUnitPrice
+    * set poLine.isPackage = isPackage
 
     Given path 'orders/order-lines'
     And request poLine

--- a/acquisitions/src/test/java/org/folio/OrdersApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersApiTest.java
@@ -308,6 +308,11 @@ public class OrdersApiTest extends TestBase {
     runFeatureTest("poline_change_instance_connection");
   }
 
+  @Test
+  void unreceivePieceAndCheckOrderLine() {
+    runFeatureTest("unreceive-piece-and-check-order-line");
+  }
+
   @BeforeAll
   public void ordersApiTestBeforeAll() {
     runFeature("classpath:thunderjet/mod-orders/orders-junit.feature");


### PR DESCRIPTION
## Purpose
[MODORDERS-984](https://issues.folio.org/browse/MODORDERS-984) - Receipt status remains "Fully received" after unreceiving piece

## Approach
Added a test unreceiving pieces and checking the receipt status in the po line afterwards.

[mod-orders PR](https://github.com/folio-org/mod-orders/pull/814)
