### PR TITLE
[MODFISTO-472] Reversed test with restricted expenditures when opening an order

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
@@ -254,8 +254,8 @@ Feature: mod-orders integration tests
   Scenario: Encumbrance update after expense class change
     Given call read("features/encumbrance-update-after-expense-class-change.feature")
 
-  Scenario: Open order failure with expenditure restrictions
-    Given call read("features/open-order-failure-with-expenditure-restrictions.feature")
+  Scenario: Open order success with expenditure restrictions
+    Given call read("features/open-order-success-with-expenditure-restrictions.feature")
 
 
 # These 2 have to be called with OrdersApiTest - this comment is here as a reminder

--- a/acquisitions/src/test/java/org/folio/OrdersApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersApiTest.java
@@ -357,8 +357,8 @@ public class OrdersApiTest extends TestBase {
   }
 
   @Test
-  void openOrderFailureWithExpenditureRestrictions() {
-    runFeatureTest("open-order-failure-with-expenditure-restrictions");
+  void openOrderSuccessWithExpenditureRestrictions() {
+    runFeatureTest("open-order-success-with-expenditure-restrictions");
   }
 
   @BeforeAll


### PR DESCRIPTION
## Purpose
[MODFISTO-472](https://folio-org.atlassian.net/browse/MODFISTO-472) - Change restricted expenditures calculations

## Approach
Reversed a previous test to make sure restricted expenditures do not prevent opening an order.

[Related mod-finance-storage PR](https://github.com/folio-org/mod-finance-storage/pull/394)