### PR TITLE
[FAT-12625] - Adding Gatling to mod-audit module.

### DIFF
--- a/mod-audit/pom.xml
+++ b/mod-audit/pom.xml
@@ -23,4 +23,16 @@
             <version>1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.gatling</groupId>
+                <artifactId>gatling-maven-plugin</artifactId>
+                <configuration>
+                    <simulationsFolder>src/test/java</simulationsFolder>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/mod-audit/src/main/resources/karate-config.js
+++ b/mod-audit/src/main/resources/karate-config.js
@@ -6,14 +6,14 @@ function fn() {
   var env = karate.env;
 
   // The "testTenant" property could be specified during test runs
-  var testTenant = karate.properties['testTenant'];
+  var testTenant = karate.properties['testTenant'] || 'testtenant';
 
   var config = {
     baseUrl: 'http://localhost:9130',
     admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
     prototypeTenant: 'diku',
 
-    testTenant: testTenant ? testTenant : 'testtenant',
+    testTenant: testTenant,
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},
     testUser: {tenant: testTenant, name: 'test-user', password: 'test'},
 

--- a/mod-audit/src/test/java/org/folio/AuditSimulation.scala
+++ b/mod-audit/src/test/java/org/folio/AuditSimulation.scala
@@ -30,7 +30,7 @@ class AuditSimulation extends Simulation {
     .exec(karateFeature("classpath:firebird/mod-audit/mod-audit-junit.feature"))
   val create = scenario("create")
     .repeat(10) {
-      exec(karateFeature("classpath:thunderjet/mod-orders/features/checkInCheckOutEvent.feature"))
+      exec(karateFeature("classpath:firebird/mod-audit/features/checkInCheckOutEvent.feature"))
     }
   val after = scenario("after").exec(karateFeature("classpath:common/destroy-data.feature"))
 

--- a/mod-audit/src/test/java/org/folio/AuditSimulation.scala
+++ b/mod-audit/src/test/java/org/folio/AuditSimulation.scala
@@ -1,0 +1,43 @@
+package org.folio
+
+import com.intuit.karate.gatling.PreDef._
+import io.gatling.core.Predef._
+import org.apache.commons.lang3.RandomUtils
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+class AuditSimulation extends Simulation {
+
+  def generateTenantId(): String = {
+    val constantString = "testtenant"
+    val randomLong = RandomUtils.nextLong
+    constantString + randomLong
+  }
+
+  val protocol = karateProtocol(
+    "/_/proxy/tenants/{tenant}" -> Nil,
+    "/_/proxy/tenants/{tenant}/modules" -> Nil,
+    "/_/proxy/tenants/{tenant}/install" -> Nil,
+    "/circulation/loans/{loanId}" -> Nil,
+    "/audit-data/circulation/logs" -> Nil,
+    "/circulation/check-out-by-barcode" -> Nil,
+    "/circulation/check-in-by-barcode" -> Nil,
+  )
+  protocol.runner.systemProperty("testTenant", generateTenantId())
+
+  val before = scenario("before")
+    .exec(karateFeature("classpath:firebird/mod-audit/mod-audit-junit.feature"))
+  val create = scenario("create")
+    .repeat(10) {
+      exec(karateFeature("classpath:thunderjet/mod-orders/features/checkInCheckOutEvent.feature"))
+    }
+  val after = scenario("after").exec(karateFeature("classpath:common/destroy-data.feature"))
+
+  setUp(
+    before.inject(atOnceUsers(1))
+      .andThen(create.inject(nothingFor(3 seconds), rampUsers(3) during (5 seconds)))
+      .andThen(after.inject(nothingFor(3 seconds), atOnceUsers(1))),
+  ).protocols(protocol)
+
+}


### PR DESCRIPTION
## Purpose
_Describe the purpose of the pull request._
Adding Gatling plugin for mod-audit module. Simulated scenarios for check-in/check-out by barcode API and monitor the API's around it.
## Approach
_How does this change fulfill the purpose?_
Taken reference to Olamide's PR - https://github.com/folio-org/folio-integration-tests/pull/1300/files
### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.
Need to do full successful run for this new code change locally but its not passing. I have created a draft PR
### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._

Gatling report screen shots -- 
![image](https://github.com/folio-org/folio-integration-tests/assets/34331959/2b9615d9-eee1-4e27-bfc9-f1ed8eacf5bc)
![image](https://github.com/folio-org/folio-integration-tests/assets/34331959/c5ae809e-2137-496d-b93f-177d852bd05c)

