### PR TITLE
[MODORDERS-1049] New test opening an order beyond restricted expenditures

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-failure-with-expenditure-restrictions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-failure-with-expenditure-restrictions.feature
@@ -34,7 +34,7 @@ Feature: Open order failure with expenditure restrictions
     * def v = call createBudget { id: "#(budgetId)", fundId: "#(fundId)", allocated: 5 }
 
 
-  Scenario: Create an order and line
+  Scenario: Create an order and line going over budget
     * def v = call createOrder { id: "#(orderId)" }
     * def v = call createOrderLine { id: "#(poLineId)", orderId: "#(orderId)", fundId: "#(fundId)", listUnitPrice: 10, titleOrPackage: titleOrPackage }
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-failure-with-expenditure-restrictions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-failure-with-expenditure-restrictions.feature
@@ -1,0 +1,102 @@
+@parallel=false
+# Created for MODORDERS-1049
+# Related to MODORDERS-528 and open-order-failure-side-effects.feature
+Feature: Open order failure with expenditure restrictions
+
+  Background:
+    * print karate.info.scenarioName
+    * url baseUrl
+    * callonce loginAdmin testAdmin
+    * def okapitokenAdmin = okapitoken
+    * callonce loginRegularUser testUser
+    * def okapitokenUser = okapitoken
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json' }
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': '*/*' }
+    * configure headers = headersUser
+
+    * callonce variables
+
+    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
+    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
+
+    * def ledgerId = callonce uuid1
+    * def fundId = callonce uuid2
+    * def budgetId = callonce uuid3
+    * def orderId = callonce uuid4
+    * def poLineId = callonce uuid5
+    * def titleOrPackage = callonce uuid6
+
+
+  Scenario: Create finances
+    * configure headers = headersAdmin
+    * def v = call createLedger { id: "#(ledgerId)", fiscalYearId: "#(globalFiscalYearId)", restrictEncumbrance: false, restrictExpenditures: true }
+    * def v = call createFund { id: "#(fundId)", ledgerId: "#(ledgerId)" }
+    * def v = call createBudget { id: "#(budgetId)", fundId: "#(fundId)", allocated: 5 }
+
+
+  Scenario: Create an order and line
+    * def v = call createOrder { id: "#(orderId)" }
+    * def v = call createOrderLine { id: "#(poLineId)", orderId: "#(orderId)", fundId: "#(fundId)", listUnitPrice: 10, titleOrPackage: titleOrPackage }
+
+
+  Scenario: Try to open the order
+    Given path 'orders/composite-orders', orderId
+    When method GET
+    Then status 200
+
+    * def orderResponse = $
+    * set orderResponse.workflowStatus = 'Open'
+
+    Given path 'orders/composite-orders', orderId
+    And request orderResponse
+    When method PUT
+    Then status 422
+
+
+  Scenario: Check inventory records were not created during the failed open order operation
+    * print 'Check instances'
+    Given path 'inventory/instances'
+    And param query = 'title==' + titleOrPackage
+    When method GET
+    And match $.totalRecords == 0
+
+    * print 'Check pieces'
+    Given path 'orders/pieces'
+    And param query = 'poLineId==' + poLineId
+    When method GET
+    Then status 200
+    And match $.totalRecords == 0
+
+    * print 'Check items'
+    Given path 'inventory/items'
+    And param query = 'purchaseOrderLineIdentifier==' + poLineId
+    When method GET
+    And match $.totalRecords == 0
+
+
+  Scenario: Change the order line amount
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+    * def poLine = $
+    * set poLine.cost.listUnitPrice = 5
+    * set poLine.cost.poLineEstimatedPrice = 5
+
+    Given path 'orders/order-lines', poLineId
+    And request poLine
+    When method PUT
+    Then status 204
+
+
+  Scenario: Try to open the order again
+    Given path 'orders/composite-orders', orderId
+    When method GET
+    Then status 200
+
+    * def orderResponse = $
+    * set orderResponse.workflowStatus = 'Open'
+
+    Given path 'orders/composite-orders', orderId
+    And request orderResponse
+    When method PUT
+    Then status 204

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
@@ -251,6 +251,9 @@ Feature: mod-orders integration tests
   Scenario: Unreceive a piece and check the order line
     Given call read("features/unreceive-piece-and-check-order-line.feature")
 
+  Scenario: Open order failure with expenditure restrictions
+    Given call read("features/open-order-failure-with-expenditure-restrictions.feature")
+
 # These 2 have to be called with OrdersApiTest - this comment is here as a reminder
 #  Scenario: Create pieces for an open order in parallel
 #    Given call read("features/parallel-create-piece.feature")

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/create-order-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/create-order-line.feature
@@ -1,5 +1,5 @@
 Feature: Create order line
-  # parameters: id, orderId, fundId, listUnitPrice, isPackage
+  # parameters: id, orderId, fundId, listUnitPrice, isPackage, titleOrPackage
 
   Background:
     * url baseUrl
@@ -8,6 +8,7 @@ Feature: Create order line
     * def listUnitPrice = karate.get('listUnitPrice', 1.0)
     * def isPackage = karate.get('isPackage', false)
     * def poLine = read('classpath:samples/mod-orders/orderLines/minimal-order-line.json')
+    * def titleOrPackage = karate.get('titleOrPackage', 'test')
     * set poLine.id = id
     * set poLine.purchaseOrderId = orderId
     * set poLine.fundDistribution[0].fundId = fundId
@@ -15,6 +16,7 @@ Feature: Create order line
     * set poLine.cost.listUnitPrice = listUnitPrice
     * set poLine.cost.poLineEstimatedPrice = listUnitPrice
     * set poLine.isPackage = isPackage
+    * set poLine.titleOrPackage = titleOrPackage
 
     Given path 'orders/order-lines'
     And request poLine

--- a/acquisitions/src/test/java/org/folio/OrdersApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersApiTest.java
@@ -351,6 +351,11 @@ public class OrdersApiTest extends TestBase {
     runFeatureTest("parallel-update-order-lines-same-order", 5);
   }
 
+  @Test
+  void openOrderFailureWithExpenditureRestrictions() {
+    runFeatureTest("open-order-failure-with-expenditure-restrictions");
+  }
+
   @BeforeAll
   public void ordersApiTestBeforeAll() {
     runFeature("classpath:thunderjet/mod-orders/orders-junit.feature");


### PR DESCRIPTION
## Purpose
[MODORDERS-1049](https://folio-org.atlassian.net/browse/MODORDERS-1049) - 500 error appears when trying to open order more than one time

## Approach
New test to open an order beyond restricted expenditures. Checks that inventory is not modified after failure and tries to open the order again after changing the amount.
Before [MODORDERS-1050](https://folio-org.atlassian.net/browse/MODORDERS-1050) is implemented this will check that the inventory rollback works when an unexpected error occurs while creating encumbrances.

## Related PR
[PR in mod-orders](https://github.com/folio-org/mod-orders/pull/847): Rollback inventory if open fails to create encumbrances