### PR TITLE
MODORDERS-1046. Retrieve holdings from member tenants for Restrict by Locations feature

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createRestrictedFund.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createRestrictedFund.feature
@@ -21,9 +21,9 @@ Feature: fund
       "fundStatus": "#(fundStatus)",
       "ledgerId": "#(ledgerId)",
       "restrictByLocations": true,
-      "locations": [
+      "locations": [{
         "locationId": "#(globalLocationsId)"
-      ],
+      }],
       "name": ""
     }
     """

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-restricted-locations.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-restricted-locations.feature
@@ -110,4 +110,4 @@ Feature: Open ongoing order
     Then status 422
     And match $.errors[0].code == 'fundLocationRestrictionViolation'
     And match $.errors[0].parameters[2].key == 'restrictedLocations'
-    And match $.errors[0].parameters[2].value == '[' + globalLocationsId + ']'
+    And match $.errors[0].parameters[2].value contains globalLocationsId


### PR DESCRIPTION
## Purpose
Fix existing test for story https://folio-org.atlassian.net/browse/MODORDERS-1046

- Fix json syntax
- Fix assertion match failed: EQUALS
  $ | not equal (STRING:STRING)
  '[testtenant7901948301395903209.b32c5ce2-6738-42db-a291-2796b1c3c4c6]'
  '[b32c5ce2-6738-42db-a291-2796b1c3c4c6]'

![image](https://github.com/folio-org/folio-integration-tests/assets/25097693/4a3c5c2f-dca7-4fd2-bddb-3dc424bdf97b)
