### PR TITLE
[MODORDERS-1055] Updated test to check encumbrances after reopening an order

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-encumbrances-after-order-is-reopened.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-encumbrances-after-order-is-reopened.feature
@@ -1,7 +1,9 @@
+# For MODORDERS-474 and MODORDERS-1055
 @parallel=false
 Feature: Check encumbrances after order is reopened
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
     * callonce loginAdmin testAdmin
     * def okapitokenAdmin = okapitoken
@@ -28,16 +30,19 @@ Feature: Check encumbrances after order is reopened
     * def otherEncumbranceId1 = callonce uuid13
     * def otherEncumbranceId2 = callonce uuid14
 
+    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
+    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
+    * def createInvoice = read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature')
+    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
+
 
   Scenario: Create a fund and budget
-  * print "Create a fund and budget"
     * configure headers = headersAdmin
-    * callonce createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)'}
-    * callonce createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 1000}
+    * def v = call createFund { id: '#(fundId)', ledgerId: '#(globalLedgerWithRestrictionsId)' }
+    * def v = call createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 1000 }
 
 
   Scenario: Check the new budget
-    * print "Check the new budget"
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET
@@ -52,39 +57,17 @@ Feature: Check encumbrances after order is reopened
     And match budget.unavailable == 0
 
 
-  Scenario: Create orders
-    * print "Create orders"
-
-    Given path 'orders/composite-orders'
-    And request
-    """
-    {
-      id: '#(orderId)',
-      vendor: '#(globalVendorId)',
-      orderType: 'One-Time'
-    }
-    """
-    When method POST
-    Then status 201
+  Scenario: Create order
+    * def v = call createOrder { id: '#(orderId)' }
 
 
   Scenario Outline: Create order lines for <orderLineId> and <fundId>
-    * print "Create order lines for <orderLineId> and <fundId>"
-
     * def orderId = <orderId>
     * def poLineId = <orderLineId>
+    * def fundId = <fundId>
+    * def amount = <amount>
 
-    Given path 'orders/order-lines'
-
-    * def orderLine = read('classpath:samples/mod-orders/orderLines/minimal-order-line.json')
-    * set orderLine.id = poLineId
-    * set orderLine.purchaseOrderId = orderId
-    * set orderLine.cost.listUnitPrice = <amount>
-    * set orderLine.fundDistribution[0].fundId = <fundId>
-
-    And request orderLine
-    When method POST
-    Then status 201
+    * def v = call createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', fundId: '#(fundId)', listUnitPrice: #(amount) }
 
     Examples:
       | orderId | orderLineId    | fundId | amount |
@@ -93,18 +76,10 @@ Feature: Check encumbrances after order is reopened
 
 
   Scenario: Create the invoice
-    * print "Create the invoice"
-    * def invoicePayload = read('classpath:samples/mod-invoice/invoices/global/invoice.json')
-    * set invoicePayload.id = invoiceId
-    Given path 'invoice/invoices'
-    And request invoicePayload
-    When method POST
-    Then status 201
+    * def v = call createInvoice { id: '#(invoiceId)' }
 
 
-  Scenario Outline: Add an invoice line
-    * print "Add an invoice line"
-
+  Scenario Outline: Add an invoice line with releaseEncumbrance=<releaseEncumbrance>
     * def invoiceLinePayload = read('classpath:samples/mod-invoice/invoices/global/invoice-line-percentage.json')
     * set invoiceLinePayload.id = <invoiceLineId>
     * set invoiceLinePayload.invoiceId = invoiceId
@@ -123,24 +98,10 @@ Feature: Check encumbrances after order is reopened
 
 
   Scenario: Open the order
-    * print "Open the order"
-
-    Given path 'orders/composite-orders', orderId
-    When method GET
-    Then status 200
-
-    * def orderResponse = $
-    * set orderResponse.workflowStatus = 'Open'
-
-    Given path 'orders/composite-orders', orderId
-    And request orderResponse
-    When method PUT
-    Then status 204
+    * def v = call openOrder { orderId: '#(orderId)' }
 
 
   Scenario: Check the budget after opening the order
-    * print "Check the budget after opening the order"
-
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET
@@ -156,8 +117,6 @@ Feature: Check encumbrances after order is reopened
 
 
   Scenario: Close the order and release encumbrances
-    * print "Close the order and release encumbrances"
-
     Given path 'orders/composite-orders', orderId
     When method GET
     Then status 200
@@ -174,21 +133,14 @@ Feature: Check encumbrances after order is reopened
 
 
   Scenario: Check encumbrances status for closed order
-    * print "Check encumbrances status for closed order"
-
     Given path '/finance/transactions'
     And param query = 'encumbrance.sourcePurchaseOrderId == ' + orderId
     When method GET
     Then status 200
-    * def path1 = "$.transactions[?(@.encumbrance.sourcePoLineId=='" + orderLineId1 + "')].encumbrance.status"
-    * match karate.jsonPath(response, path1)[0] == 'Released'
-    * def path2 = "$.transactions[?(@.encumbrance.sourcePoLineId=='" + orderLineId2 + "')].encumbrance.status"
-    * match karate.jsonPath(response, path2)[0] == 'Released'
+    And match each $.transactions[*].encumbrance.status == 'Released'
 
 
   Scenario: Check the budget after closing the order
-    * print "Check the budget after closing the order"
-
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET
@@ -204,8 +156,6 @@ Feature: Check encumbrances after order is reopened
 
 
   Scenario: Add some encumbrance to later test the budget checks when reopening the order
-    * print "Add some encumbrance to later test the budget checks when reopening the order"
-
     Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
@@ -236,8 +186,6 @@ Feature: Check encumbrances after order is reopened
 
 
   Scenario: Check the budget, there should not be enough founds to reopen
-    * print "Check the budget, there should not be enough founds to reopen"
-
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET
@@ -253,8 +201,6 @@ Feature: Check encumbrances after order is reopened
 
 
   Scenario: Try reopening the order, this should fail because of encumbrance restrictions
-    * print "Try reopening the order, this should fail because of encumbrance restrictions"
-
     Given path 'orders/composite-orders', orderId
     When method GET
     Then status 200
@@ -271,8 +217,6 @@ Feature: Check encumbrances after order is reopened
 
 
   Scenario: Release the added encumbrance
-    * print "Release the added encumbrance"
-
     Given path 'finance/transactions', otherEncumbranceId1
     When method GET
     Then status 200
@@ -291,41 +235,7 @@ Feature: Check encumbrances after order is reopened
     Then status 204
 
 
-  Scenario: Add another (lower) encumbrance to test reopening encumbrance checks
-    * print "Add another (lower) encumbrance to test reopening encumbrance checks"
-
-    Given path 'finance/transactions/batch-all-or-nothing'
-    And request
-    """
-    {
-      "transactionsToCreate": [{
-        "id": "#(otherEncumbranceId2)",
-        "amount": 500,
-        "currency": "USD",
-        "description": "encumber 500",
-        "fiscalYearId": "#(globalFiscalYearId)",
-        "source": "User",
-        "fromFundId": "#(fundId)",
-        "transactionType": "Encumbrance",
-        "encumbrance": {
-          "initialAmountEncumbered": 500,
-          "status": "Unreleased",
-          "orderType": "One-Time",
-          "subscription": false,
-          "reEncumber": false,
-          "sourcePurchaseOrderId": '#(otherOrderId2)',
-          "sourcePoLineId": '#(otherOrderLineId2)'
-        }
-      }]
-    }
-    """
-    When method POST
-    Then status 204
-
-
   Scenario: Check the budget before reopening the order
-    * print "Check the budget before reopening the order"
-
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET
@@ -333,47 +243,28 @@ Feature: Check encumbrances after order is reopened
 
     * def budget = response.budgets[0]
 
-    And match budget.available == 500
+    And match budget.available == 1000
     And match budget.expenditures == 0
-    And match budget.encumbered == 500
+    And match budget.encumbered == 0
     And match budget.awaitingPayment == 0
-    And match budget.unavailable == 500
+    And match budget.unavailable == 0
 
 
   Scenario: Reopen the order
-    * print "Reopen the order"
-
-    # encumbrances without an invoice line having releaseEncumbrance=true (with the first poline) should be unreleased
-    Given path 'orders/composite-orders', orderId
-    When method GET
-    Then status 200
-    And match $.workflowStatus == 'Closed'
-
-    * def orderResponse = $
-    * set orderResponse.workflowStatus = 'Open'
-
-    Given path 'orders/composite-orders', orderId
-    And request orderResponse
-    When method PUT
-    Then status 204
+    * def v = call openOrder { orderId: '#(orderId)' }
 
 
   Scenario: check encumbrances status for reopened order
-    * print "check encumbrances status for reopened order"
-
     Given path '/finance/transactions'
     And param query = 'encumbrance.sourcePurchaseOrderId == ' + orderId
     When method GET
     Then status 200
-    * def path1 = "$.transactions[?(@.encumbrance.sourcePoLineId=='" + orderLineId1 + "')].encumbrance.status"
-    * match karate.jsonPath(response, path1)[0] == 'Unreleased'
-    * def path2 = "$.transactions[?(@.encumbrance.sourcePoLineId=='" + orderLineId2 + "')].encumbrance.status"
-    * match karate.jsonPath(response, path2)[0] == 'Released'
+    And match $.transactions == '#[2]'
+    And match each $.transactions[*].encumbrance.orderStatus == 'Open'
+    And match each $.transactions[*].encumbrance.status == 'Unreleased'
 
 
   Scenario: Final budget check
-    * print "Final budget check"
-
     Given path '/finance/budgets'
     And param query = 'fundId == ' + fundId
     When method GET
@@ -381,8 +272,8 @@ Feature: Check encumbrances after order is reopened
 
     * def budget = response.budgets[0]
 
-    And match budget.available == 100
+    And match budget.available == 0
     And match budget.expenditures == 0
-    And match budget.encumbered == 900
+    And match budget.encumbered == 1000
     And match budget.awaitingPayment == 0
-    And match budget.unavailable == 900
+    And match budget.unavailable == 1000


### PR DESCRIPTION
## Purpose
[MODORDERS-1055](https://folio-org.atlassian.net/browse/MODORDERS-1055) - orderStatus is not always updated when reopening an order

## Approach
Updated existing test. The 2 encumbrances in the test are now released because the invoice is not approved, which means some additional changes were needed for the test to pass (especially with the encumbrance restrictions).
A separate test (`check-encumbrances-after-order-is-reopened-2`) already checks an encumbrance is not unreleased when an order with an approved invoice is reopened.

[Related mod-orders PR](https://github.com/folio-org/mod-orders/pull/859)
