### PR TITLE
FAT-16096 Add hrId to MARC_BIB record creation

### DIFF
--- a/mod-inventory/src/main/resources/folijet/mod-inventory/features/inventoryFeatureTest.feature
+++ b/mod-inventory/src/main/resources/folijet/mod-inventory/features/inventoryFeatureTest.feature
@@ -269,6 +269,7 @@ Feature: inventory
     Given def instance = call read(utilsPath+'@CreateInstance') { source:'MARC', title:'TestInstance' }
     And def instanceId = instance.id
 
+    * def instanceHrid = 'in' + ("00000000000" + Math.floor(Math.random() * 10000000000)).slice(-11)
     Given def snapshot = call read(utilsPath+'@CreateSnapshot')
     And def snapshotId = snapshot.id
 

--- a/mod-inventory/src/main/resources/folijet/mod-inventory/samples/record.json
+++ b/mod-inventory/src/main/resources/folijet/mod-inventory/samples/record.json
@@ -281,7 +281,8 @@
   "deleted" : false,
   "state": "ACTUAL",
   "externalIdsHolder" : {
-    "instanceId" : "#(instanceId)"
+    "instanceId" : "#(instanceId)",
+    "instanceHrid" : "#(instanceHrid)"
   },
   "additionalInfo" : {
     "suppressDiscovery" : false


### PR DESCRIPTION
## Purpose
Karate test fail: [folijet/mod-inventory] ModInventoryTests {2}  folijet/mod-inventory/features/inventoryFeatureTest.feature

## Approach
Add hrId to MARC_BIB record creation

### Learning
[FAT-16096](https://folio-org.atlassian.net/browse/FAT-16096)
