### PR TITLE
MODFQMMGR-223 Add gatling to the mod-fqm-manager tests

### DIFF
--- a/mod-fqm-manager/pom.xml
+++ b/mod-fqm-manager/pom.xml
@@ -11,20 +11,31 @@
     </parent>
 
     <artifactId>mod-fqm-manager</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>${parent.version}</version>
     <packaging>jar</packaging>
 
     <dependencies>
         <dependency>
             <groupId>org.folio</groupId>
             <artifactId>common</artifactId>
-            <version>1.0-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>org.folio</groupId>
             <artifactId>testrail-integration</artifactId>
-            <version>1.0-SNAPSHOT</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>io.gatling</groupId>
+                <artifactId>gatling-maven-plugin</artifactId>
+                <configuration>
+                    <simulationsFolder>src/test/java</simulationsFolder>
+                    <skip>false</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
 
 </project>

--- a/mod-fqm-manager/src/main/resources/corsair/mod-fqm-manager/features/query.feature
+++ b/mod-fqm-manager/src/main/resources/corsair/mod-fqm-manager/features/query.feature
@@ -13,6 +13,7 @@ Feature: Query
     * def orgContactEntityTypeId = '7a7860cd-e939-504f-b51f-ed3e1e6b12b9'
 
   Scenario: Post query
+    * print '## Create query'
     Given path 'query'
     And request { entityTypeId: '#(itemEntityTypeId)', fqlQuery: '{\"item_status\": {\"$in\": [\"missing\", \"lost\"]}}' }
     When method POST
@@ -37,11 +38,13 @@ Feature: Query
     And match $.parameters[0].value == "Field invalid_field is not present in definition of entity type drv_item_details"
 
   Scenario: Get query results with query id
+    * print '## Create query'
     Given path 'query'
     And request { entityTypeId: '#(itemEntityTypeId)', fqlQuery: '{\"item_status\": {\"$in\": [\"missing\", \"lost\"]}}' }
     When method POST
     Then status 201
     * def queryId = $.queryId
+    * print '## Get query results'
     Given path 'query/' + queryId
     When method GET
     Then status 200
@@ -63,14 +66,17 @@ Feature: Query
     Then status 404
 
   Scenario: Cancel query
+    * print '## Create query'
     Given path 'query'
     And request { entityTypeId: '#(userEntityTypeId)' , fqlQuery: '{\"username\": {\"$regex\":\"integration_test_user_123\"}}' }
     When method POST
     Then status 201
     * def queryId = $.queryId
+    * print '## Cancel query'
     Given path 'query/' + queryId
     When method DELETE
     Then status 204
+    * print '## Verify the query was cancelled'
     Given path 'query/' + queryId
     When method GET
     Then assert (responseStatus == 200 && response.status == "CANCELLED") || responseStatus == 404

--- a/mod-fqm-manager/src/main/resources/karate-config.js
+++ b/mod-fqm-manager/src/main/resources/karate-config.js
@@ -9,14 +9,14 @@ function fn() {
   var env = karate.env;
 
   // The "testTenant" property could be specified during test runs
-  var testTenant = karate.properties['testTenant'];
+  var testTenant = karate.properties['testTenant'] || 'testtenant';
 
   var config = {
     baseUrl: 'http://localhost:9130',
     admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
     prototypeTenant: 'diku',
 
-    testTenant: testTenant ? testTenant : 'testtenant',
+    testTenant: testTenant,
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},
     testUser: {tenant: testTenant, name: 'test-user', password: 'test'},
 

--- a/mod-fqm-manager/src/test/java/org/folio/QuerySimulation.scala
+++ b/mod-fqm-manager/src/test/java/org/folio/QuerySimulation.scala
@@ -1,0 +1,43 @@
+package org.folio
+
+import com.intuit.karate.gatling.PreDef._
+import io.gatling.core.Predef._
+import org.apache.commons.lang3.RandomUtils
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+class QuerySimulation extends Simulation {
+
+  def generateTenantId(): String = {
+    val constantString = "testtenant"
+    val randomLong = RandomUtils.nextLong
+    constantString + randomLong
+  }
+
+  val protocol = karateProtocol(
+    "/_/proxy/tenants/{tenant}" -> Nil,
+    "/_/proxy/tenants/{tenant}/modules" -> Nil,
+    "/_/proxy/tenants/{tenant}/install" -> Nil,
+    "/query" -> Nil,
+    "/query/{queryId}" -> Nil,
+    "/query/purge" -> Nil,
+    "users/00000000-1111-2222-9999-44444444444" -> Nil,
+  )
+  protocol.runner.systemProperty("testTenant", generateTenantId())
+
+  val before = scenario("before")
+    .exec(karateFeature("classpath:corsair/mod-fqm-manager/fqm-junit.feature"))
+  val create = scenario("create")
+    .repeat(10) {
+      exec(karateFeature("classpath:corsair/mod-fqm-manager/features/query.feature"))
+    }
+  val after = scenario("after").exec(karateFeature("classpath:common/destroy-data.feature"))
+
+  setUp(
+    before.inject(atOnceUsers(1))
+      .andThen(create.inject(nothingFor(3 seconds), rampUsers(3) during (5 seconds)))
+      .andThen(after.inject(nothingFor(3 seconds), atOnceUsers(1))),
+  ).protocols(protocol)
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -150,6 +150,18 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
+
+      <!-- Pin the shared submodules to the project version, so that other submodules don't need to worry about the version -->
+      <dependency>
+        <groupId>org.folio</groupId>
+        <artifactId>common</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.folio</groupId>
+        <artifactId>testrail-integration</artifactId>
+        <version>${project.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
This PR adds karate-gatling to mod-fqm-manager, based on the work done for the acquisitions module. It sets the shared submodule dependency versions in the parent POM's `dependencyManagemenet` section, so that consuming modules don't need to set a version in their `dependencies`; the version is set to `${project.version}`, so that we're always using the version that matches the root project's POM.