### PR TITLE
fix(mod-quick-marc) fix quick-marc-linking-records feature

### DIFF
--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-linking-records.feature
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-linking-records.feature
@@ -95,7 +95,7 @@ Feature: linking-records tests
     And match bibRecord.parsedRecord.content.fields[*].100.subfields[*].9 != []
 
     # delete linking authority
-    Given path 'records-editor/records', authorityId
+    Given path 'authority-storage/authorities', authorityId
     When method DELETE
     Then assert responseStatus == 204 || responseStatus == 408
     And eval if (responseStatus == 204) sleep(5000)

--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/samples/setup-records/holdings.json
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/samples/setup-records/holdings.json
@@ -12,7 +12,7 @@
   "holdingsStatementsForIndexes": [],
   "holdingsStatementsForSupplements": [],
   "statisticalCodeIds": [],
-  "sourceId": "036ee84a-6afd-4c3c-9ad3-4a12ab875f59",
+  "sourceId": "#(sourceId)",
   "metadata": {
     "createdDate": "2022-04-20T08:21:30.124+00:00",
     "createdByUserId": "b8649f0d-5fb3-5b00-ab61-dc9c7d04d914",

--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/setup.feature
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/setup.feature
@@ -11,6 +11,7 @@ Feature: Setup quickMARC
 
     * def snapshotId = '7dbf5dcf-f46c-42cd-924b-04d99cd410b9'
     * def instanceId = '337d160e-a36b-4a2b-b4c1-3589f230bd2c'
+    * def sourceId = '036ee84a-6afd-4c3c-9ad3-4a12ab875f59'
     * def instanceHrid = 'in00000000001'
     * def linkedAuthorityId = 'e7537134-0724-4720-9b7d-bddec65c0fad'
     * def authorityNaturalId = 'n00001263'
@@ -43,7 +44,7 @@ Feature: Setup quickMARC
     And request
     """
       {
-       "id": "036ee84a-6afd-4c3c-9ad3-4a12ab875f59",
+       "id": "#(sourceId)",
        "name": "MARC"
       }
     """

--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/quick-marc-junit.feature
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/quick-marc-junit.feature
@@ -3,29 +3,30 @@ Feature: mod-quick-marc integration tests
   Background:
     * url baseUrl
     * table modules
-      | name                                |
-      | 'mod-login'                         |
-      | 'mod-permissions'                   |
-      | 'mod-configuration'                 |
-      | 'mod-quick-marc'                    |
-      | 'mod-source-record-manager'         |
-      | 'mod-source-record-storage'         |
-      | 'mod-inventory'                     |
-      | 'mod-inventory-storage'             |
-      | 'mod-entities-links'                |
+      | name                        |
+      | 'mod-login'                 |
+      | 'mod-permissions'           |
+      | 'mod-configuration'         |
+      | 'mod-quick-marc'            |
+      | 'mod-source-record-manager' |
+      | 'mod-source-record-storage' |
+      | 'mod-inventory'             |
+      | 'mod-inventory-storage'     |
+      | 'mod-entities-links'        |
 
     * table userPermissions
-      | name                                                |
-      | 'configuration.all'                                 |
-      | 'inventory-storage.all'                             |
-      | 'source-storage.all'                                |
-      | 'marc-records-editor.all'                           |
-      | 'metadata-provider.logs.get'                        |
-      | 'change-manager.jobexecutions.get'                  |
-      | 'converter-storage.field-protection-settings.get'   |
-      | 'instance-authority-links.instances.collection.put' |
-      | 'instance-authority-links.instances.collection.get' |
-      | 'inventory-storage.authority-source-files.item.post'|
+      | name                                                 |
+      | 'configuration.all'                                  |
+      | 'inventory-storage.all'                              |
+      | 'inventory-storage.authorities.all'                  |
+      | 'source-storage.all'                                 |
+      | 'marc-records-editor.all'                            |
+      | 'metadata-provider.logs.get'                         |
+      | 'change-manager.jobexecutions.get'                   |
+      | 'converter-storage.field-protection-settings.get'    |
+      | 'instance-authority-links.instances.collection.put'  |
+      | 'instance-authority-links.instances.collection.get'  |
+      | 'inventory-storage.authority-source-files.item.post' |
 
   Scenario: create tenant and users for testing
     Given call read('classpath:common/setup-users.feature')


### PR DESCRIPTION
## Purpose
Fix Karate test fail: quick-marc-linking-records

## Approach
Update linking authority delete endpoint


https://folio-org.atlassian.net/browse/FAT-14613
