### PR TITLE
Stabilize Thunderjet consortia tests

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/reopen-order-with-50-lines.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/reopen-order-with-50-lines.feature
@@ -28,7 +28,7 @@ Feature: Reopen order with 50 lines
     * def budgetId = callonce uuid2
     * def orderId = callonce uuid3
 
-    * configure readTimeout = 60000
+    * configure readTimeout = 90000
 
 
   Scenario: Prepare finances

--- a/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/util/tenant-and-local-admin-setup.feature
+++ b/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/util/tenant-and-local-admin-setup.feature
@@ -23,4 +23,5 @@ Feature: setup tenant
     * call read('features/util/initData.feature@InstallModules') { modules: [{name: 'folio_users'}], tenant: '#(tenant)'}
 
     # enable 'mod-consortia'
+    * call read(login) admin
     * call read('features/util/initData.feature@InstallModules') { modules: [{name: 'mod-consortia'}], tenant: '#(tenant)'}


### PR DESCRIPTION
## Purpose
Time to live of accessToken is 10 min, initial setup of 3 tenants with all modules requires more than 10 min that causes InvlaidTokenException
Solution: make relogin after each particular tenant setup
