### PR TITLE
FAT-16090, FAT-16091, FAT-16093, FAT-16097, FAT-16098, FAT-16099 - Firebird regression (MODSOURMAN-1203)

### DIFF
--- a/mod-data-export/src/test/resources/samples/marc_bib_record.json
+++ b/mod-data-export/src/test/resources/samples/marc_bib_record.json
@@ -517,7 +517,8 @@
   "deleted": false,
   "order": 0,
   "externalIdsHolder": {
-    "instanceId": "replace_instanceId"
+    "instanceId": "replace_instanceId",
+    "instanceHrid": "replace_instanceHrid"
   },
   "additionalInfo": {
     "suppressDiscovery": false

--- a/mod-data-export/src/test/resources/samples/marc_bib_record_deleted.json
+++ b/mod-data-export/src/test/resources/samples/marc_bib_record_deleted.json
@@ -517,7 +517,8 @@
   "deleted": false,
   "order": 0,
   "externalIdsHolder": {
-    "instanceId": "51bb90b1-5410-426a-9945-58f29640259e"
+    "instanceId": "51bb90b1-5410-426a-9945-58f29640259e",
+    "instanceHrid": "in0000000001"
   },
   "additionalInfo": {
     "suppressDiscovery": false

--- a/mod-oai-pmh/src/test/resources/samples/marc_record.json
+++ b/mod-oai-pmh/src/test/resources/samples/marc_record.json
@@ -452,7 +452,8 @@
     }
   },
   "externalIdsHolder": {
-    "instanceId": "54cc0262-76df-4cac-acca-b10e9bc5c79a"
+    "instanceId": "54cc0262-76df-4cac-acca-b10e9bc5c79a",
+    "instanceHrid": "in0000000000001"
   },
   "deleted": false,
   "order": 0,


### PR DESCRIPTION
FAT-16090, FAT-16091, FAT-16093, FAT-16097, FAT-16098, FAT-16099 - Firebird regression (MODSOURMAN-1203)

[FAT-16090](https://folio-org.atlassian.net/browse/FAT-16090)
[FAT-16091](https://folio-org.atlassian.net/browse/FAT-16091)
[FAT-16093](https://folio-org.atlassian.net/browse/FAT-16093)
[FAT-16097](https://folio-org.atlassian.net/browse/FAT-16097)
[FAT-16098](https://folio-org.atlassian.net/browse/FAT-16098)
[FAT-16099](https://folio-org.atlassian.net/browse/FAT-16099)

## Purpose
To fix issue creating SRS record without required field externalIdsHolder.instanceHrid.

## Approach
Adding value externalIdsHolder.instanceHrid in samples.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
