### PR TITLE
FAT-16101 Add instanceHrid to MARC_BIB record creation

### DIFF
--- a/mod-source-record-storage/src/main/resources/folijet/mod-source-record-storage/features/get-source-storage-records.feature
+++ b/mod-source-record-storage/src/main/resources/folijet/mod-source-record-storage/features/get-source-storage-records.feature
@@ -323,6 +323,7 @@ Feature: Source-Record-Storage
   Scenario: Test calculation of records generation
     * def instanceId = uuid()
     * def hrId = 'inst000000000019'
+    * def instanceHrid = 'in' + ("00000000000" + Math.floor(Math.random() * 10000000000)).slice(-11)
     Given call read('classpath:folijet/mod-source-record-storage/features/global/postToInventory.feature')
 
     * print 'Create snapshot, create record, mark snapshot committed, create another snapshot, save record with the same matched id, verify records generation'

--- a/mod-source-record-storage/src/main/resources/folijet/mod-source-record-storage/features/samples/record.json
+++ b/mod-source-record-storage/src/main/resources/folijet/mod-source-record-storage/features/samples/record.json
@@ -281,7 +281,8 @@
   "deleted" : false,
   "state": "ACTUAL",
   "externalIdsHolder" : {
-    "instanceId" : "#(instanceId)"
+    "instanceId" : "#(instanceId)",
+    "instanceHrid" : "#(instanceHrid)"
   },
   "additionalInfo" : {
     "suppressDiscovery" : false

--- a/mod-source-record-storage/src/main/resources/folijet/mod-source-record-storage/features/samples/recordWith999field.json
+++ b/mod-source-record-storage/src/main/resources/folijet/mod-source-record-storage/features/samples/recordWith999field.json
@@ -291,7 +291,8 @@
   },
   "deleted" : false,
   "externalIdsHolder" : {
-    "instanceId" : "6b4ae089-e1ee-431f-af83-e1133f8e3da0"
+    "instanceId" : "6b4ae089-e1ee-431f-af83-e1133f8e3da0",
+    "instanceHrid": "inst000000000001"
   },
   "additionalInfo" : {
     "suppressDiscovery" : false


### PR DESCRIPTION
## Purpose
Karate test fail: [folijet/mod-source-record-storage] ModSourceRecordStorageTest {2}  folijet/mod-source-record-storage/features/get-source-storage-records.feature

## Approach
Add hrId to MARC_BIB record creation

### Learning
[FAT-16101](https://folio-org.atlassian.net/browse/FAT-16101)
