### PR TITLE
[MODCON-FIX-1]. Update required modules list to fix mod-circulation exception

### DIFF
--- a/mod-consortia/src/main/resources/thunderjet/mod-consortia/consortia-junit.feature
+++ b/mod-consortia/src/main/resources/thunderjet/mod-consortia/consortia-junit.feature
@@ -15,6 +15,7 @@ Feature: mod-consortia integration tests
       | 'mod-users'                 |
       | 'mod-login'                 |
       | 'mod-inventory-storage'     |
+      | 'mod-pubsub'                |
       | 'mod-circulation-storage'   |
       | 'mod-source-record-manager' |
       | 'mod-entities-links'        |


### PR DESCRIPTION
## Purpose

Update required module list to fix this exception:

```log
10:36:53.575 [main] DEBUG com.intuit.karate - response time in milliseconds: 20358
1 < 500
1 < Content-Type: text/plain
Tenant operation failed for module mod-circulation-storage-17.3.0-SNAPSHOT.411: org.folio.util.pubsub.exceptions.ModuleRegistrationException: EventDescriptor was not registered for eventType: LOG_RECORD . Status code: 404
```

## Approach

- Add `mod-pubsub` to the list of required modules

