### PR TITLE
Fixed testes after extracting credit from expended

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/cancel-invoice-linked-to-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/cancel-invoice-linked-to-order.feature
@@ -206,7 +206,8 @@ Feature: Cancel an invoice linked to an order
     Then status 200
     And match $.amount == 0
     And match $.encumbrance.initialAmountEncumbered == 10
-    And match $.encumbrance.amountExpended == 5
+    And match $.encumbrance.amountExpended == 10
+    And match $.encumbrance.amountCredited == 5
     And match $.encumbrance.amountAwaitingPayment == 0
     And match $.encumbrance.status == 'Released'
 
@@ -214,11 +215,12 @@ Feature: Cancel an invoice linked to an order
     Given path 'finance/budgets', budgetId
     When method GET
     Then status 200
-    And match $.unavailable == 5
-    And match $.available == 995
+    And match $.unavailable == 10
+    And match $.available == 990
     And match $.awaitingPayment == 0
-    And match $.expenditures == 5
-    And match $.cashBalance == 995
+    And match $.expenditures == 10
+    And match $.credits == 5
+    And match $.cashBalance == 990
     And match $.encumbered == 0
 
     * print "Cancel the invoice"
@@ -335,7 +337,8 @@ Feature: Cancel an invoice linked to an order
     Then status 200
     And match $.amount == 0
     And match $.encumbrance.initialAmountEncumbered == 10
-    And match $.encumbrance.amountExpended == -5
+    And match $.encumbrance.amountExpended == 0
+    And match $.encumbrance.amountCredited == 5
     And match $.encumbrance.amountAwaitingPayment == 0
     And match $.encumbrance.status == 'Released'
 
@@ -343,11 +346,12 @@ Feature: Cancel an invoice linked to an order
     Given path 'finance/budgets', budgetId
     When method GET
     Then status 200
-    And match $.unavailable == -5
-    And match $.available == 1005
+    And match $.unavailable == 0
+    And match $.available == 1000
     And match $.awaitingPayment == 0
-    And match $.expenditures == -5
-    And match $.cashBalance == 1005
+    And match $.expenditures == 0
+    And match $.credits == 5
+    And match $.cashBalance == 1000
     And match $.encumbered == 0
 
     * print "Cancel the invoice"

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/cancel-invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/cancel-invoice.feature
@@ -194,12 +194,13 @@ Feature: Cancel an invoice
     Given path 'finance/budgets', budgetId
     When method GET
     Then status 200
-    And match $.unavailable == 5
-    And match $.available == 995
+    And match $.unavailable == 10
+    And match $.available == 990.0
     And match $.awaitingPayment == 0
-    And match $.expenditures == 5
-    And match $.cashBalance == 995
+    And match $.expenditures == 10
+    And match $.cashBalance == 990
     And match $.encumbered == 0
+    And match $.credits == 5
 
     * print "Cancel the invoice"
     Given path 'invoice/invoices', invoiceId
@@ -257,3 +258,4 @@ Feature: Cancel an invoice
     And match $.expenditures == 0
     And match $.cashBalance == 1000
     And match $.encumbered == 0
+    And match $.credits == 0


### PR DESCRIPTION
## Purpose
MOFISTO-481
https://folio-org.atlassian.net/browse/FAT-14407
https://folio-org.atlassian.net/browse/FAT-14406
https://folio-org.atlassian.net/browse/FAT-14405
## Approach
Since, credit are being extracted from expenditures, calculation need to be fixed in karate tests. Credit transactions will no longer added to expenditures. Changed several places, before cancel invoice. After invoice verification still valid.

Extracting credit from expended amount will affect avaliable cashBalance, unavaliable amounts. 

