### PR TITLE
Fix failing tests with sourceId

### DIFF
--- a/edge-rtac/src/main/resources/core_platform/edge-rtac/features/rtac.feature
+++ b/edge-rtac/src/main/resources/core_platform/edge-rtac/features/rtac.feature
@@ -27,8 +27,10 @@ Feature: rtac tests
     * call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostLocation') { extLocationId: #(extLocationId), extServicePointId: #(extServicePointId) }
 
     # post holding
+    * def extHoldingSourceId = call random_uuid
+    * def extHoldingSourceName = call random_string
     * def extHoldingId = call random_uuid
-    * def createHoldingsResponse = call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostHoldings') { extHoldingsRecordId: #(extHoldingId), extLocationId: #(extLocationId), extInstanceId: #(extInstanceId) }
+    * def createHoldingsResponse = call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostHoldings') { extHoldingSourceId: #(extHoldingSourceId), extHoldingSourceName: #(extHoldingSourceName), extHoldingsRecordId: #(extHoldingId), extLocationId: #(extLocationId), extInstanceId: #(extInstanceId) }
     * def expectedHoldingsCopyNumber = createHoldingsResponse.copyNumber
 
     # post items
@@ -63,8 +65,10 @@ Feature: rtac tests
     * call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostLocation') { extLocationId: #(extLocationId1), extServicePointId: #(extServicePointId1) }
 
     # post first holding
+    * def extHoldingSourceId1 = call random_uuid
+    * def extHoldingSourceName1 = call random_string
     * def extHoldingId1 = call random_uuid
-    * def createHoldingsResponse = call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostHoldings') { extHoldingsRecordId: #(extHoldingId1), extLocationId: #(extLocationId1), extInstanceId: #(extInstanceId1) }
+    * def createHoldingsResponse = call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostHoldings') { extHoldingSourceId: #(extHoldingSourceId1), extHoldingSourceName: #(extHoldingSourceName1), extHoldingsRecordId: #(extHoldingId1), extLocationId: #(extLocationId1), extInstanceId: #(extInstanceId1) }
     * def expectedFirstHoldingsCopyNumber = createHoldingsResponse.copyNumber
 
     # post item for the first holding
@@ -82,8 +86,10 @@ Feature: rtac tests
     * call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostLocation') { extLocationId: #(extLocationId2), extServicePointId: #(extServicePointId2) }
 
     # post second holding
+    * def extHoldingSourceId2 = call random_uuid
+    * def extHoldingSourceName2 = call random_string
     * def extHoldingId2 = call random_uuid
-    * def createHoldingsResponse = call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostHoldings') { extHoldingsRecordId: #(extHoldingId2), extLocationId: #(extLocationId2), extInstanceId: #(extInstanceId2) }
+    * def createHoldingsResponse = call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostHoldings') { extHoldingSourceId: #(extHoldingSourceId2), extHoldingSourceName: #(extHoldingSourceName2), extHoldingsRecordId: #(extHoldingId2), extLocationId: #(extLocationId2), extInstanceId: #(extInstanceId2) }
     * def expectedSecondHoldingsCopyNumber = createHoldingsResponse.copyNumber
 
     # post item for the second holding
@@ -117,8 +123,10 @@ Feature: rtac tests
     * call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostLocation') { extLocationId: #(extLocationId1), extServicePointId: #(extServicePointId1) }
 
     # post first holding
+    * def extHoldingSourceId1 = call random_uuid
+    * def extHoldingSourceName1 = call random_string
     * def extHoldingId1 = call random_uuid
-    * def createHoldingsResponse = call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostHoldings') { extHoldingsRecordId: #(extHoldingId1), extLocationId: #(extLocationId1), extInstanceId: #(extInstanceId1) }
+    * def createHoldingsResponse = call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostHoldings') { extHoldingSourceId: #(extHoldingSourceId1), extHoldingSourceName: #(extHoldingSourceName1), extHoldingsRecordId: #(extHoldingId1), extLocationId: #(extLocationId1), extInstanceId: #(extInstanceId1) }
     * def expectedFirstHoldingsCopyNumber = createHoldingsResponse.copyNumber
 
     # post item for the first holding
@@ -136,8 +144,10 @@ Feature: rtac tests
     * call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostLocation') { extLocationId: #(extLocationId2), extServicePointId: #(extServicePointId2) }
 
     # post second holding
+    * def extHoldingSourceId2 = call random_uuid
+    * def extHoldingSourceName2 = call random_string
     * def extHoldingId2 = call random_uuid
-    * def createHoldingsResponse = call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostHoldings') { extHoldingsRecordId: #(extHoldingId2), extLocationId: #(extLocationId2), extInstanceId: #(extInstanceId2) }
+    * def createHoldingsResponse = call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostHoldings') { extHoldingSourceId: #(extHoldingSourceId2), extHoldingSourceName: #(extHoldingSourceName2), extHoldingsRecordId: #(extHoldingId2), extLocationId: #(extLocationId2), extInstanceId: #(extInstanceId2) }
     * def expectedSecondHoldingsCopyNumber = createHoldingsResponse.copyNumber
 
     # post item for the second holding
@@ -177,8 +187,10 @@ Feature: rtac tests
     * call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostLocation') { extLocationId: #(extLocationId1), extServicePointId: #(extServicePointId1) }
 
     # post first holding
+    * def extHoldingSourceId1 = call random_uuid
+    * def extHoldingSourceName1 = call random_string
     * def extHoldingId1 = call random_uuid
-    * def createHoldingsResponse = call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostHoldings') { extHoldingsRecordId: #(extHoldingId1), extLocationId: #(extLocationId1), extInstanceId: #(extInstanceId1) }
+    * def createHoldingsResponse = call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostHoldings') { extHoldingSourceId: #(extHoldingSourceId1), extHoldingSourceName: #(extHoldingSourceName1), extHoldingsRecordId: #(extHoldingId1), extLocationId: #(extLocationId1), extInstanceId: #(extInstanceId1) }
     * def expectedFirstHoldingsCopyNumber = createHoldingsResponse.copyNumber
 
     # post item for the first holding
@@ -195,8 +207,10 @@ Feature: rtac tests
     * call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostLocation') { extLocationId: #(extLocationId2), extServicePointId: #(extServicePointId2) }
 
     # post second holding
+    * def extHoldingSourceId2 = call random_uuid
+    * def extHoldingSourceName2 = call random_string
     * def extHoldingId2 = call random_uuid
-    * def createHoldingsResponse = call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostHoldings') { extHoldingsRecordId: #(extHoldingId2), extLocationId: #(extLocationId2), extInstanceId: #(extInstanceId2) }
+    * def createHoldingsResponse = call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostHoldings') { extHoldingSourceId: #(extHoldingSourceId2), extHoldingSourceName: #(extHoldingSourceName2), extHoldingsRecordId: #(extHoldingId2), extLocationId: #(extLocationId2), extInstanceId: #(extInstanceId2) }
     * def expectedSecondHoldingsCopyNumber = createHoldingsResponse.copyNumber
 
     # post item for the second holding

--- a/edge-rtac/src/main/resources/core_platform/edge-rtac/features/samples/holdings/holdings-entity-request.json
+++ b/edge-rtac/src/main/resources/core_platform/edge-rtac/features/samples/holdings/holdings-entity-request.json
@@ -2,5 +2,6 @@
   "id": "#(holdingId)",
   "instanceId": "#(instanceId)",
   "permanentLocationId": "#(locationId)",
+  "sourceId": "#(holdingSourceId)",
   "copyNumber": "1"
 }

--- a/edge-rtac/src/main/resources/core_platform/edge-rtac/features/samples/source-record-entity-request.json
+++ b/edge-rtac/src/main/resources/core_platform/edge-rtac/features/samples/source-record-entity-request.json
@@ -1,0 +1,5 @@
+{
+  "id": "#(holdingSourceId)",
+  "name": "#(holdingSourceName)",
+  "source": "folio"
+}

--- a/edge-rtac/src/main/resources/core_platform/edge-rtac/features/util/initData.feature
+++ b/edge-rtac/src/main/resources/core_platform/edge-rtac/features/util/initData.feature
@@ -95,9 +95,22 @@ Feature: init data for edge-rtac
 
   @PostHoldings
   Scenario: create holdings
+    * def intHoldingSourceId = call random_uuid
+    * def intHoldingSourceName = call random_string
+    * def sourceIdEntityRequest = read('samples/source-record-entity-request.json')
+    * sourceIdEntityRequest.id = karate.get('extHoldingSourceId', intHoldingSourceId)
+    * sourceIdEntityRequest.name = karate.get('extHoldingSourceName', intHoldingSourceName)
+    * print sourceIdEntityRequest
+
+    Given path 'holdings-sources'
+    And request sourceIdEntityRequest
+    When method POST
+    Then status 201
+
     * def holdingsEntityRequest = read('samples/holdings/holdings-entity-request.json')
     * holdingsEntityRequest.id = karate.get('extHoldingsRecordId', holdingId)
     * holdingsEntityRequest.instanceId = karate.get('extInstanceId', instanceId)
+    * holdingsEntityRequest.sourceId = karate.get('extHoldingSourceId', intHoldingSourceId)
     * holdingsEntityRequest.permanentLocationId = karate.get('extLocationId', locationId)
     Given path 'holdings-storage', 'holdings'
     And request holdingsEntityRequest


### PR DESCRIPTION
## Purpose
[ticket](https://folio-org.atlassian.net/browse/FAT-14366)
Fix edge-rtac scenarios because holding source id missing. 

## Approach
- Add holding sources

## Visuals
<img width="1512" alt="image" src="https://github.com/folio-org/folio-integration-tests/assets/160738549/be55b8df-5126-4248-93b9-4e7acec4d402">

