### PR TITLE
[FAT-13846] Updated tests to separate credits from expenditures

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/cancel-invoice-linked-to-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/cancel-invoice-linked-to-order.feature
@@ -206,7 +206,8 @@ Feature: Cancel an invoice linked to an order
     Then status 200
     And match $.amount == 0
     And match $.encumbrance.initialAmountEncumbered == 10
-    And match $.encumbrance.amountExpended == 5
+    And match $.encumbrance.amountExpended == 10
+    And match $.encumbrance.amountCredited == 5
     And match $.encumbrance.amountAwaitingPayment == 0
     And match $.encumbrance.status == 'Released'
 
@@ -217,7 +218,8 @@ Feature: Cancel an invoice linked to an order
     And match $.unavailable == 5
     And match $.available == 995
     And match $.awaitingPayment == 0
-    And match $.expenditures == 5
+    And match $.expenditures == 10
+    And match $.credits == 5
     And match $.cashBalance == 995
     And match $.encumbered == 0
 
@@ -267,6 +269,7 @@ Feature: Cancel an invoice linked to an order
     And match $.encumbrance.initialAmountEncumbered == 10
     And match $.encumbrance.amountAwaitingPayment == 0
     And match $.encumbrance.amountExpended == 0
+    And match $.encumbrance.amountCredited == 0
     And match $.encumbrance.status == 'Unreleased'
 
     * print "Check budget after cancelling"
@@ -277,6 +280,7 @@ Feature: Cancel an invoice linked to an order
     And match $.available == 990
     And match $.awaitingPayment == 0
     And match $.expenditures == 0
+    And match $.credits == 0
     And match $.cashBalance == 1000
     And match $.encumbered == 10
 
@@ -335,7 +339,8 @@ Feature: Cancel an invoice linked to an order
     Then status 200
     And match $.amount == 0
     And match $.encumbrance.initialAmountEncumbered == 10
-    And match $.encumbrance.amountExpended == -5
+    And match $.encumbrance.amountExpended == 0
+    And match $.encumbrance.amountCredited == 5
     And match $.encumbrance.amountAwaitingPayment == 0
     And match $.encumbrance.status == 'Released'
 
@@ -343,10 +348,11 @@ Feature: Cancel an invoice linked to an order
     Given path 'finance/budgets', budgetId
     When method GET
     Then status 200
-    And match $.unavailable == -5
+    And match $.unavailable == 0
     And match $.available == 1005
     And match $.awaitingPayment == 0
-    And match $.expenditures == -5
+    And match $.expenditures == 0
+    And match $.credits == 5
     And match $.cashBalance == 1005
     And match $.encumbered == 0
 
@@ -376,6 +382,7 @@ Feature: Cancel an invoice linked to an order
     And match $.encumbrance.initialAmountEncumbered == 10
     And match $.encumbrance.amountAwaitingPayment == 0
     And match $.encumbrance.amountExpended == 0
+    And match $.encumbrance.amountCredited == 0
     And match $.encumbrance.status == 'Unreleased'
 
     * print "Check budget after cancelling"
@@ -386,6 +393,7 @@ Feature: Cancel an invoice linked to an order
     And match $.available == 990
     And match $.awaitingPayment == 0
     And match $.expenditures == 0
+    And match $.credits == 0
     And match $.cashBalance == 1000
     And match $.encumbered == 10
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/create-order-and-invoice-with-odd-penny.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/create-order-and-invoice-with-odd-penny.feature
@@ -142,6 +142,7 @@ Feature: Create orders and invoices with odd penny
 
     And match budget.available == 10000 - expectedEncumbered
     And match budget.expenditures == 0
+    And match budget.credits == 0
     And match budget.encumbered == expectedEncumbered
     And match budget.awaitingPayment == 0
     And match budget.unavailable == expectedEncumbered
@@ -379,10 +380,11 @@ Feature: Create orders and invoices with odd penny
 
     * def budget = response.budgets[0]
 
-    And match budget.expenditures == <amount>
+    And match budget.expenditures == <expenditures>
+    And match budget.credits == <credits>
 
     Examples:
-      | fundId  | amount |
-      | fundId1 | 50.01  |
-      | fundId2 | 50.02  |
-      | fundId3 | 0.0    |
+      | fundId  | expenditures | credits |
+      | fundId1 | 80.01        |    30.0 |
+      | fundId2 | 80.02        |    30.0 |
+      | fundId3 | 40.01        |   40.01 |

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/batch-transaction-api.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/batch-transaction-api.feature
@@ -162,6 +162,7 @@ Feature: Batch Transaction API
     And match $.allocated == 107
     And match $.available == 83
     And match $.expenditures == 0
+    And match $.credits == 0
     And match $.encumbered == 5
     And match $.awaitingPayment == 19
     And match $.unavailable == 24

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-expense-classes.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-expense-classes.feature
@@ -87,7 +87,7 @@ Feature: Budget expense classes
     Then status 200
     And match response.budgetExpenseClassTotals == '#[1]'
     And match response.totalRecords == 1
-    And match each response.budgetExpenseClassTotals contains {"encumbered": 0.00, "awaitingPayment": 0.00, "expended": 0.00, "percentageExpended": 0.00}
+    And match each response.budgetExpenseClassTotals contains { "encumbered": 0.0, "awaitingPayment": 0.0, "expended": 0.0, "credited": 0.0, "percentageExpended": 0.0, "percentageCredited": 0.0 }
 
     Given path '/finance-storage/budget-expense-classes'
     And param query = 'budgetId==' + budgetIdWithoutExpenseClasses
@@ -128,7 +128,7 @@ Feature: Budget expense classes
     Then status 200
     And match response.budgetExpenseClassTotals == '#[2]'
     And match response.totalRecords == 2
-    And match each response.budgetExpenseClassTotals contains {"encumbered": 0.00, "awaitingPayment": 0.00, "expended": 0.00, "percentageExpended": 0.00}
+    And match each response.budgetExpenseClassTotals contains { "encumbered": 0.0, "awaitingPayment": 0.0, "expended": 0.0, "credited": 0.0, "percentageExpended": 0.0, "percentageCredited": 0.0 }
 
     Given path '/finance/budgets', budgetIdWithExpenseClassesWithoutTransactions
     And request budgetBody
@@ -172,7 +172,7 @@ Feature: Budget expense classes
     Then status 200
     And match response.budgetExpenseClassTotals == '#[1]'
     And match response.totalRecords == 1
-    And match each response.budgetExpenseClassTotals contains {"encumbered": 65.11, "awaitingPayment": 0.6, "expended": 0.00, "percentageExpended": "#notpresent"}
+    And match each response.budgetExpenseClassTotals contains {"encumbered": 65.11, "awaitingPayment": 0.6, "expended": 0.0, "percentageExpended": "#notpresent"}
 
     Given path '/finance/budgets', budgetIdWithExpenseClassesWithTransactions
     When method GET
@@ -197,6 +197,6 @@ Feature: Budget expense classes
     And match response.totalRecords == 2
     * def expenseClass1Totals = karate.jsonPath(response, "$.budgetExpenseClassTotals[*][?(@.expenseClassName == 'Print')]")
     * def expenseClass2Totals = karate.jsonPath(response, "$.budgetExpenseClassTotals[*][?(@.expenseClassName == 'Electronic')]")
-    And match expenseClass1Totals[0] contains { "expended": 80.0, "percentageExpended": 36.36 }
-    And match expenseClass2Totals[0] contains { "expended": 120.0, "percentageExpended": 54.55 }
+    And match expenseClass1Totals[0] contains { "expended": 100.0, "credited": 20.0, "percentageExpended": 45.45, "percentageCredited": 100.0 }
+    And match expenseClass2Totals[0] contains { "expended": 120.0, "credited": 0.0, "percentageExpended": 54.55, "percentageCredited": "#notpresent" }
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-expense-classes.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/budget-expense-classes.feature
@@ -198,5 +198,5 @@ Feature: Budget expense classes
     * def expenseClass1Totals = karate.jsonPath(response, "$.budgetExpenseClassTotals[*][?(@.expenseClassName == 'Print')]")
     * def expenseClass2Totals = karate.jsonPath(response, "$.budgetExpenseClassTotals[*][?(@.expenseClassName == 'Electronic')]")
     And match expenseClass1Totals[0] contains { "expended": 100.0, "credited": 20.0, "percentageExpended": 45.45, "percentageCredited": 100.0 }
-    And match expenseClass2Totals[0] contains { "expended": 120.0, "credited": 0.0, "percentageExpended": 54.55, "percentageCredited": "#notpresent" }
+    And match expenseClass2Totals[0] contains { "expended": 120.0, "credited": 0.0, "percentageExpended": 54.55, "percentageCredited": 0.0 }
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/fiscal-year-totals.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/fiscal-year-totals.feature
@@ -141,7 +141,7 @@ Feature: Fiscal year totals
     And match response.financialSummary.awaitingPayment == 3108.23
     And match response.financialSummary.expenditures == 742
     And match response.financialSummary.credits == 11.0
-    And match response.financialSummary.unavailable == 29081.57
+    And match response.financialSummary.unavailable == 29070.57
     And match response.financialSummary.totalFunding == 45103
     And match response.financialSummary.available == 16021.43
     And match response.financialSummary.cashBalance == 44361

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/fiscal-year-totals.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/fiscal-year-totals.feature
@@ -143,7 +143,7 @@ Feature: Fiscal year totals
     And match response.financialSummary.credits == 11.0
     And match response.financialSummary.unavailable == 29070.57
     And match response.financialSummary.totalFunding == 45103
-    And match response.financialSummary.available == 16021.43
-    And match response.financialSummary.cashBalance == 44361
+    And match response.financialSummary.available == 16032.43
+    And match response.financialSummary.cashBalance == 44372.0
     And match response.financialSummary.overEncumbrance == 0.04
     And match response.financialSummary.overExpended == 841.96

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/fiscal-year-totals.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/fiscal-year-totals.feature
@@ -78,6 +78,7 @@ Feature: Fiscal year totals
     And match response.financialSummary.encumbered == 0
     And match response.financialSummary.awaitingPayment == 0
     And match response.financialSummary.expenditures == 0
+    And match response.financialSummary.credits == 0
     And match response.financialSummary.unavailable == 0
     And match response.financialSummary.totalFunding == 0
     And match response.financialSummary.available == 0
@@ -106,6 +107,7 @@ Feature: Fiscal year totals
       "encumbered": <encumbered>,
       "awaitingPayment": <awaitingPayment>,
       "expenditures": <expenditures>,
+      "credits": <credits>,
       "netTransfers": <netTransfers>,
       "allowableEncumbrance": 150.0,
       "allowableExpenditure": 150.0
@@ -115,10 +117,10 @@ Feature: Fiscal year totals
     Then status 201
 
     Examples:
-      | fundId  | budgetId  | initialAllocation | allocationTo | allocationFrom | netTransfers | encumbered | awaitingPayment | expenditures |
-      | fundId1 | budgetId1 | 10000             | 9000         | 1000.01        | 100.01       | 231.34     | 763.23          | 242          |
-      | fundId2 | budgetId2 | 24500             | 499.98       | 10000.01       | 9999.99      | 25000      | 0               | 0            |
-      | fundId3 | budgetId3 | 3001.91           | 1001.52      | 2000.39        | 0            | 0          | 2345            | 500          |
+      | fundId  | budgetId  | initialAllocation | allocationTo | allocationFrom | netTransfers | encumbered | awaitingPayment | expenditures | credits |
+      | fundId1 | budgetId1 | 10000             | 9000         | 1000.01        | 100.01       | 231.34     | 763.23          | 242          |      11 |
+      | fundId2 | budgetId2 | 24500             | 499.98       | 10000.01       | 9999.99      | 25000      | 0               | 0            |       0 |
+      | fundId3 | budgetId3 | 3001.91           | 1001.52      | 2000.39        | 0            | 0          | 2345            | 500          |       0 |
 
   Scenario: Get fiscal year when withFinancialSummary parameter is empty should not return financialSummary
     Given path 'finance/fiscal-years', fiscalYearId
@@ -138,6 +140,7 @@ Feature: Fiscal year totals
     And match response.financialSummary.encumbered == 25231.34
     And match response.financialSummary.awaitingPayment == 3108.23
     And match response.financialSummary.expenditures == 742
+    And match response.financialSummary.credits == 11.0
     And match response.financialSummary.unavailable == 29081.57
     And match response.financialSummary.totalFunding == 45103
     And match response.financialSummary.available == 16021.43

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/group-expense-classes.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/group-expense-classes.feature
@@ -190,6 +190,6 @@ Feature: Group expense classes
     * def expenseClass1Totals = karate.jsonPath(response, "$.groupExpenseClassTotals[*][?(@.expenseClassName == 'Print')]")
     * def expenseClass2Totals = karate.jsonPath(response, "$.groupExpenseClassTotals[*][?(@.expenseClassName == 'Electronic')]")
     * def expenseClass3Totals = karate.jsonPath(response, "$.groupExpenseClassTotals[*][?(@.expenseClassName == @.id)]")
-    And match expenseClass1Totals[0] contains { "encumbered": 1130, "awaitingPayment": 12, "expended": 80.0, "percentageExpended": 40.0 }
-    And match expenseClass2Totals[0] contains { "encumbered": 41, "awaitingPayment": 11.11, "expended": 120.0, "percentageExpended": 60.0 }
-    And match expenseClass3Totals[0] contains { "expended": 0.0, "percentageExpended": 0.0 }
+    And match expenseClass1Totals[0] contains { "encumbered": 1130, "awaitingPayment": 12, "expended": 100.0, "credited": 20.0, "percentageExpended": 45.45, "percentageCredited": 100.0 }
+    And match expenseClass2Totals[0] contains { "encumbered": 41, "awaitingPayment": 11.11, "expended": 120.0, "credited": 0.0, "percentageExpended": 54.55, "percentageCredited": 0.0 }
+    And match expenseClass3Totals[0] contains { "expended": 0.0, "credited": 0.0, "percentageExpended": 0.0, "percentageCredited": 0.0 }

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-totals.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/ledger-totals.feature
@@ -104,10 +104,10 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
     Then status 204
 
     Examples:
-      | fundId  | budgetId  | ledgerId           | initialAllocation | encumbered | awaitingPayment | expenditures |
-      | fundId1 | budgetId1 | ledgerWithBudgets1 | 10000             | 231.34     | 763.23          | 242          |
-      | fundId2 | budgetId2 | ledgerWithBudgets2 | 24500             | 25000      | 0               | 0            |
-      | fundId3 | budgetId3 | ledgerWithBudgets1 | 6601.91           | 0          | 2345            | 500          |
+      | fundId  | budgetId  | ledgerId           | initialAllocation | encumbered | awaitingPayment | expenditures | credits |
+      | fundId1 | budgetId1 | ledgerWithBudgets1 | 10000             | 231.34     | 763.23          | 242          | 5       |
+      | fundId2 | budgetId2 | ledgerWithBudgets2 | 24500             | 25000      | 0               | 0            | 0       |
+      | fundId3 | budgetId3 | ledgerWithBudgets1 | 6601.91           | 0          | 2345            | 500          | 2       |
 
   Scenario: Get ledger with budgets when fiscalYear parameter is empty should return zero totals
     Given path 'finance/ledgers', ledgerWithBudgets1
@@ -156,9 +156,9 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
     And match response.overExpended == <overExpended>
 
   Examples:
-      | ledgerId           | initialAllocation | allocated | encumbered | awaitingPayment | expenditures | unavailable | totalFunding | available | overEncumbrance | overExpended |
-      | ledgerWithBudgets1 | 16601.91          | 16601.91  | 231.34     | 3108.23         | 742          | 4081.57     | 16601.91     | 12520.34  |0.0              | 0.0          |
-      | ledgerWithBudgets2 | 24500             | 24500     | 25000      | 0.0             | 0.0          | 25000       | 24500        | -500.0       |500.0            | 0.0          |
+      | ledgerId           | initialAllocation | allocated | encumbered | awaitingPayment | expenditures | credits | unavailable | totalFunding | available | overEncumbrance | overExpended |
+      | ledgerWithBudgets1 | 16601.91          | 16601.91  | 231.34     | 3108.23         | 742          | 7       | 4074.57     | 16608.91     | 12527.34  | 0.0             | 0.0          |
+      | ledgerWithBudgets2 | 24500             | 24500     | 25000      | 0.0             | 0.0          | 0       | 25000       | 24500        | -500.0    | 500.0           | 0.0          |
 
 
   Scenario Outline: Create allocation from <fromFundId> to <toFundId>
@@ -275,9 +275,9 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
     And match response.overExpended == <overExpended>
 
     Examples:
-      | ledgerId           | initialAllocation | allocationFrom |allocationTo | netTransfers | allocated | encumbered | awaitingPayment | expenditures | unavailable | totalFunding | available | overEncumbrance | overExpended |
-      | ledgerWithBudgets1 | 16601.91          |979.0           |0.0          | -21.0        | 15622.91  | 231.34     | 3108.23         | 742          | 4081.57     | 15601.91     | 11520.34  |0.0              | 0.0          |
-      | ledgerWithBudgets2 | 24500             |20.0            |954.0        | 21.0         | 25434.0   | 25000      | 0.0             | 0.0          | 25000.0     | 25455.0      | 455       |0.0              | 0.0          |
+      | ledgerId           | initialAllocation | allocationFrom | allocationTo | netTransfers | allocated | encumbered | awaitingPayment | expenditures | credits | unavailable | totalFunding | available | overEncumbrance | overExpended |
+      | ledgerWithBudgets1 | 16601.91          | 979.0          | 0.0          | -21.0        | 15622.91  | 231.34     | 3108.23         | 742          | 7       | 4074.57     | 15608.91     | 11527.34  | 0.0             | 0.0          |
+      | ledgerWithBudgets2 | 24500             | 20.0           | 954.0        | 21.0         | 25434.0   | 25000      | 0.0             | 0.0          | 0       | 25000.0     | 25455.0      | 455       | 0.0             | 0.0          |
 
 
 
@@ -327,11 +327,12 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
      And match ledger1.encumbered == 231.34
      And match ledger1.awaitingPayment == 3108.23
      And match ledger1.expenditures == 742
-     And match ledger1.unavailable == 4081.57
+     And match ledger1.credits == 7
+     And match ledger1.unavailable == 4074.57
      And match ledger1.netTransfers == -21.0
-     And match ledger1.totalFunding == 15601.91
-     And match ledger1.available == 11520.34
-     And match ledger1.cashBalance == ledger1.totalFunding - ledger1.expenditures
+     And match ledger1.totalFunding == 15608.91
+     And match ledger1.available == 11527.34
+     And match ledger1.cashBalance == ledger1.totalFunding - ledger1.expenditures + ledger1.credits
      And match ledger1.overEncumbrance == 0.0
      And match ledger1.overExpended == 0.0
 
@@ -342,6 +343,7 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
      And match ledger2.encumbered == 0
      And match ledger2.awaitingPayment == 0
      And match ledger2.expenditures == 0
+     And match ledger2.credits == 0
      And match ledger2.unavailable == 0
      And match ledger2.netTransfers == 0
      And match ledger2.totalFunding == 0
@@ -357,11 +359,12 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
      And match ledger3.encumbered == 25000.0
      And match ledger3.awaitingPayment == 0
      And match ledger3.expenditures == 0
+     And match ledger3.credits == 0
      And match ledger3.unavailable == 25000.0
      And match ledger3.netTransfers == 21.0
      And match ledger3.totalFunding == 25455.0
      And match ledger3.available == 455.0
-     And match ledger3.cashBalance == ledger3.totalFunding - ledger3.expenditures
+     And match ledger3.cashBalance == ledger3.totalFunding - ledger3.expenditures + ledger3.credits
      And match ledger3.overEncumbrance == 0
      And match ledger3.overExpended == 0
 
@@ -387,6 +390,7 @@ Feature: Verify calculation of the Ledger totals for the fiscal year
       encumbered:  '#notpresent',
       awaitingPayment:  '#notpresent',
       expenditures:  '#notpresent',
+      credits:  '#notpresent',
       unavailable:  '#notpresent',
       netTransfers:  '#notpresent',
       totalFunding:  '#notpresent',

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/cancel-invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/cancel-invoice.feature
@@ -52,6 +52,7 @@ Feature: Cancel an invoice
     And match $.available == 990
     And match $.awaitingPayment == 10
     And match $.expenditures == 0
+    And match $.credits == 0
     And match $.cashBalance == 1000
     And match $.encumbered == 0
 
@@ -88,6 +89,7 @@ Feature: Cancel an invoice
     And match $.available == 1000
     And match $.awaitingPayment == 0
     And match $.expenditures == 0
+    And match $.credits == 0
     And match $.cashBalance == 1000
     And match $.encumbered == 0
 
@@ -127,7 +129,8 @@ Feature: Cancel an invoice
     And match $.unavailable == 5
     And match $.available == 995
     And match $.awaitingPayment == 0
-    And match $.expenditures == 5
+    And match $.expenditures == 10
+    And match $.credits == 5
     And match $.cashBalance == 995
     And match $.encumbered == 0
 
@@ -177,5 +180,6 @@ Feature: Cancel an invoice
     And match $.available == 1000
     And match $.awaitingPayment == 0
     And match $.expenditures == 0
+    And match $.credits == 0
     And match $.cashBalance == 1000
     And match $.encumbered == 0

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/exchange-rate-update-after-invoice-approval.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/exchange-rate-update-after-invoice-approval.feature
@@ -161,6 +161,7 @@ Feature: Check remaining amount upon invoice approval
     And match $.available == 10
     * match $.awaitingPayment == 250
     * match $.expenditures == 0
+    * match $.credits == 0
 
     # =================== update approved invoice with new exchange rate not exceed budget remaining amount ===================
     * configure headers = headersUser
@@ -188,6 +189,7 @@ Feature: Check remaining amount upon invoice approval
     And match $.available == 0
     * match $.awaitingPayment == 260
     * match $.expenditures == 0
+    * match $.credits == 0
 
 
     # =================== pay invoice with new exchange rate not exceed budget remaining amount ===================
@@ -217,3 +219,4 @@ Feature: Check remaining amount upon invoice approval
     And match $.available == 20
     * match $.awaitingPayment == 0
     * match $.expenditures == 240
+    * match $.credits == 0

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/check_total_encumbered_expended_calculated_correctly.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/check_total_encumbered_expended_calculated_correctly.feature
@@ -218,7 +218,7 @@ Feature: Check that totalEncumbered and totalExpended calculated correctly
       | currentEncCredit  | paymentsOrderId        | paymentsLineId        | 1452.5 | currentFiscalYear  | fundId2 |
 
 
-  Scenario Outline: create payments, credits for <encumbranceId>
+  Scenario Outline: create pending payments for <encumbranceId>
     * def encumbranceId = <encumbranceId>
     * def fundId = <fundId>
     * def fiscalYearId = <fiscalYearId>
@@ -298,10 +298,11 @@ Feature: Check that totalEncumbered and totalExpended calculated correctly
     Then status 200
     * match $.totalEncumbered == <totalEncumbered>
     * match $.totalExpended == <totalExpended>
+    * match $.totalCredited == <totalCredited>
 
 
     Examples:
-      | orderId                | totalEncumbered | totalExpended |
-      | encumbranceOnlyOrderId | 604.66          | 0             |
-      | noEncumbranceOrderId   | 0               | 0             |
-      | paymentsOrderId        | 3551.88         | 152.29         |
+      | orderId                | totalEncumbered | totalExpended | totalCredited |
+      | encumbranceOnlyOrderId | 604.66          | 0             |             0 |
+      | noEncumbranceOrderId   | 0               | 0             |             0 |
+      | paymentsOrderId        | 3551.88         | 152.29        |         99.37 |

--- a/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
+++ b/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
@@ -6,7 +6,6 @@ import org.folio.test.config.TestModuleConfiguration;
 import org.folio.test.services.TestIntegrationService;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @FolioTest(team = "thunderjet", module = "cross-modules")
@@ -46,7 +45,6 @@ public class CrossModulesApiTest extends TestBase {
   }
 
   @Test
-  @Disabled("It will be re-enabled after completing credits feature (MODFIN-371, MODFIST-481)")
   void createOrderAndInvoiceWithOddPenny() {
     runFeatureTest("create-order-and-invoice-with-odd-penny");
   }
@@ -117,7 +115,6 @@ public class CrossModulesApiTest extends TestBase {
   }
 
   @Test
-  @Disabled("It will be re-enabled after completing credits feature (MODFIN-371, MODFIST-481)")
   void cancelInvoiceLinkedToOrder() {
     runFeatureTest("cancel-invoice-linked-to-order");
   }

--- a/acquisitions/src/test/java/org/folio/InvoicesApiTest.java
+++ b/acquisitions/src/test/java/org/folio/InvoicesApiTest.java
@@ -6,7 +6,6 @@ import org.folio.test.config.TestModuleConfiguration;
 import org.folio.test.services.TestIntegrationService;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @FolioTest(team = "thunderjet", module = "mod-invoice")
@@ -131,7 +130,6 @@ public class InvoicesApiTest extends TestBase {
   }
 
   @Test
-  @Disabled("It will be re-enabled after completing credits feature (MODFIN-371, MODFIST-481)")
   void cancelInvoice() {
     runFeatureTest("cancel-invoice");
   }


### PR DESCRIPTION
## Purpose
[FAT-13846](https://folio-org.atlassian.net/browse/FAT-13846) - Update tests to separate credits from expenditures

## Approach
- Updated amounts and totals wherever credits are used (otherwise the tests are still valid)
- Added some test cases with credits to check totals
- I did not check if the tests pass because the implementation is not complete. So there might be something to fix afterwards, but for now it can be used as a target to achieve with the implementation.