### PR TITLE
MODORDSTOR-395. Metadata for Create Title is not populated

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/poline-claiming-interval-checks.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/poline-claiming-interval-checks.feature
@@ -53,6 +53,7 @@ Feature: Claiming Active/Claiming interval checks
 
   Scenario: Validate claim in title
     * print "Validate claim in title"
+    * print "Validate that metadata is populated"
 
     Given path 'orders/titles'
     And param query = 'poLineId==' + poLineId
@@ -63,6 +64,8 @@ Feature: Claiming Active/Claiming interval checks
     * def titleId = title.id
     And match title.claimingActive == true
     And match title.claimingInterval == 1
+    And match title.metadata.createdDate != null
+    And match title.metadata.createdByUserId != null
 
   Scenario: Update claim for poLine
     * print "Update claim for poLine"


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/MODORDSTOR-395
![Screenshot_24](https://github.com/folio-org/folio-integration-tests/assets/25097693/6ccaddfb-c804-4500-bfc0-1b6c6e4bb310)
