### PR TITLE
[MODINV-1053] Verify holdings and items has new ids during update-ownership

### DIFF
--- a/mod-inventory/src/main/resources/folijet/mod-inventory/features/consortia/features/update-ownership.feature
+++ b/mod-inventory/src/main/resources/folijet/mod-inventory/features/consortia/features/update-ownership.feature
@@ -103,16 +103,17 @@ Feature: Updating ownership of holdings and item api tests
     When method GET
     Then status 200
     And match response.totalRecords == 1
-    And match response.holdingsRecords[0].id == holdingsId2
+    And match response.holdingsRecords[0].id != holdingsId2
     And match response.holdingsRecords[0].instanceId == instanceId
+    And def sharedHoldingsId = response.holdingsRecords[0].id
 
     Given path 'inventory/items-by-holdings-id'
-    And param query = 'holdingsRecordId==' + holdingsId2
+    And param query = 'holdingsRecordId==' + sharedHoldingsId
     When method GET
     Then status 200
     And match response.totalRecords == 1
-    And match response.items[0].id == itemsId2
-    And match response.items[0].holdingsRecordId == holdingsId2
+    And match response.items[0].id != itemsId2
+    And match response.items[0].holdingsRecordId == sharedHoldingsId
 
     # Verify that shared Instance don’t have the moved Holdings and linked Item on the University tenant
     * configure headers = headersUniversity


### PR DESCRIPTION
## Purpose
Verify holdings and items has new ids during update-ownership
## Approach
Verify holdings and items has new ids during update-ownership