### PR TITLE
Add Authtoken-Refresh-Cache = true to invildate permissions cache during login

### DIFF
--- a/common/src/main/resources/common/login.feature
+++ b/common/src/main/resources/common/login.feature
@@ -8,6 +8,7 @@ Feature: login
     Given path 'authn/login-with-expiry'
     And header Accept = 'application/json'
     And header x-okapi-tenant = tenant
+    And header Authtoken-Refresh-Cache = true
     And request { username: '#(name)', password: '#(password)' }
     When method POST
     Then status 201


### PR DESCRIPTION
Header name in mod-authtoken: https://github.com/folio-org/mod-authtoken/blob/c11c02504f3168f08266178e73ff25978da933be/src/main/java/org/folio/auth/authtokenmodule/MainVerticle.java#L23

How it uses: https://github.com/folio-org/mod-authtoken/blob/master/src/main/java/org/folio/auth/authtokenmodule/apis/FilterApi.java#L260
