### PR TITLE
MODORDERS-1094: Fix wrong id of 'Invalid ISBN'

### DIFF
--- a/acquisitions/src/main/resources/global/inventory.feature
+++ b/acquisitions/src/main/resources/global/inventory.feature
@@ -35,8 +35,8 @@ Feature: global inventory
     And request
     """
     {
-      "id": "e6633d72-a51a-45bb-9385-9a257848e686",
-      "name": "Invalid ISBN"
+      "id": "fcca2643-406a-482a-b760-7a7f8aec640e",
+      "name": "Formal falsche ISBN"
     }
     """
     When method POST

--- a/acquisitions/src/main/resources/global/variables.feature
+++ b/acquisitions/src/main/resources/global/variables.feature
@@ -23,7 +23,7 @@ Feature: Global variables
   Scenario: inventory variables
     * def globalIdentifierTypeId = '6d6f642d-0010-1111-aaaa-6f7264657273'
     * def globalISBNIdentifierTypeId = '8261054f-be78-422d-bd51-4ed9f33c3422'
-    * def globalInvalidISBNIdentifierTypeId = 'e6633d72-a51a-45bb-9385-9a257848e686'
+    * def globalInvalidISBNIdentifierTypeId = 'fcca2643-406a-482a-b760-7a7f8aec640e'
     * def globalInstanceTypeId = '6d6f642d-0000-1111-aaaa-6f7264657273'
     * def globalSecondInstanceTypeId = '30fffe0e-e985-4144-b2e2-1e8179bdb41f'
     * def globalInstanceStatusId = 'daf2681c-25af-4202-a3fa-e58fdf806183'


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODORDERS-1094

## Purpose
mod-orders must reference product types = inventory identifier types ("ISBN", "Invalid ISBN") by id, not by name, because libraries my translate the name.

As mod-orders no longer uses the name but the id the integration test needs to use the official id.

## Approach
Replace wrong id by correct id:
https://github.com/folio-org/mod-inventory-storage/blob/v27.1.0/reference-data/identifier-types/InvalidIsbn.json

## TODOS and Open Questions
- [x] Merge at the same time as https://github.com/folio-org/mod-orders/pull/917

## Additional information
The ISBN id is already correct ("8261054f-be78-422d-bd51-4ed9f33c3422"):
https://github.com/folio-org/mod-inventory-storage/blob/v27.1.0/reference-data/identifier-types/isbn.json
https://github.com/folio-org/folio-integration-tests/blob/4477f65e60c8a56a3e3972de0eb6ec810b9dea0d/acquisitions/src/main/resources/global/inventory.feature#L26
https://github.com/folio-org/folio-integration-tests/blob/4477f65e60c8a56a3e3972de0eb6ec810b9dea0d/acquisitions/src/main/resources/global/variables.feature#L25
