### PR TITLE
FAT-9973: Karate test fail. mod bulk operations holdings features

### DIFF
--- a/mod-bulk-operations/src/main/resources/firebird/mod-bulk-operations/features/holdings.feature
+++ b/mod-bulk-operations/src/main/resources/firebird/mod-bulk-operations/features/holdings.feature
@@ -890,6 +890,8 @@ Feature: mod bulk operations holdings features
     Then status 200
 
     * def holding = response.holdingsRecords[0]
+    * delete holding.holdingsItems
+    * delete holding.bareHoldingsItems
     * def holdingId = holding.id
     * holding.administrativeNotes = ['note1']
     * holding.notes = [{'holdingsNoteTypeId': 'db9b4787-95f0-4e78-becf-26748ce6bdeb', 'note': 'note2'}]


### PR DESCRIPTION
## Purpose
https://issues.folio.org/browse/FAT-9973
mod bulk operations holdings feature Karate tests failure


## Approach
removing of unsupported elements:
holding.holdingsItems
holding.bareHoldingsItems


### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
