### PR TITLE
[FAT-13426-2]. Add missing arg comments on create-order-line reusable

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/create-order-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/create-order-line.feature
@@ -1,5 +1,5 @@
 Feature: Create order line
-  # parameters: id, orderId, fundId, listUnitPrice, isPackage, titleOrPackage
+  # parameters: id, orderId, fundId, listUnitPrice, isPackage, titleOrPackage, paymentStatus, receiptStatus
 
   Background:
     * url baseUrl


### PR DESCRIPTION
## Purpose

- Add missing arg comments on create-order-line reusable (for better long-term maintenance)

## Approach

- Update a comment
