### PR TITLE
[MODORDERS-1081] Add required permission

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders-junit.feature
@@ -48,7 +48,8 @@ Feature: mod-orders integration tests
       | 'orders.item.unopen'              |
       | 'invoice.all'                     |
       | 'audit.all'                       |
-      | 'orders-storage.claiming.process' |
+      | 'orders-storage.claiming.process'      |
+      | 'inventory-storage.instances.item.get' |
 
   Scenario: create tenant and users for testing
     Given call read('classpath:common/setup-users.feature')

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
@@ -39,6 +39,7 @@ Feature: mod-orders integration tests
       | 'orders.item.unopen'                   |
       | 'orders-storage.claiming.process'      |
       | 'inventory-storage.holdings.collection.get' |
+      | 'inventory-storage.instances.item.get'      |
       | 'inventory-storage.items.collection.get'    |
 
 # Looks like already exist, but if not pleas uncomment


### PR DESCRIPTION
## Purpose
[[MODORDERS-1081] Create instance when user adds receiving title to package order line](https://folio-org.atlassian.net/browse/MODORDERS-1081)

## Approach
Add required `inventory-storage.instances.item.get` to the default user