### PR TITLE
[MODFIN-352] Fixed tests to remove old transaction API

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/delete-encumbrance.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/delete-encumbrance.feature
@@ -79,9 +79,15 @@ Feature: Test deleting an encumbrance
     Then status 204
 
     # delete the encumbrance
-    Given path 'finance/encumbrances', transaction.id
+    Given path 'finance/transactions/batch-all-or-nothing'
     And headers headersUser
-    When method DELETE
+    And request
+    """
+    {
+      "idsOfTransactionsToDelete": [ "#(transaction.id)" ]
+    }
+    """
+    When method POST
     Then status 204
 
     # check the transaction is gone
@@ -207,8 +213,13 @@ Feature: Test deleting an encumbrance
     Then status 204
 
     # try to delete the encumbrance
-    Given path 'finance/encumbrances', encumbranceId
+    Given path 'finance/transactions/batch-all-or-nothing'
     And headers headersUser
-    When method DELETE
+    And request
+    """
+    {
+      "idsOfTransactionsToDelete": [ "#(encumbranceId)" ]
+    }
+    """
+    When method POST
     Then status 422
-

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-can-be-deleted-if-have-only-allocation-transactions-From-or-To.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-can-be-deleted-if-have-only-allocation-transactions-From-or-To.feature
@@ -45,10 +45,11 @@ Feature: Budget can be deleted if have only allocation transactions From or To
   Scenario Outline: Create allocation <allocationId> for <fundId>
     * def fundId = <fundId>
     * def allocationId = <allocationId>
-    Given path 'finance/allocations'
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
     {
+      "transactionsToCreate": [{
         "id": "#(allocationId)",
         "amount": 25,
         "currency": "USD",
@@ -57,10 +58,11 @@ Feature: Budget can be deleted if have only allocation transactions From or To
         "source": "User",
         "toFundId": "#(fundId)",
         "transactionType": "Allocation"
+      }]
     }
     """
     When method POST
-    Then status 201
+    Then status 204
     Examples:
       | fundId                      | allocationId     |
       | fundIdWithFromAllocation    | fromAllocationId |

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-can-not-be-deleted-if-have-other-than-allocation-transactions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-can-not-be-deleted-if-have-other-than-allocation-transactions.feature
@@ -45,10 +45,11 @@ Feature: Budget can not be deleted if have other than allocation transactions
   Scenario Outline: Create allocation <allocationId> for <fundId>
     * def fundId = <fundId>
     * def allocationId = <allocationId>
-    Given path 'finance/allocations'
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
     {
+      "transactionsToCreate": [{
         "id": "#(allocationId)",
         "amount": 25,
         "currency": "USD",
@@ -57,32 +58,36 @@ Feature: Budget can not be deleted if have other than allocation transactions
         "source": "User",
         "toFundId": "#(fundId)",
         "transactionType": "Allocation"
+      }]
     }
     """
     When method POST
-    Then status 201
+    Then status 204
     Examples:
       | fundId                      | allocationId     |
       | fundIdWithFromAllocation    | fromAllocationId |
       | fundIdWithToAllocation      | toAllocationId   |
 
   Scenario: Transfer money from first budget to second
-    Given path 'finance-storage/transactions'
-    * configure headers = headersAdmin
+    * def transferId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
     {
-      "amount": "25",
-      "currency": "USD",
-      "fromFundId": "#(fundIdWithFromAllocation)",
-      "toFundId": "#(fundIdWithToAllocation)",
-      "fiscalYearId": "#(globalFiscalYearId)",
-      "transactionType": "Transfer",
-      "source": "User"
+      "transactionsToCreate": [{
+        "id": "#(transferId)",
+        "amount": "25",
+        "currency": "USD",
+        "fromFundId": "#(fundIdWithFromAllocation)",
+        "toFundId": "#(fundIdWithToAllocation)",
+        "fiscalYearId": "#(globalFiscalYearId)",
+        "transactionType": "Transfer",
+        "source": "User"
+      }]
     }
     """
     When method POST
-    Then status 201
+    Then status 204
 
   Scenario Outline: Verify that budget <budgetId> only with allocation transaction can be deleted and money were not spent
     * def budgetId = <budgetId>

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-can-not-be-deleted-if-have-to-and-from-fund-in-allocation-transactions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-can-not-be-deleted-if-have-to-and-from-fund-in-allocation-transactions.feature
@@ -46,10 +46,11 @@ Feature: Budget can not be deleted if have to and from fund in allocation transa
     * def toFundId = <toFundId>
     * def fromFundId = <fromFundId>
     * def allocationId = <allocationId>
-    Given path 'finance/allocations'
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
     {
+      "transactionsToCreate": [{
         "id": "#(allocationId)",
         "amount": 25,
         "currency": "USD",
@@ -59,10 +60,11 @@ Feature: Budget can not be deleted if have to and from fund in allocation transa
         "fromFundId": "#(fromFundId)",
         "toFundId": "#(toFundId)",
         "transactionType": "Allocation"
+      }]
     }
     """
     When method POST
-    Then status 201
+    Then status 204
     Examples:
       | toFundId                 | fromFundId             | allocationId     |
       | fundIdWithFromAllocation |fundIdWithToAllocation  | fromAllocationId |

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-transfer-transactions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-transfer-transactions.feature
@@ -90,39 +90,46 @@ Feature: Make transfer transaction and verify budget updates
       | ledgerIdSecond | 200       | 200       | 0            | 0           |
 
   Scenario: Transfer money from first budget to second with negative number which is allowed
-    Given path 'finance/transfers'
+    * def transferId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
     {
-      "amount": "1001",
-      "currency": "USD",
-      "fromFundId": "#(fundIdFirst)",
-      "toFundId": "#(fundIdSecond)",
-      "fiscalYearId": "#(globalFiscalYearId)",
-      "transactionType": "Transfer",
-      "source": "User"
+      "transactionsToCreate": [{
+        "id": "#(transferId)",
+        "amount": "1001",
+        "currency": "USD",
+        "fromFundId": "#(fundIdFirst)",
+        "toFundId": "#(fundIdSecond)",
+        "fiscalYearId": "#(globalFiscalYearId)",
+        "transactionType": "Transfer",
+        "source": "User"
+      }]
     }
     """
     When method POST
-    Then status 201
-    And match $.amount == 1001
+    Then status 204
 
   Scenario: Transfer money from first budget to second
-    Given path 'finance-storage/transactions'
+    * def transferId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
     {
-      "amount": "25",
-      "currency": "USD",
-      "fromFundId": "#(fundIdFirst)",
-      "toFundId": "#(fundIdSecond)",
-      "fiscalYearId": "#(globalFiscalYearId)",
-      "transactionType": "Transfer",
-      "source": "User"
+      "transactionsToCreate": [{
+        "id": "#(transferId)",
+        "amount": "25",
+        "currency": "USD",
+        "fromFundId": "#(fundIdFirst)",
+        "toFundId": "#(fundIdSecond)",
+        "fiscalYearId": "#(globalFiscalYearId)",
+        "transactionType": "Transfer",
+        "source": "User"
+      }]
     }
     """
     When method POST
-    Then status 201
+    Then status 204
 
   Scenario Outline: check budget after first transaction
     * def fundId = <fundId>
@@ -165,21 +172,25 @@ Feature: Make transfer transaction and verify budget updates
       | ledgerIdSecond | 200       | 200       | 0            | 0           |
 
   Scenario: Transfer money from first budget to third
-    Given path 'finance-storage/transactions'
+    * def transferId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
     {
-      "amount": "25",
-      "currency": "USD",
-      "fromFundId": "#(fundIdFirst)",
-      "toFundId": "#(fundIdThird)",
-      "fiscalYearId": "#(globalFiscalYearId)",
-      "transactionType": "Transfer",
-      "source": "User"
+      "transactionsToCreate": [{
+        "id": "#(transferId)",
+        "amount": "25",
+        "currency": "USD",
+        "fromFundId": "#(fundIdFirst)",
+        "toFundId": "#(fundIdThird)",
+        "fiscalYearId": "#(globalFiscalYearId)",
+        "transactionType": "Transfer",
+        "source": "User"
+      }]
     }
     """
     When method POST
-    Then status 201
+    Then status 204
 
   Scenario Outline: check budget after second transaction
     * def fundId = <fundId>

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-transfer-transactions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-transfer-transactions.feature
@@ -29,7 +29,7 @@ Feature: Make transfer transaction and verify budget updates
 
   Scenario Outline: Setup ledger
     * def ledgerId = <ledgerId>
-    * call createLedger { 'id': '#(ledgerId)'}
+    * call createLedger { 'id': '#(ledgerId)', restrictExpenditures: false, restrictEncumbrance: false }
 
     Examples:
       | ledgerId       |

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/group-and-ledger-transfers-after-rollover.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/group-and-ledger-transfers-after-rollover.feature
@@ -99,39 +99,47 @@ Feature: Group and ledger transfers after rollover
 
 
   Scenario: Transfer from fund 1 (ledger 1) to fund 2 (ledger 1) in FY 1
-    Given path 'finance/transfers'
+    * def transferId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
     {
-      "amount": 10,
-      "currency": "USD",
-      "fromFundId": "#(fundId1)",
-      "toFundId": "#(fundId2)",
-      "fiscalYearId": "#(fyId1)",
-      "transactionType": "Transfer",
-      "source": "User"
+      "transactionsToCreate": [{
+        "id": "#(transferId)",
+        "amount": 10,
+        "currency": "USD",
+        "fromFundId": "#(fundId1)",
+        "toFundId": "#(fundId2)",
+        "fiscalYearId": "#(fyId1)",
+        "transactionType": "Transfer",
+        "source": "User"
+      }]
     }
     """
     When method POST
-    Then status 201
+    Then status 204
 
 
   Scenario: Transfer from fund 3 (ledger 2) to fund 1 (ledger 1) in FY 1
-    Given path 'finance/transfers'
+    * def transferId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
     {
-      "amount": 5,
-      "currency": "USD",
-      "fromFundId": "#(fundId3)",
-      "toFundId": "#(fundId1)",
-      "fiscalYearId": "#(fyId1)",
-      "transactionType": "Transfer",
-      "source": "User"
+      "transactionsToCreate": [{
+        "id": "#(transferId)",
+        "amount": 5,
+        "currency": "USD",
+        "fromFundId": "#(fundId3)",
+        "toFundId": "#(fundId1)",
+        "fiscalYearId": "#(fyId1)",
+        "transactionType": "Transfer",
+        "source": "User"
+      }]
     }
     """
     When method POST
-    Then status 201
+    Then status 204
 
 
   Scenario: Check group summary net transfers after transfer

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/group-fiscal-year-totals.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/group-fiscal-year-totals.feature
@@ -93,10 +93,13 @@ Feature: Group fiscal year totals
     When method POST
     Then status 201
 
-    Given path 'finance-storage/transactions'
+    * def allocationId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
     {
+      "transactionsToCreate": [{
+        "id": "#(allocationId)",
         "amount": <initialAllocation>,
         "currency": "USD",
         "description": "To allocation",
@@ -104,11 +107,11 @@ Feature: Group fiscal year totals
         "source": "User",
         "toFundId": "#(fundId)",
         "transactionType": "Allocation"
+      }]
     }
     """
     When method POST
-    Then status 201
-
+    Then status 204
 
     Examples:
       | fundId  | budgetId  | groupId | initialAllocation | encumbered | awaitingPayment | expenditures |
@@ -150,10 +153,13 @@ Feature: Group fiscal year totals
   Scenario Outline: Create allocation from <fromFundId> to <toFundId>
     * def toFundId = <toFundId>
     * def fromFundId = <fromFundId>
-    Given path 'finance/allocations'
+    * def allocationId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
     {
+      "transactionsToCreate": [{
+        "id": "#(allocationId)",
         "amount": <amount>,
         "currency": "USD",
         "description": "To allocation",
@@ -162,10 +168,11 @@ Feature: Group fiscal year totals
         "fromFundId" : "#(fromFundId)",
         "toFundId": "#(toFundId)",
         "transactionType": "Allocation"
+      }]
     }
     """
     When method POST
-    Then status 201
+    Then status 204
     Examples:
       |fromFundId| toFundId | amount|
       |fundId1   | fundId2  | 420   |
@@ -176,21 +183,25 @@ Feature: Group fiscal year totals
   Scenario Outline: Transfer money from <fromFundId> to <toFundId>
     * def toFundId = <toFundId>
     * def fromFundId = <fromFundId>
-    Given path 'finance/transfers'
+    * def transferId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
     {
-      "amount": <amount>,
-      "currency": "USD",
-      "fromFundId": "#(fromFundId)",
-      "toFundId": "#(toFundId)",
-      "fiscalYearId": "#(globalFiscalYearId)",
-      "transactionType": "Transfer",
-      "source": "User"
+      "transactionsToCreate": [{
+        "id": "#(transferId)",
+        "amount": <amount>,
+        "currency": "USD",
+        "fromFundId": "#(fromFundId)",
+        "toFundId": "#(toFundId)",
+        "fiscalYearId": "#(globalFiscalYearId)",
+        "transactionType": "Transfer",
+        "source": "User"
+      }]
     }
     """
     When method POST
-    Then status 201
+    Then status 204
     Examples:
       |fromFundId| toFundId | amount|
       |fundId1   | fundId2  | 15    |
@@ -201,20 +212,24 @@ Feature: Group fiscal year totals
 
   Scenario Outline: Allocate only with <fromFundId>
     * def fromFundId = <fromFundId>
-    Given path 'finance/allocations'
+    * def allocationId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
     {
-      "amount": <amount>,
-      "currency": "USD",
-      "fromFundId": "#(fromFundId)",
-      "fiscalYearId": "#(globalFiscalYearId)",
-      "transactionType": "Allocation",
-      "source": "User"
+      "transactionsToCreate": [{
+        "id": "#(allocationId)",
+        "amount": <amount>,
+        "currency": "USD",
+        "fromFundId": "#(fromFundId)",
+        "fiscalYearId": "#(globalFiscalYearId)",
+        "transactionType": "Allocation",
+        "source": "User"
+      }]
     }
     """
     When method POST
-    Then status 201
+    Then status 204
     Examples:
       |fromFundId| amount|
       |fundId1   | 25    |

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-preview-rollover.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-preview-rollover.feature
@@ -326,10 +326,13 @@ Feature: Ledger fiscal year rollover
       | lawBudget2         | law2          | fromFiscalYearId | 80        | 170                  | 160                  | [#(globalElecExpenseClassId)]                             | ['#(groupId1)', #(groupId2)] |
 
   Scenario: Create transfer to SCIENCE2020 budget
-    Given path 'finance/transfers'
+    * def transferId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
-      {
+    {
+      "transactionsToCreate": [{
+        "id": "#(transferId)",
         "amount": 50,
         "currency": "USD",
         "description": "Rollover test transfer",
@@ -338,10 +341,11 @@ Feature: Ledger fiscal year rollover
         "fromFundId": "#(latin)",
         "toFundId": "#(science)",
         "transactionType": "Transfer"
-      }
+      }]
+    }
     """
     When method POST
-    Then status 201
+    Then status 204
 
   Scenario Outline: Create open orders with 1 fund distribution
     * configure headers = headersAdmin

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover-pol-and-system-currencies-are-different.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover-pol-and-system-currencies-are-different.feature
@@ -311,10 +311,13 @@ Feature: Ledger fiscal year rollover pol and system currencies are different
       | libBud3          | libFund3     | fromFiscalYearId | 1000      | 100                  | 100                  | [#(globalElecExpenseClassId)]                             | ['#(groupId2)']              |
 
   Scenario: Create transfer to SCIENCE2020 budget
-    Given path 'finance/transfers'
+    * def transferId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
-      {
+    {
+      "transactionsToCreate": [{
+        "id": "#(transferId)",
         "amount": 50,
         "currency": "USD",
         "description": "Rollover test transfer",
@@ -323,10 +326,11 @@ Feature: Ledger fiscal year rollover pol and system currencies are different
         "fromFundId": "#(latin)",
         "toFundId": "#(science)",
         "transactionType": "Transfer"
-      }
+      }]
+    }
     """
     When method POST
-    Then status 201
+    Then status 204
 
   Scenario Outline: Create open orders with 1 fund distribution
     * configure headers = headersAdmin

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-rollover.feature
@@ -322,10 +322,13 @@ Feature: Ledger fiscal year rollover
       | classicalBud2    | classicalFund2 | toFiscalYearId   | 1000      | 100                  | 100                  | [#(globalElecExpenseClassId)]                             | ['#(groupId2)']              | 'Planned'    |
 
   Scenario: Create transfer to SCIENCE2020 budget
-    Given path 'finance/transfers'
+    * def transferId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
-      {
+    {
+      "transactionsToCreate": [{
+        "id": "#(transferId)",
         "amount": 50,
         "currency": "USD",
         "description": "Rollover test transfer",
@@ -334,10 +337,11 @@ Feature: Ledger fiscal year rollover
         "fromFundId": "#(latin)",
         "toFundId": "#(science)",
         "transactionType": "Transfer"
-      }
+      }]
+    }
     """
     When method POST
-    Then status 201
+    Then status 204
 
   Scenario Outline: Create open orders with 1 fund distribution
     * configure headers = headersAdmin

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-sequential-rollovers.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-fiscal-year-sequential-rollovers.feature
@@ -343,10 +343,13 @@ Feature: Ledger fiscal year sequential rollovers
       | classicalBud2    | classicalFund2 | fiscalYearId2 | 1000      | 100                  | 100                  | [#(globalElecExpenseClassId)]                             | ['#(groupId2)']              | 'Planned'    |
 
   Scenario: Create transfer to SCIENCE2020 budget
-    Given path 'finance/transfers'
+    * def transferId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
-      {
+    {
+      "transactionsToCreate": [{
+        "id": "#(transferId)",
         "amount": 50,
         "currency": "USD",
         "description": "Rollover test transfer",
@@ -355,10 +358,11 @@ Feature: Ledger fiscal year sequential rollovers
         "fromFundId": "#(latin)",
         "toFundId": "#(science)",
         "transactionType": "Transfer"
-      }
+      }]
+    }
     """
     When method POST
-    Then status 201
+    Then status 204
 
   Scenario Outline: Create open orders with 1 fund distribution
     * configure headers = headersAdmin

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-totals.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-totals.feature
@@ -83,10 +83,13 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
     When method POST
     Then status 201
 
-    Given path 'finance-storage/transactions'
+    * def allocationId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
     {
+      "transactionsToCreate": [{
+        "id": "#(allocationId)",
         "amount": <initialAllocation>,
         "currency": "USD",
         "description": "To allocation",
@@ -94,10 +97,11 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
         "source": "User",
         "toFundId": "#(fundId)",
         "transactionType": "Allocation"
+      }]
     }
     """
     When method POST
-    Then status 201
+    Then status 204
 
     Examples:
       | fundId  | budgetId  | ledgerId           | initialAllocation | encumbered | awaitingPayment | expenditures |
@@ -160,10 +164,13 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
   Scenario Outline: Create allocation from <fromFundId> to <toFundId>
     * def toFundId = <toFundId>
     * def fromFundId = <fromFundId>
-    Given path 'finance/allocations'
+    * def allocationId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
     {
+      "transactionsToCreate": [{
+        "id": "#(allocationId)",
         "amount": <amount>,
         "currency": "USD",
         "description": "To allocation",
@@ -172,10 +179,11 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
         "fromFundId" : "#(fromFundId)",
         "toFundId": "#(toFundId)",
         "transactionType": "Allocation"
+      }]
     }
     """
     When method POST
-    Then status 201
+    Then status 204
     Examples:
       |fromFundId| toFundId | amount|
       |fundId1   | fundId2  | 420   |
@@ -186,21 +194,25 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
   Scenario Outline: Transfer money from <fromFundId> to <toFundId>
     * def toFundId = <toFundId>
     * def fromFundId = <fromFundId>
-    Given path 'finance/transfers'
+    * def transferId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
     {
-      "amount": <amount>,
-      "currency": "USD",
-      "fromFundId": "#(fromFundId)",
-      "toFundId": "#(toFundId)",
-      "fiscalYearId": "#(globalFiscalYearId)",
-      "transactionType": "Transfer",
-      "source": "User"
+      "transactionsToCreate": [{
+        "id": "#(transferId)",
+        "amount": <amount>,
+        "currency": "USD",
+        "fromFundId": "#(fromFundId)",
+        "toFundId": "#(toFundId)",
+        "fiscalYearId": "#(globalFiscalYearId)",
+        "transactionType": "Transfer",
+        "source": "User"
+      }]
     }
     """
     When method POST
-    Then status 201
+    Then status 204
     Examples:
       |fromFundId| toFundId | amount|
       |fundId1   | fundId2  | 15    |
@@ -211,20 +223,24 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
 
   Scenario Outline: Allocate only with <fromFundId>
     * def fromFundId = <fromFundId>
-    Given path 'finance/allocations'
+    * def allocationId = call uuid
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
     {
-      "amount": <amount>,
-      "currency": "USD",
-      "fromFundId": "#(fromFundId)",
-      "fiscalYearId": "#(globalFiscalYearId)",
-      "transactionType": "Allocation",
-      "source": "User"
+      "transactionsToCreate": [{
+        "id": "#(allocationId)",
+        "amount": <amount>,
+        "currency": "USD",
+        "fromFundId": "#(fromFundId)",
+        "fiscalYearId": "#(globalFiscalYearId)",
+        "transactionType": "Allocation",
+        "source": "User"
+      }]
     }
     """
     When method POST
-    Then status 201
+    Then status 204
     Examples:
       |fromFundId| amount|
       |fundId1   | 25    |

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/reopen-order-creates-encumbrances.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/reopen-order-creates-encumbrances.feature
@@ -78,8 +78,14 @@ Feature: Reopen an order creates encumbrances
     When method PUT
     Then status 204
 
-    Given path 'finance/encumbrances', encumbranceId
-    When method DELETE
+    Given path 'finance/transactions/batch-all-or-nothing'
+    And request
+    """
+    {
+      "idsOfTransactionsToDelete": [ "#(encumbranceId)" ]
+    }
+    """
+    When method POST
     Then status 204
 
 


### PR DESCRIPTION
## Purpose
[MODFIN-352](https://folio-org.atlassian.net/browse/MODFIN-352) - Remove the old transaction API

## Approach
Fixed the tests to remove the old transaction API in mod-finance.

[Related mod-finance PR](https://github.com/folio-org/mod-finance/pull/245)
[Related mod-finance-storage PR](https://github.com/folio-org/mod-finance-storage/pull/407)
