### PR TITLE
[MODORDERS-1073] Invoice encumbrance update without acquisition unit

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
@@ -159,5 +159,8 @@ Feature: cross-module integration tests
   Scenario: Check paymentStatus after reopen
     Given call read('features/check-paymentstatus-after-reopen.feature')
 
+  Scenario: Invoice encumbrance update without acquisition unit
+    Given call read('features/invoice-encumbrance-update-without-acquisition-unit.feature')
+
   Scenario: wipe data
     Given call read('classpath:common/destroy-data.feature')

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/invoice-encumbrance-update-without-acquisition-unit.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/invoice-encumbrance-update-without-acquisition-unit.feature
@@ -1,0 +1,145 @@
+# For MODORDERS-1073
+@parallel=false
+Feature: Invoice encumbrance update without acquisition unit
+
+  Background:
+    * print karate.info.scenarioName
+
+    * url baseUrl
+
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json, text/plain' }
+
+    * configure headers = headersUser
+
+    * callonce variables
+
+    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
+    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
+    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
+    * def createInvoice = read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature')
+    * def createInvoiceLine = read('classpath:thunderjet/mod-invoice/reusable/create-invoice-line.feature')
+
+    * def fundId = callonce uuid1
+    * def budgetId = callonce uuid2
+    * def orderId = callonce uuid3
+    * def poLineId = callonce uuid4
+    * def invoiceId = callonce uuid5
+    * def invoiceLineId = callonce uuid6
+    * def acqUnitId = callonce uuid7
+    * def acqUnitMembershipId = callonce uuid8
+
+
+  Scenario: Prepare finances
+    * configure headers = headersAdmin
+    * def v = call createFund { id: '#(fundId)' }
+    * def v = call createBudget { id: '#(budgetId)', allocated: 1000, fundId: '#(fundId)', status: 'Active' }
+
+
+  Scenario: Create acq unit
+    * configure headers = headersAdmin
+    Given path 'acquisitions-units/units'
+    And request
+    """
+    {
+      "id": '#(acqUnitId)',
+      "protectUpdate": true,
+      "protectCreate": true,
+      "protectDelete": true,
+      "protectRead": true,
+      "name": "testAcqUnitForInvoice"
+    }
+    """
+    When method POST
+    Then status 201
+
+
+  Scenario: Create acq unit membership
+    * configure headers = headersAdmin
+    Given path 'acquisitions-units/memberships'
+    And request
+    """
+      {
+        "id": '#(acqUnitMembershipId)',
+        "userId": "00000000-1111-5555-9999-999999999992",
+        "acquisitionsUnitId": "#(acqUnitId)"
+      }
+    """
+    When method POST
+    Then status 201
+
+
+  Scenario: Create an order
+    * def v = call createOrder { id: '#(orderId)' }
+
+
+  Scenario: Create an order line
+    * def v = call createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', fundId: '#(fundId)', listUnitPrice: 10 }
+
+
+  Scenario: Open the order
+    * def v = call openOrder { orderId: '#(orderId)' }
+
+
+  Scenario: Create an invoice
+    * def v = call createInvoice { id: '#(invoiceId)', acqUnitIds: ['#(acqUnitId)'] }
+
+
+  Scenario: Add an invoice line linked to the po line
+    * print "Get the encumbrance id"
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+    * def poLine = $
+    * def encumbranceId = poLine.fundDistribution[0].encumbrance
+
+    * print "Add an invoice line linked to the po line"
+    * def v = call createInvoiceLine { invoiceLineId: '#(invoiceLineId)', invoiceId: '#(invoiceId)', poLineId: '#(poLineId)', fundId: '#(fundId)', encumbranceId: '#(encumbranceId)', total: 10 }
+
+
+  Scenario: Remove acq unit membership
+    * configure headers = headersAdmin
+    Given path 'acquisitions-units/memberships', acqUnitMembershipId
+    When method DELETE
+    Then status 204
+
+
+  Scenario: Remove the order line fund distribution
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+
+    * def poLine = $
+    * remove poLine.fundDistribution
+
+    Given path 'orders/order-lines', poLineId
+    And request poLine
+    When method PUT
+    Then status 204
+
+
+  Scenario: Re-add acq unit membership
+    * configure headers = headersAdmin
+    Given path 'acquisitions-units/memberships'
+    And request
+    """
+      {
+        "id": '#(acqUnitMembershipId)',
+        "userId": "00000000-1111-5555-9999-999999999992",
+        "acquisitionsUnitId": "#(acqUnitId)"
+      }
+    """
+    When method POST
+    Then status 201
+
+
+  Scenario: Check the encumbrance link was removed in the invoice line
+    Given path 'invoice/invoice-lines', invoiceLineId
+    When method GET
+    Then status 200
+    And match $.fundDistributions[0].encumbrance == '#notpresent'

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/reusable/create-invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/reusable/create-invoice.feature
@@ -1,5 +1,5 @@
 Feature: Create invoice
-  # parameters: id
+  # parameters: id, acqUnitIds?
 
   Background:
     * url baseUrl
@@ -7,8 +7,10 @@ Feature: Create invoice
   Scenario: createInvoice
     * def invoice = read('classpath:samples/mod-invoice/invoices/global/invoice.json')
     * def fiscalYearId = karate.get('fiscalYearId', null)
+    * def acqUnitIds = karate.get('acqUnitIds', [])
     * set invoice.id = id
     * set invoice.fiscalYearId = fiscalYearId
+    * set invoice.acqUnitIds = acqUnitIds
 
     Given path 'invoice/invoices'
     And request invoice

--- a/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
+++ b/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
@@ -189,6 +189,11 @@ public class CrossModulesApiTest extends TestBase {
     runFeatureTest("check-paymentstatus-after-reopen");
   }
 
+  @Test
+  void invoiceEncumbranceUpdateWithoutAcquisitionUnit() {
+    runFeatureTest("invoice-encumbrance-update-without-acquisition-unit");
+  }
+
   @BeforeAll
   public void crossModuleApiTestBeforeAll() {
     runFeature("classpath:thunderjet/cross-modules/cross-modules-junit.feature");


### PR DESCRIPTION
## Purpose
[MODORDERS-1073](https://folio-org.atlassian.net/browse/MODORDERS-1073) - Invoice encumbrance link not removed because of acquisition unit

## Approach
New test matching MODORDERS-1073 case.

[mod-invoice PR](https://github.com/folio-org/mod-invoice/pull/481) - [mod-orders PR](https://github.com/folio-org/mod-orders/pull/873)