### PR TITLE
[MODINVOICE-516] Pay invoice without order acq unit perm

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules-junit.feature
@@ -23,10 +23,11 @@ Feature: cross-module integration tests
       | 'mod-organizations-storage' |
 
     * table adminAdditionalPermissions
-      | name                        |
-      | 'finance.module.all'        |
-      | 'finance.all'               |
-      | 'orders-storage.module.all' |
+      | name                                         |
+      | 'finance.module.all'                         |
+      | 'finance.all'                                |
+      | 'orders-storage.module.all'                  |
+      | 'acquisitions-units.memberships.item.delete' |
 
     * table userPermissions
       | name                          |

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
@@ -19,10 +19,11 @@ Feature: cross-module integration tests
     * def testUser = {tenant: '#(testTenant)', name: 'test-user', password: 'test'}
 
     * table adminAdditionalPermissions
-      | name                                                        |
-      | 'finance.module.all'                                        |
-      | 'finance.all'                                               |
-      | 'orders-storage.module.all'                                 |
+      | name                                         |
+      | 'finance.module.all'                         |
+      | 'finance.all'                                |
+      | 'orders-storage.module.all'                  |
+      | 'acquisitions-units.memberships.item.delete' |
 
     * table userPermissions
       | name                          |
@@ -151,6 +152,9 @@ Feature: cross-module integration tests
 
   Scenario: Pending payment update after encumbrance deletion
     Given call read('features/pending-payment-update-after-encumbrance-deletion.feature')
+
+  Scenario: Pay invoice without order acq unit permission
+    Given call read('features/pay-invoice-without-order-acq-unit-permission.feature')
 
   Scenario: wipe data
     Given call read('classpath:common/destroy-data.feature')

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/pay-invoice-without-order-acq-unit-permission.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/pay-invoice-without-order-acq-unit-permission.feature
@@ -1,0 +1,119 @@
+# For MODINVOICE-516
+@parallel=false
+Feature: Pay invoice without order acq unit permission
+
+  Background:
+    * print karate.info.scenarioName
+
+    * url baseUrl
+
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json, text/plain' }
+
+    * configure headers = headersUser
+
+    * callonce variables
+
+    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
+    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
+    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
+    * def createInvoice = read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature')
+    * def createInvoiceLine = read('classpath:thunderjet/mod-invoice/reusable/create-invoice-line.feature')
+    * def approveInvoice = read('classpath:thunderjet/mod-invoice/reusable/approve-invoice.feature')
+    * def payInvoice = read('classpath:thunderjet/mod-invoice/reusable/pay-invoice.feature')
+
+    * def fundId = callonce uuid1
+    * def budgetId = callonce uuid2
+    * def orderId = callonce uuid3
+    * def poLineId = callonce uuid4
+    * def invoiceId = callonce uuid5
+    * def invoiceLineId = callonce uuid6
+    * def acqUnitId = callonce uuid7
+    * def acqUnitMembershipId = callonce uuid8
+
+
+  Scenario: Prepare finances
+    * configure headers = headersAdmin
+    * def v = call createFund { id: '#(fundId)' }
+    * def v = call createBudget { id: '#(budgetId)', allocated: 1000, fundId: '#(fundId)', status: 'Active' }
+
+
+  Scenario: Create acq unit
+    * configure headers = headersAdmin
+    Given path 'acquisitions-units/units'
+    And request
+    """
+    {
+      "id": '#(acqUnitId)',
+      "protectUpdate": true,
+      "protectCreate": true,
+      "protectDelete": true,
+      "protectRead": true,
+      "name": "testAcqUnit"
+    }
+    """
+    When method POST
+    Then status 201
+
+
+  Scenario: Create acq unit membership
+    * configure headers = headersAdmin
+    Given path 'acquisitions-units/memberships'
+    And request
+    """
+      {
+        "id": '#(acqUnitMembershipId)',
+        "userId": "00000000-1111-5555-9999-999999999992",
+        "acquisitionsUnitId": "#(acqUnitId)"
+      }
+    """
+    When method POST
+    Then status 201
+
+
+  Scenario: Create an order
+    * def v = call createOrder { id: '#(orderId)', acqUnitIds: ['#(acqUnitId)'] }
+
+
+  Scenario: Create an order line
+    * def v = call createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', fundId: '#(fundId)', listUnitPrice: 10 }
+
+
+  Scenario: Open the order
+    * def v = call openOrder { orderId: '#(orderId)' }
+
+
+  Scenario: Create an invoice
+    * def v = call createInvoice { id: '#(invoiceId)' }
+
+
+  Scenario: Add an invoice line linked to the po line
+    * print "Get the encumbrance id"
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+    * def poLine = $
+    * def encumbranceId = poLine.fundDistribution[0].encumbrance
+
+    * print "Add an invoice line linked to the po line"
+    * def v = call createInvoiceLine { invoiceLineId: '#(invoiceLineId)', invoiceId: '#(invoiceId)', poLineId: '#(poLineId)', fundId: '#(fundId)', encumbranceId: '#(encumbranceId)', total: 10 }
+
+
+  Scenario: Approve the invoice
+    * def v = call approveInvoice { invoiceId: '#(invoiceId)' }
+
+
+  Scenario: Remove acq unit membership
+    * configure headers = headersAdmin
+    Given path 'acquisitions-units/memberships', acqUnitMembershipId
+    When method DELETE
+    Then status 204
+
+
+  Scenario: Pay the invoice
+    * def v = call payInvoice { invoiceId: '#(invoiceId)' }

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/create-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/create-order.feature
@@ -1,5 +1,5 @@
 Feature: Create order
-  # parameters: id, vendor?, orderType?, ongoing?, reEncumber?
+  # parameters: id, vendor?, orderType?, ongoing?, reEncumber?, acqUnitIds?
 
   Background:
     * url baseUrl
@@ -9,6 +9,7 @@ Feature: Create order
     * def orderType = karate.get('orderType', 'One-Time')
     * def ongoing = karate.get('ongoing', null)
     * def reEncumber = karate.get('reEncumber', false)
+    * def acqUnitIds = karate.get('acqUnitIds', [])
     Given path 'orders/composite-orders'
     And request
     """
@@ -17,7 +18,8 @@ Feature: Create order
       vendor: #(vendor),
       orderType: #(orderType),
       ongoing: #(ongoing),
-      reEncumber: #(reEncumber)
+      reEncumber: #(reEncumber),
+      acqUnitIds: #(acqUnitIds)
     }
     """
     When method POST

--- a/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
+++ b/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
@@ -179,6 +179,11 @@ public class CrossModulesApiTest extends TestBase {
     runFeatureTest("pending-payment-update-after-encumbrance-deletion");
   }
 
+  @Test
+  void payInvoiceWithoutOrderAcqUnitPermission() {
+    runFeatureTest("pay-invoice-without-order-acq-unit-permission");
+  }
+
   @BeforeAll
   public void crossModuleApiTestBeforeAll() {
     runFeature("classpath:thunderjet/cross-modules/cross-modules-junit.feature");


### PR DESCRIPTION
## Purpose
[MODINVOICE-516](https://folio-org.atlassian.net/browse/MODINVOICE-516) - Invoice transactions should not be changed when acquisition check was failed

## Approach
Added a new test with the MODINVOICE-516 scenario.

[Related mod-orders PR](https://github.com/folio-org/mod-orders/pull/871)
[Related mod-invoice PR](https://github.com/folio-org/mod-invoice/pull/479)