### PR TITLE
[MODORDERS-1079] P/E mix update piece

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/MODORDERS-538-piece-against-non-package-mixed-pol-manual-piece-creation-is-true.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/MODORDERS-538-piece-against-non-package-mixed-pol-manual-piece-creation-is-true.feature
@@ -264,7 +264,7 @@ Feature: Should create and delete pieces for non package mixed POL with quantity
     And match orderResponse.totalEstimatedPrice == 7.0
     And match poLine.cost.quantityElectronic == 1
     And match poLine.cost.quantityPhysical == 1
-    And match poLine.locations == '#[2]'
+    And match poLine.locations == '#[1]'
 
     * print 'Check encumbrances initial value'
     Given path 'finance/transactions'
@@ -325,7 +325,7 @@ Feature: Should create and delete pieces for non package mixed POL with quantity
     And match orderResponse.totalEstimatedPrice == 7.0
     And match poLine.cost.quantityElectronic == 1
     And match poLine.cost.quantityPhysical == 1
-    And match poLine.locations == '#[2]'
+    And match poLine.locations == '#[1]'
 
     * print 'Check encumbrances initial value'
     Given path 'finance/transactions'
@@ -380,7 +380,7 @@ Feature: Should create and delete pieces for non package mixed POL with quantity
     And match orderResponse.totalEstimatedPrice == 7.0
     And match poLine.cost.quantityElectronic == 1
     And match poLine.cost.quantityPhysical == 1
-    And match poLine.locations == '#[2]'
+    And match poLine.locations == '#[1]'
 
     * print 'Check encumbrances initial value'
     Given path 'finance/transactions'

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/pe-mix-update-piece.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/pe-mix-update-piece.feature
@@ -1,0 +1,64 @@
+# For MODORDERS-1079
+Feature: P/E mix update piece
+
+  Background:
+    * print karate.info.scenarioName
+
+    * url baseUrl
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json' }
+
+    * configure headers = headersUser
+
+    * callonce variables
+
+    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
+    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
+
+
+  Scenario: Update piece for default P/E mix
+    * def fundId = call uuid
+    * def budgetId = call uuid
+    * def orderId = call uuid
+    * def poLineId = call uuid
+
+    * print "Create finances"
+    * configure headers = headersAdmin
+    * call createFund { id: '#(fundId)' }
+    * call createBudget { id: '#(budgetId)', allocated: 1000, fundId: '#(fundId)', status: 'Active' }
+    * configure headers = headersUser
+
+    * print "Create an order"
+    * def v = call createOrder { id: '#(orderId)' }
+
+    * print "Create an order line with a P/E mix"
+    * def poLine = read('classpath:samples/mod-orders/orderLines/minimal-mixed-order-line.json')
+    * set poLine.id = poLineId
+    * set poLine.purchaseOrderId = orderId
+    * set poLine.fundDistribution[0].fundId = fundId
+    Given path 'orders/order-lines'
+    And request poLine
+    When method POST
+    Then status 201
+
+    * print "Open the order"
+    * def v = call openOrder { orderId: '#(orderId)' }
+
+    * print 'Get the electronic piece'
+    Given path 'orders/pieces'
+    And param query = 'poLineId==' + poLineId + ' AND format==Electronic'
+    When method GET
+    Then status 200
+    And match $.totalRecords == 1
+    * def piece = $.pieces[0]
+
+    * print 'Update it without changing anything'
+    Given path 'orders/pieces', piece.id
+    And request piece
+    When method PUT
+    Then status 204

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
@@ -257,6 +257,8 @@ Feature: mod-orders integration tests
   Scenario: Open order success with expenditure restrictions
     Given call read("features/open-order-success-with-expenditure-restrictions.feature")
 
+  Scenario: P/E mix update piece
+    Given call read("features/pe-mix-update-piece.feature")
 
 # These 2 have to be called with OrdersApiTest - this comment is here as a reminder
 #  Scenario: Create pieces for an open order in parallel

--- a/acquisitions/src/test/java/org/folio/OrdersApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersApiTest.java
@@ -361,6 +361,11 @@ public class OrdersApiTest extends TestBase {
     runFeatureTest("open-order-success-with-expenditure-restrictions");
   }
 
+  @Test
+  void peMixUpdatePiece() {
+    runFeatureTest("pe-mix-update-piece");
+  }
+
   @BeforeAll
   public void ordersApiTestBeforeAll() {
     runFeature("classpath:thunderjet/mod-orders/orders-junit.feature");


### PR DESCRIPTION
## Purpose
[MODORDERS-1079](https://folio-org.atlassian.net/browse/MODORDERS-1079) - Could not edit holdings for piece created from P/E mix Po Line

## Approach
- New test matching the ticket case
- Fixed another test to match the new logic

[mod-orders PR](https://github.com/folio-org/mod-orders/pull/882)