### PR TITLE
[MODORDERS-1071] Check paymentStatus after reopen

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
@@ -156,5 +156,8 @@ Feature: cross-module integration tests
   Scenario: Pay invoice without order acq unit permission
     Given call read('features/pay-invoice-without-order-acq-unit-permission.feature')
 
+  Scenario: Check paymentStatus after reopen
+    Given call read('features/check-paymentstatus-after-reopen.feature')
+
   Scenario: wipe data
     Given call read('classpath:common/destroy-data.feature')

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-paymentstatus-after-reopen.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-paymentstatus-after-reopen.feature
@@ -1,0 +1,87 @@
+# For MODORDERS-1071
+Feature: Check paymentStatus after reopen
+
+  Background:
+    * print karate.info.scenarioName
+
+    * url baseUrl
+
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json, text/plain' }
+
+    * configure headers = headersUser
+
+    * callonce variables
+
+    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
+    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
+    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
+    * def closeOrder = read('classpath:thunderjet/mod-orders/reusable/close-order.feature')
+    * def createInvoice = read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature')
+    * def createInvoiceLine = read('classpath:thunderjet/mod-invoice/reusable/create-invoice-line.feature')
+    * def approveInvoice = read('classpath:thunderjet/mod-invoice/reusable/approve-invoice.feature')
+
+
+  Scenario: Open order, approve invoice, close order, reopen order, check paymentStatus
+    * def fundId = call uuid
+    * def budgetId = call uuid
+    * def orderId = call uuid
+    * def poLineId = call uuid
+    * def invoiceId = call uuid
+    * def invoiceLineId = call uuid
+
+    * print "Prepare finances"
+    * configure headers = headersAdmin
+    * def v = call createFund { id: '#(fundId)' }
+    * def v = call createBudget { id: '#(budgetId)', allocated: 1000, fundId: '#(fundId)', status: 'Active' }
+    * configure headers = headersUser
+
+    * print "Create an order"
+    * def v = call createOrder { id: '#(orderId)' }
+
+    * print "Create an order line"
+    * def v = call createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', fundId: '#(fundId)', listUnitPrice: 10 }
+
+    * print "Open the order"
+    * def v = call openOrder { orderId: '#(orderId)' }
+
+    * print "Create an invoice"
+    * def v = call createInvoice { id: '#(invoiceId)' }
+
+    * print "Get the encumbrance id"
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+    * def poLine = $
+    * def encumbranceId = poLine.fundDistribution[0].encumbrance
+
+    * print "Add an invoice line linked to the po line"
+    * def v = call createInvoiceLine { invoiceLineId: '#(invoiceLineId)', invoiceId: '#(invoiceId)', poLineId: '#(poLineId)', fundId: '#(fundId)', encumbranceId: '#(encumbranceId)', total: 10 }
+
+    * print "Approve the invoice"
+    * def v = call approveInvoice { invoiceId: '#(invoiceId)' }
+
+    * print "Check the po line paymentStatus"
+    Given path 'orders/order-lines', poLineId
+    * configure headers = headersUser
+    When method GET
+    Then status 200
+    And match $.paymentStatus == 'Awaiting Payment'
+
+    * print "Close the order"
+    * def v = call closeOrder { orderId: '#(orderId)' }
+
+    * print "Reopen the order"
+    * def v = call openOrder { orderId: '#(orderId)' }
+
+    * print "Check the po line paymentStatus"
+    Given path 'orders/order-lines', poLineId
+    * configure headers = headersUser
+    When method GET
+    Then status 200
+    And match $.paymentStatus == 'Awaiting Payment'

--- a/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
+++ b/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
@@ -184,6 +184,11 @@ public class CrossModulesApiTest extends TestBase {
     runFeatureTest("pay-invoice-without-order-acq-unit-permission");
   }
 
+  @Test
+  void checkPaymentStatusAfterReopen() {
+    runFeatureTest("check-paymentstatus-after-reopen");
+  }
+
   @BeforeAll
   public void crossModuleApiTestBeforeAll() {
     runFeature("classpath:thunderjet/cross-modules/cross-modules-junit.feature");


### PR DESCRIPTION
## Purpose
[MODORDERS-1071](https://folio-org.atlassian.net/browse/MODORDERS-1071) - PaymentStatus can be wrong after reopening an order

## Approach
Added a new test: open an order, approve the invoice, close the order, reopen the order, check line paymentStatus.

[mod-orders PR](https://github.com/folio-org/mod-orders/pull/872)