### PR TITLE
FAT-12199 Fixed mod-template-engine test case failure.

### DIFF
--- a/mod-template-engine/src/main/resources/vega/mod-template-engine/features/samples/template-request-entity.json
+++ b/mod-template-engine/src/main/resources/vega/mod-template-engine/features/samples/template-request-entity.json
@@ -8,6 +8,8 @@
     },
     "item": {
       "name": "My Item"
-    }
+    },
+    "expirationTime": 24,
+    "expirationUnitOfTime" : "hours"
   }
 }

--- a/mod-template-engine/src/main/resources/vega/mod-template-engine/features/templateRequest.feature
+++ b/mod-template-engine/src/main/resources/vega/mod-template-engine/features/templateRequest.feature
@@ -13,8 +13,11 @@ Feature: Template processing requests tests
     When method GET
     Then status 200
 
-    * requestEntity.templateId = response.templates[0].id
-    * requestEntity.outputFormat = response.templates[0].outputFormats[0]
+#   Filtering response based on description so that subsequent assertion will gets succeeded irrespective of order of response
+    * def filterResponseByDesc = karate.filter(response.templates, function(item){ return item.description == "Account activation email" })
+    * requestEntity.templateId = filterResponseByDesc[0].id
+    * requestEntity.outputFormat = filterResponseByDesc[0].outputFormats[0]
+
 
     Given path 'template-request'
     And request requestEntity


### PR DESCRIPTION
## Purpose
The purpose of the PR is to fix mod-template-engine failing test case

## Approach
In the existing implementation, it is assumed that the first object of the response belongs to Complete activation of your FOLIO account template. But it looks like now the order is changed because of it test case is failing. 
In order to fix this, we are filtering the response based on description so that irrespective of the order of response, the karate will pass. 
Also, we have added expirationTime and expirationUnitOfTime in context so that [this ](https://github.com/folio-org/mod-template-engine/pull/101)change in mod-template-engine wont break the assertion

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
