### PR TITLE
[FAT-16037] Extend Karate coverage for Bind pieces in ECS mode

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/consortia/consortia-orders-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/consortia-orders-junit.feature
@@ -59,6 +59,7 @@ Feature: mod-consortia integration tests
 
     # define main users
     * def consortiaAdmin = { id: '#(centralAdminId)', username: 'consortia_admin', password: 'consortia_admin_password', tenant: '#(centralTenant)'}
+    * def centralUser1 = { id: '#(centralUser1Id)', username: 'central_user1', password: 'central_user1_password', type: 'staff', tenant: '#(centralTenant)'}
     * def universityUser1 = { id: '#(universityUser1Id)', username: 'university_user1', password: 'university_user1_password', type: 'staff', tenant: '#(universityTenant)'}
 
     # define custom login
@@ -72,6 +73,7 @@ Feature: mod-consortia integration tests
     # add 'consortia.all' (for consortia management)
     * call login consortiaAdmin
     * call read('classpath:common-consortia/initData.feature@PutPermissions') { desiredPermissions: ['consortia.all']}
+    * call read('classpath:common-consortia/initData.feature@PostUser') centralUser1
 
     * call login universityUser1
     * call read('classpath:common-consortia/initData.feature@PutPermissions') { desiredPermissions: ['consortia.all']}
@@ -96,14 +98,17 @@ Feature: mod-consortia integration tests
     * call read('order-utils/organizations.feature')
     * call read('order-utils/orders.feature')
 
-  Scenario: Create and open order
-    Given call read('features/open-order-with-locations-from-different-tenants.feature')
+#  Scenario: Create and open order
+#    Given call read('features/open-order-with-locations-from-different-tenants.feature')
+#
+#  Scenario: Reopen order and change instance connection orderLine
+#    Given call read('features/reopen-and-change-instance-connection-order-with-locations-from-different-tenants.feature')
+#
+#  Scenario: Test cross-tenant inventory objects creation when working with pieces
+#    Given call read("features/pieces-api-test-for-cross-tenant-envs.feature")
 
-  Scenario: Reopen order and change instance connection orderLine
-    Given call read('features/reopen-and-change-instance-connection-order-with-locations-from-different-tenants.feature')
-
-  Scenario: Test cross-tenant inventory objects creation when working with pieces
-    Given call read("features/pieces-api-test-for-cross-tenant-envs.feature")
+  Scenario: Test bind pieces features in ECS environment
+    Given call read("features/bind-pieces-ecs.feature")
 
   @DestroyData
   Scenario: Destroy created ['central', 'university'] tenants

--- a/acquisitions/src/main/resources/thunderjet/consortia/consortia-orders-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/consortia-orders-junit.feature
@@ -98,14 +98,14 @@ Feature: mod-consortia integration tests
     * call read('order-utils/organizations.feature')
     * call read('order-utils/orders.feature')
 
-#  Scenario: Create and open order
-#    Given call read('features/open-order-with-locations-from-different-tenants.feature')
-#
-#  Scenario: Reopen order and change instance connection orderLine
-#    Given call read('features/reopen-and-change-instance-connection-order-with-locations-from-different-tenants.feature')
-#
-#  Scenario: Test cross-tenant inventory objects creation when working with pieces
-#    Given call read("features/pieces-api-test-for-cross-tenant-envs.feature")
+  Scenario: Create and open order
+    Given call read('features/open-order-with-locations-from-different-tenants.feature')
+
+  Scenario: Reopen order and change instance connection orderLine
+    Given call read('features/reopen-and-change-instance-connection-order-with-locations-from-different-tenants.feature')
+
+  Scenario: Test cross-tenant inventory objects creation when working with pieces
+    Given call read("features/pieces-api-test-for-cross-tenant-envs.feature")
 
   Scenario: Test bind pieces features in ECS environment
     Given call read("features/bind-pieces-ecs.feature")

--- a/acquisitions/src/main/resources/thunderjet/consortia/features/bind-pieces-ecs.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/features/bind-pieces-ecs.feature
@@ -1,0 +1,12 @@
+Feature: Verify Bind Piece feature in ECS environment
+
+  Background:
+    * def bindPiecesFeatures = read('classpath:thunderjet/mod-orders/features/bind-piece.feature')
+
+  Scenario: Test bind pieces features
+    * set consortiaAdmin.name = consortiaAdmin.username
+    * set centralUser1.name = centralUser1.username
+    * table tenants
+      | tenantId1     | tenantId2        | adminUser      | regularUser    | holdingId1        | holdingId2           | holdingId3        |
+      | centralTenant | universityTenant | consortiaAdmin | consortiaAdmin | centralHoldingId1 | universityHoldingId1 | centralHoldingId2 |
+    * def v = call bindPiecesFeatures tenants

--- a/acquisitions/src/main/resources/thunderjet/consortia/variables/variablesCentral.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/variables/variablesCentral.feature
@@ -51,3 +51,4 @@ Feature: Central variables
 
   Scenario: User IDs
     * def centralAdminId = '122b3d2b-4788-4f1e-9117-56daa91cb75c'
+    * def centralUser1Id = '6d27d190-b6e4-4075-b80f-01517bafb2d4'

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/bind-piece.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/bind-piece.feature
@@ -62,11 +62,11 @@ Feature: Verify Bind Piece feature
     * call createOrder { id: '#(orderId)' }
 
     # 3. Create patron and user
-    * def v = call createUserGroup { id: '#(patronId)', group: 'staff', tenant: '#(tenantId1)' }
+    * def v = call createUserGroup { id: '#(patronId)', group: 'patron', tenantId: '#(tenantId1)' }
     * def v = call createUser { id: '#(userId)', patronId: '#(patronId)'}
 
     # 4. Setup Circulation Policy
-    * call createCirculationPolicy
+    * call createCirculationPolicy { tenant: '#(tenantId1)' }
 
     * configure headers = headersUser
 
@@ -513,15 +513,11 @@ Feature: Verify Bind Piece feature
     * def requestId1 = call uuid
     * def requestId2 = call uuid
 
-
-#    * table circulationRequestData
-#      | id         | requesterId | itemId      |
-#      | requestId1 | userId      | prevItemId1 |
-#      | requestId2 | userId      | prevItemId2 |
-#    * def v = call createCirculationRequest circulationRequestData
-    * call createCirculationRequest {id: "#(requestId1)", requesterId: "#(userId)", itemId: "#(prevItemId1)", tenantId: "#(tenantId1)"}
-    * call pause 1000
-    * call createCirculationRequest {id: "#(requestId2)", requesterId: "#(userId)", itemId: "#(prevItemId2)", tenantId: "#(tenantId1)"}
+    * table circulationRequestData
+      | id         | requesterId | itemId      | tenantId  |
+      | requestId1 | userId      | prevItemId1 | tenantId1 |
+      | requestId2 | userId      | prevItemId2 | tenantId1 |
+    * def v = call createCirculationRequest circulationRequestData
 
     # 2.3 Verify circulation request with previous item details
     Given path 'circulation', 'requests', requestId1
@@ -540,7 +536,7 @@ Feature: Verify Bind Piece feature
 
     # 3. Receive both pieceId1 and pieceId2
     * table receivePieceDetails
-      | pieceId          | poLineId  | holdingId        |
+      | pieceId          | poLineId  | holdingId  |
       | pieceWithItemId1 | poLineId1 | holdingId1 |
       | pieceWithItemId2 | poLineId1 | holdingId3 |
     * def v = call receivePieceWithHolding receivePieceDetails
@@ -668,7 +664,7 @@ Feature: Verify Bind Piece feature
 
     # 3. Receive both pieceId1 and pieceId2
     * table receivePieceDetails
-      | pieceId          | poLineId  | holdingId        |
+      | pieceId          | poLineId  | holdingId  |
       | pieceWithItemId1 | poLineId1 | holdingId1 |
       | pieceWithItemId2 | poLineId1 | holdingId3 |
     * def v = call receivePieceWithHolding receivePieceDetails

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/bind-piece.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/bind-piece.feature
@@ -2,9 +2,15 @@ Feature: Verify Bind Piece feature
 
   Background:
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * def tenantId1 = karate.get('tenantId1', testTenant);
+    * def tenantId2 = karate.get('tenantId2', testTenant);
+    * def adminUser = karate.get('adminUser', testAdmin);
+    * def regularUser = karate.get('regularUser', testUser);
+
+    * callonce loginAdmin adminUser
     * def okapitokenAdmin = okapitoken
-    * callonce loginRegularUser testUser
+    * callonce loginRegularUser regularUser
     * def okapitokenUser = okapitoken
     * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json'  }
     * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': '*/*'  }
@@ -19,9 +25,13 @@ Feature: Verify Bind Piece feature
     * def createCirculationRequest = read('classpath:thunderjet/mod-orders/reusable/create-circulation-request.feature')
     * def createUserGroup = read('classpath:thunderjet/mod-orders/reusable/user-init-data.feature@CreateGroup')
     * def createUser = read('classpath:thunderjet/mod-orders/reusable/user-init-data.feature@CreateUser')
-    * def receivePiece = read('classpath:thunderjet/mod-orders/reusable/receive-piece.feature')
+    * def receivePieceWithHolding = read('classpath:thunderjet/mod-orders/reusable/receive-piece-with-holding.feature')
 
     * callonce variables
+
+    * def holdingId1 = karate.get('holdingId1', globalHoldingId1);
+    * def holdingId2 = karate.get('holdingId2', globalHoldingId2);
+    * def holdingId3 = karate.get('holdingId3', globalHoldingId3);
 
     * def fromYear = callonce getCurrentYear
     * def toYear = parseInt(fromYear) + 1
@@ -52,7 +62,7 @@ Feature: Verify Bind Piece feature
     * call createOrder { id: '#(orderId)' }
 
     # 3. Create patron and user
-    * def v = call createUserGroup { id: '#(patronId)' }
+    * def v = call createUserGroup { id: '#(patronId)', group: 'staff', tenant: '#(tenantId1)' }
     * def v = call createUser { id: '#(userId)', patronId: '#(patronId)'}
 
     # 4. Setup Circulation Policy
@@ -199,7 +209,8 @@ Feature: Verify Bind Piece feature
         format: "Physical",
         poLineId: "#(poLineId1)",
         titleId: "#(titleId)",
-        holdingId: "#(globalHoldingId1)",
+        holdingId: "#(holdingId1)",
+        receivingTenantId: "#(tenantId1)",
         chronology: "111"
       }
       """
@@ -214,7 +225,8 @@ Feature: Verify Bind Piece feature
         format: "Physical",
         poLineId: "#(poLineId1)",
         titleId: "#(titleId)",
-        holdingId: "#(globalHoldingId2)",
+        holdingId: "#(holdingId2)",
+        receivingTenantId: "#(tenantId2)",
         chronology: "222"
       }
       """
@@ -225,7 +237,8 @@ Feature: Verify Bind Piece feature
     # 3. Try Binding expected pieces together for poLineId1 with pieceId1 and pieceId2
     * def bindPieceCollection = read('classpath:samples/mod-orders/bindPieces/bindPieceCollection.json')
     * set bindPieceCollection.poLineId = poLineId1
-    * set bindPieceCollection.bindItem.holdingId = globalHoldingId1
+    * set bindPieceCollection.bindItem.holdingId = holdingId1
+    * set bindPieceCollection.bindItem.tenantId = tenantId1
     * set bindPieceCollection.bindPieceIds[0] = pieceId1
     * set bindPieceCollection.bindPieceIds[1] = pieceId2
 
@@ -238,8 +251,11 @@ Feature: Verify Bind Piece feature
 
 
     # 4. Receive both pieceId1 and pieceId2
-    * def v = call receivePiece { pieceId: "#(pieceId1)", poLineId: "#(poLineId1)" }
-    * def v = call receivePiece { pieceId: "#(pieceId2)", poLineId: "#(poLineId1)" }
+    * table receivePieceDetails
+      | pieceId  | poLineId  | holdingId  | tenantId  |
+      | pieceId1 | poLineId1 | holdingId1 | tenantId1 |
+      | pieceId2 | poLineId1 | holdingId2 | tenantId2 |
+    * def v = call receivePieceWithHolding receivePieceDetails
 
 
     # 5. Binding received pieces together for poLineId1 with pieceId1 and pieceId2
@@ -258,37 +274,40 @@ Feature: Verify Bind Piece feature
     Given path 'orders/pieces', pieceId1
     When method GET
     Then status 200
-    And match $.isBound == true
-    And match $.itemId == '#present'
-    And match $.bindItemId == newItemId
+    And match response.isBound == true
+    And match response.itemId == '#present'
+    And match response.bindItemId == newItemId
+    And match response.bindItemTenantId == tenantId1
 
     Given path 'orders/pieces', pieceId2
     When method GET
     Then status 200
-    And match $.isBound == true
-    And match $.itemId == '#present'
-    And match $.bindItemId == newItemId
+    And match response.isBound == true
+    And match response.itemId == '#present'
+    And match response.bindItemId == newItemId
+    And match response.bindItemTenantId == tenantId1
 
 
     # 7. Check item details with 'bindPieceCollection' details after pieces are bound
-    Given path 'item-storage/items', newItemId
-    When method GET
+    Given path 'inventory/tenant-items'
+    And request { tenantItemPairs: [ { tenantId: "#(tenantId1)", itemId: "#(newItemId)" } ] }
+    When method POST
     Then status 200
-    And match $.holdingsRecordId == globalHoldingId1
-    And match $.status.name == 'In process'
-    And match $.barcode == bindPieceCollection.bindItem.barcode
-    And match $.itemLevelCallNumber == bindPieceCollection.bindItem.callNumber
-    And match $.permanentLoanTypeId == bindPieceCollection.bindItem.permanentLoanTypeId
-    And match $.materialTypeId == bindPieceCollection.bindItem.materialTypeId
-    And match $.purchaseOrderLineIdentifier == bindPieceCollection.poLineId
-    And match $.chronology == '#notpresent'
+    And match response.tenantItems[*].item.holdingsRecordId contains holdingId1
+    And match response.tenantItems[*].item.status.name contains 'In process'
+    And match response.tenantItems[*].item.barcode contains bindPieceCollection.bindItem.barcode
+    And match response.tenantItems[*].item.itemLevelCallNumber contains bindPieceCollection.bindItem.callNumber
+    And match response.tenantItems[*].item.permanentLoanTypeId contains bindPieceCollection.bindItem.permanentLoanTypeId
+    And match response.tenantItems[*].item.materialTypeId contains bindPieceCollection.bindItem.materialTypeId
+    And match response.tenantItems[*].item.purchaseOrderLineIdentifier contains bindPieceCollection.poLineId
+    And match response.tenantItems[*].tenantId contains tenantId1
 
 
     # 8. Verify Title 'bindItemIds' field
     Given path 'orders/titles', titleId
     When method GET
     Then status 200
-    And match $.bindItemIds[*] contains newItemId
+    And match response.bindItemIds[*] contains newItemId
 
 
   @Positive
@@ -309,7 +328,8 @@ Feature: Verify Bind Piece feature
         format: "Physical",
         poLineId: "#(poLineId1)",
         titleId: "#(titleId)",
-        holdingId: "#(globalHoldingId1)",
+        holdingId: "#(holdingId1)",
+        receivingTenantId: "#(tenantId1)",
         displayOnHolding: false,
         enumeration: "111",
         chronology: "111",
@@ -331,7 +351,8 @@ Feature: Verify Bind Piece feature
         format: "Physical",
         poLineId: "#(poLineId1)",
         titleId: "#(titleId)",
-        holdingId: "#(globalHoldingId1)",
+        holdingId: "#(holdingId2)",
+        receivingTenantId: "#(tenantId2)",
         displayOnHolding: false,
         enumeration: "420",
         chronology: "420",
@@ -345,26 +366,27 @@ Feature: Verify Bind Piece feature
 
 
     # 2. Check previous item details of piece before bound
-    Given path 'item-storage/items', prevItemId1
-    When method GET
+    Given path 'inventory/tenant-items'
+    And request { tenantItemPairs: [ { tenantId: "#(tenantId1)", itemId: "#(prevItemId1)" }, { tenantId: "#(tenantId2)", itemId: "#(prevItemId2)" } ] }
+    When method POST
     Then status 200
-    And match $.status.name == 'On order'
-
-    Given path 'item-storage/items', prevItemId2
-    When method GET
-    Then status 200
-    And match $.status.name == 'On order'
+    And match response.tenantItems[*].item.status.name contains 'On order'
+    And match response.tenantItems[*].tenantId contains any ['#(tenantId1)', '#(tenantId2)']
 
 
     # 3. Receive both pieceId1 and pieceId2
-    * def v = call receivePiece { pieceId: "#(pieceWithItemId1)", poLineId: "#(poLineId1)" }
-    * def v = call receivePiece { pieceId: "#(pieceWithItemId2)", poLineId: "#(poLineId1)" }
+    * table receivePieceDetails
+      | pieceId          | poLineId  | holdingId  | tenantId  |
+      | pieceWithItemId1 | poLineId1 | holdingId1 | tenantId1 |
+      | pieceWithItemId2 | poLineId1 | holdingId2 | tenantId2 |
+    * def v = call receivePieceWithHolding receivePieceDetails
 
 
     # 4. Bind pieces together for poLineId1 with pieceId1 and pieceId2
     * def bindPieceCollection = read('classpath:samples/mod-orders/bindPieces/bindPieceCollection.json')
     * set bindPieceCollection.bindItem.barcode = '1111110'
-    * set bindPieceCollection.bindItem.holdingId = globalHoldingId2
+    * set bindPieceCollection.bindItem.holdingId = holdingId2
+    * set bindPieceCollection.bindItem.tenantId = tenantId2
     * set bindPieceCollection.poLineId = poLineId1
     * set bindPieceCollection.bindPieceIds[0] = pieceWithItemId1
     * set bindPieceCollection.bindPieceIds[1] = pieceWithItemId2
@@ -378,29 +400,29 @@ Feature: Verify Bind Piece feature
     Given path 'orders/pieces', pieceWithItemId1
     When method GET
     Then status 200
-    And match $.isBound == true
-    And match $.itemId == '#present'
-    And match $.bindItemId == newItemId
+    And match response.isBound == true
+    And match response.itemId == '#present'
+    And match response.bindItemId == newItemId
+    And match response.bindItemTenantId == tenantId2
 
     Given path 'orders/pieces', pieceWithItemId2
     When method GET
     Then status 200
-    And match $.isBound == true
-    And match $.itemId == '#present'
-    And match $.bindItemId == newItemId
+    And match response.isBound == true
+    And match response.itemId == '#present'
+    And match response.bindItemId == newItemId
+    And match response.bindItemTenantId == tenantId2
 
 
     # 6. Check previous item1, item2 status of piece after bound
     # Status of item1 and item2 should changed from "On order" to "Unavailable"
-    Given path 'item-storage/items', prevItemId1
-    When method GET
+    Given path 'inventory/tenant-items'
+    And request { tenantItemPairs: [ { tenantId: "#(tenantId1)", itemId: "#(prevItemId1)" }, { tenantId: "#(tenantId2)", itemId: "#(prevItemId2)" } ] }
+    When method POST
     Then status 200
-    And match $.status.name == 'Unavailable'
-
-    Given path 'item-storage/items', prevItemId2
-    When method GET
-    Then status 200
-    And match $.status.name == 'Unavailable'
+    And match response.tenantItems[*].item.status.name !contains 'On order'
+    And match response.tenantItems[*].item.status.name contains 'Unavailable'
+    And match response.tenantItems[*].tenantId contains any ['#(tenantId1)', '#(tenantId2)']
 
 
     # 7. Update bounded piece
@@ -414,7 +436,8 @@ Feature: Verify Bind Piece feature
         format: "Physical",
         poLineId: "#(poLineId1)",
         titleId: "#(titleId)",
-        holdingId: "#(globalHoldingId1)",
+        holdingId: "#(holdingId2)",
+        receivingTenantId: "#(tenantId2)",
         displayOnHolding: false,
         enumeration: "420",
         chronology: "420",
@@ -425,10 +448,12 @@ Feature: Verify Bind Piece feature
     When method PUT
     Then status 204
 
-    Given path 'item-storage/items', newItemId
-    When method GET
+    Given path 'inventory/tenant-items'
+    And request { tenantItemPairs: [ { tenantId: "#(tenantId2)", itemId: "#(newItemId)" } ] }
+    When method POST
     Then status 200
-    And match $.barcode == '1111110'
+    And match response.tenantItems[*].item.barcode contains '1111110'
+    And match response.tenantItems[*].tenantId contains tenantId2
 
 
   Scenario: When pieces have items with open circulation requests, these requests should be moved
@@ -444,7 +469,7 @@ Feature: Verify Bind Piece feature
       {
         id: "#(pieceWithItemId1)",
         format: "Physical",
-        holdingId: "#(globalHoldingId1)",
+        holdingId: "#(holdingId1)",
         poLineId: "#(poLineId1)",
         displayOnHolding: false,
         enumeration: "333",
@@ -458,7 +483,7 @@ Feature: Verify Bind Piece feature
     Then status 201
     * def prevItemId1 = response.itemId
 
-    # 1.2 Creating second piece with item to bind in Title with 'titleId' with different holding 'globalHoldingId2'
+    # 1.2 Creating second piece with item to bind in Title with 'titleId' with different holding 'holdingId3'
     Given path 'orders/pieces'
     * configure headers = headersUser
     And request
@@ -466,7 +491,7 @@ Feature: Verify Bind Piece feature
       {
         id: "#(pieceWithItemId2)",
         format: "Physical",
-        holdingId: "#(globalHoldingId2)",
+        holdingId: "#(holdingId3)",
         poLineId: "#(poLineId1)",
         displayOnHolding: false,
         enumeration: "444",
@@ -488,9 +513,15 @@ Feature: Verify Bind Piece feature
     * def requestId1 = call uuid
     * def requestId2 = call uuid
 
-    * call createCirculationRequest {id: "#(requestId1)", requesterId: "#(userId)", itemId: "#(prevItemId1)"}
+
+#    * table circulationRequestData
+#      | id         | requesterId | itemId      |
+#      | requestId1 | userId      | prevItemId1 |
+#      | requestId2 | userId      | prevItemId2 |
+#    * def v = call createCirculationRequest circulationRequestData
+    * call createCirculationRequest {id: "#(requestId1)", requesterId: "#(userId)", itemId: "#(prevItemId1)", tenantId: "#(tenantId1)"}
     * call pause 1000
-    * call createCirculationRequest {id: "#(requestId2)", requesterId: "#(userId)", itemId: "#(prevItemId2)"}
+    * call createCirculationRequest {id: "#(requestId2)", requesterId: "#(userId)", itemId: "#(prevItemId2)", tenantId: "#(tenantId1)"}
 
     # 2.3 Verify circulation request with previous item details
     Given path 'circulation', 'requests', requestId1
@@ -508,14 +539,17 @@ Feature: Verify Bind Piece feature
 
 
     # 3. Receive both pieceId1 and pieceId2
-    * def v = call receivePiece { pieceId: "#(pieceWithItemId1)", poLineId: "#(poLineId1)" }
-    * def v = call receivePiece { pieceId: "#(pieceWithItemId2)", poLineId: "#(poLineId1)" }
+    * table receivePieceDetails
+      | pieceId          | poLineId  | holdingId        |
+      | pieceWithItemId1 | poLineId1 | holdingId1 |
+      | pieceWithItemId2 | poLineId1 | holdingId3 |
+    * def v = call receivePieceWithHolding receivePieceDetails
 
 
     # 4.1 Prepare data for binding pieces
     * def bindPieceCollection = read('classpath:samples/mod-orders/bindPieces/bindPieceCollection.json')
     * set bindPieceCollection.bindItem.barcode = '33333'
-    * set bindPieceCollection.bindItem.holdingId = globalHoldingId1
+    * set bindPieceCollection.bindItem.holdingId = holdingId1
     * set bindPieceCollection.poLineId = poLineId1
     * set bindPieceCollection.bindPieceIds[0] = pieceWithItemId1
     * set bindPieceCollection.bindPieceIds[1] = pieceWithItemId2
@@ -567,7 +601,7 @@ Feature: Verify Bind Piece feature
       {
         id: "#(pieceWithItemId1)",
         format: "Physical",
-        holdingId: "#(globalHoldingId1)",
+        holdingId: "#(holdingId1)",
         poLineId: "#(poLineId1)",
         displayOnHolding: false,
         enumeration: "333",
@@ -581,7 +615,7 @@ Feature: Verify Bind Piece feature
     Then status 201
     * def prevItemId1 = response.itemId
 
-    # 1.2 Creating second piece with item to bind in Title with 'titleId' with different holding 'globalHoldingId2'
+    # 1.2 Creating second piece with item to bind in Title with 'titleId' with different holding 'holdingId3'
     Given path 'orders/pieces'
     * configure headers = headersUser
     And request
@@ -589,7 +623,7 @@ Feature: Verify Bind Piece feature
       {
         id: "#(pieceWithItemId2)",
         format: "Physical",
-        holdingId: "#(globalHoldingId2)",
+        holdingId: "#(holdingId3)",
         poLineId: "#(poLineId1)",
         displayOnHolding: false,
         enumeration: "444",
@@ -611,8 +645,11 @@ Feature: Verify Bind Piece feature
     * def requestId1 = call uuid
     * def requestId2 = call uuid
 
-    * call createCirculationRequest {id: "#(requestId1)", requesterId: "#(userId)", itemId: "#(prevItemId1)"}
-    * call createCirculationRequest {id: "#(requestId2)", requesterId: "#(userId)", itemId: "#(prevItemId2)"}
+    * table circulationRequestData
+      | id         | requesterId | itemId      | tenantId  |
+      | requestId1 | userId      | prevItemId1 | tenantId1 |
+      | requestId2 | userId      | prevItemId2 | tenantId1 |
+    * def v = call createCirculationRequest circulationRequestData
 
     # 2.2 Verify circulation request with previous item details
     Given path 'circulation', 'requests', requestId1
@@ -630,14 +667,17 @@ Feature: Verify Bind Piece feature
 
 
     # 3. Receive both pieceId1 and pieceId2
-    * def v = call receivePiece { pieceId: "#(pieceWithItemId1)", poLineId: "#(poLineId1)" }
-    * def v = call receivePiece { pieceId: "#(pieceWithItemId2)", poLineId: "#(poLineId1)" }
+    * table receivePieceDetails
+      | pieceId          | poLineId  | holdingId        |
+      | pieceWithItemId1 | poLineId1 | holdingId1 |
+      | pieceWithItemId2 | poLineId1 | holdingId3 |
+    * def v = call receivePieceWithHolding receivePieceDetails
 
 
     # 4. Verify SUCCESS Open Requests for item when request action is 'Do Nothing'
     * def bindPieceCollection = read('classpath:samples/mod-orders/bindPieces/bindPieceCollection.json')
     * set bindPieceCollection.bindItem.barcode = '444444'
-    * set bindPieceCollection.bindItem.holdingId = globalHoldingId1
+    * set bindPieceCollection.bindItem.holdingId = holdingId1
     * set bindPieceCollection.poLineId = poLineId1
     * set bindPieceCollection.bindPieceIds[0] = pieceWithItemId1
     * set bindPieceCollection.bindPieceIds[1] = pieceWithItemId2
@@ -680,24 +720,25 @@ Feature: Verify Bind Piece feature
 
     # 2. Create two pieces with 'pieceId1' and 'pieceId2'
     * table pieces
-      | id       | format     | poLineId  | titleId  | holdingId        |
-      | pieceId1 | "Physical" | poLineId2 | titleId2 | globalHoldingId1 |
-      | pieceId2 | "Physical" | poLineId2 | titleId2 | globalHoldingId2 |
+      | id       | format     | poLineId  | titleId  | holdingId  | receivingTenantId |
+      | pieceId1 | "Physical" | poLineId2 | titleId2 | holdingId1 | tenantId1         |
+      | pieceId2 | "Physical" | poLineId2 | titleId2 | holdingId2 | tenantId2         |
     * def v = call createPieceWithHolding pieces
 
 
     # 3 Receive both pieceId1 and pieceId2
-    * table receiveDetails
-      | pieceId  | poLineId  |
-      | pieceId1 | poLineId2 |
-      | pieceId2 | poLineId2 |
-    * def v = call receivePiece receiveDetails
+    * table receivePieceDetails
+      | pieceId  | poLineId  | holdingId  | tenantId  |
+      | pieceId1 | poLineId2 | holdingId1 | tenantId1 |
+      | pieceId2 | poLineId2 | holdingId2 | tenantId2 |
+    * def v = call receivePieceWithHolding receivePieceDetails
 
 
     # 4. Binding received pieces together for poLineId2 with pieceId1 and pieceId2
     * def bindPieceCollection = read('classpath:samples/mod-orders/bindPieces/bindPieceCollection.json')
     * set bindPieceCollection.poLineId = poLineId2
-    * set bindPieceCollection.bindItem.holdingId = globalHoldingId1
+    * set bindPieceCollection.bindItem.holdingId = holdingId1
+    * set bindPieceCollection.bindItem.tenantId = tenantId1
     * set bindPieceCollection.bindItem.barcode = "123321"
     * set bindPieceCollection.bindPieceIds[0] = pieceId1
     * set bindPieceCollection.bindPieceIds[1] = pieceId2
@@ -719,6 +760,7 @@ Feature: Verify Bind Piece feature
     And match response.isBound == true
     And match response.itemId == '#present'
     And match response.bindItemId == newItemId
+    And match response.bindItemTenantId == tenantId1
 
     Given path 'orders/pieces', pieceId2
     When method GET
@@ -726,15 +768,18 @@ Feature: Verify Bind Piece feature
     And match response.isBound == true
     And match response.itemId == '#present'
     And match response.bindItemId == newItemId
+    And match response.bindItemTenantId == tenantId1
 
 
     # 6. Check item details with 'bindPieceCollection' details after pieces are bound
-    Given path 'item-storage/items', newItemId
-    When method GET
+    Given path 'inventory/tenant-items'
+    And request { tenantItemPairs: [ { tenantId: "#(tenantId1)", itemId: "#(newItemId)" } ] }
+    When method POST
     Then status 200
-    And match response.holdingsRecordId == globalHoldingId1
-    And match response.status.name == 'In process'
-    And match response.barcode == bindPieceCollection.bindItem.barcode
+    And match response.tenantItems[*].item.holdingsRecordId contains holdingId1
+    And match response.tenantItems[*].item.status.name contains 'In process'
+    And match response.tenantItems[*].item.barcode contains bindPieceCollection.bindItem.barcode
+    And match response.tenantItems[*].tenantId contains tenantId1
 
 
     # 7. Verify Title 'bindItemIds' field
@@ -756,6 +801,7 @@ Feature: Verify Bind Piece feature
     And match response.isBound == false
     And match response.itemId == '#present'
     And match response.bindItemId == '#notpresent'
+    And match response.bindItemTenantId == '#notpresent'
 
 
     # 9. Verify Title bindItemIds is not empty as piece2 is still bound
@@ -778,6 +824,7 @@ Feature: Verify Bind Piece feature
     And match response.isBound == false
     And match response.itemId == '#present'
     And match response.bindItemId == '#notpresent'
+    And match response.bindItemTenantId == '#notpresent'
 
 
     # 11. Verify Title bindItemIds is empty as no piece is bound

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/create-circulation-policy.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/create-circulation-policy.feature
@@ -3,9 +3,16 @@ Feature: Reusable function to initi circulation request
 
   Background:
     * url baseUrl
+    * def resourceExists = read('classpath:common/resource-exists.feature')
 
   @CreateLoanPolicy
   Scenario: Create loan policy
+    * table resourceDetails
+      | resourcePath                        | queryVal                               | tenantId |
+      | 'loan-policy-storage/loan-policies' | 'd9cd0bed-1b49-4b5e-a7bd-064b8d177231' | tenant   |
+    * def exists = call resourceExists resourceDetails
+    * if (exists[0].result) karate.abort()
+
     Given path 'loan-policy-storage/loan-policies'
     And header x-okapi-tenant = tenant
     And request
@@ -37,6 +44,12 @@ Feature: Reusable function to initi circulation request
 
   @CreateRequestPolicy
   Scenario: Create request policy
+    * table resourceDetails
+      | resourcePath                              | queryVal                               | tenantId |
+      | 'request-policy-storage/request-policies' | 'd9cd0bed-1b49-4b5e-a7bd-064b8d177231' | tenant   |
+    * def exists = call resourceExists resourceDetails
+    * if (exists[0].result) karate.abort()
+
     Given path 'request-policy-storage/request-policies'
     And header x-okapi-tenant = tenant
     And request
@@ -58,6 +71,12 @@ Feature: Reusable function to initi circulation request
 
   @CreateNoticePolicy
   Scenario: Create notice policy
+    * table resourceDetails
+      | resourcePath                                          | queryVal                               | tenantId |
+      | 'patron-notice-policy-storage/patron-notice-policies' | '122b3d2b-4788-4f1e-9117-56daa91cb75c' | tenant   |
+    * def exists = call resourceExists resourceDetails
+    * if (exists[0].result) karate.abort()
+
     Given path 'patron-notice-policy-storage/patron-notice-policies'
     And header x-okapi-tenant = tenant
     And request
@@ -78,19 +97,25 @@ Feature: Reusable function to initi circulation request
 
   @CreateOverdueFinePolicy
   Scenario: Create overdue fine policy
+    * table resourceDetails
+      | resourcePath             | queryVal                               | tenantId |
+      | 'overdue-fines-policies' | 'cd3f6cac-fa17-4079-9fae-2fb28e521412' | tenant   |
+    * def exists = call resourceExists resourceDetails
+    * if (exists[0].result) karate.abort()
+
     Given path 'overdue-fines-policies'
     And header x-okapi-tenant = tenant
     And request
       """
       {
+        "id": "cd3f6cac-fa17-4079-9fae-2fb28e521412",
         "name": "overdueFinePolicyName",
         "description": "Test overdue fine policy",
         "countClosed": true,
         "maxOverdueFine": 0.0,
         "forgiveOverdueFine": true,
         "gracePeriodRecall": true,
-        "maxOverdueRecallFine": 0.0,
-        "id": "cd3f6cac-fa17-4079-9fae-2fb28e521412"
+        "maxOverdueRecallFine": 0.0
       }
       """
     When method POST
@@ -99,11 +124,18 @@ Feature: Reusable function to initi circulation request
 
   @CreateLostItemFeesPolicy
   Scenario: Create lost item fees policy
+    * table resourceDetails
+      | resourcePath              | queryVal                               | tenantId |
+      | 'lost-item-fees-policies' | 'ed892c0e-52e0-4cd9-8133-c0ef07b4a709' | tenant   |
+    * def exists = call resourceExists resourceDetails
+    * if (exists[0].result) karate.abort()
+
     Given path 'lost-item-fees-policies'
     And header x-okapi-tenant = tenant
     And request
       """
       {
+        "id": "ed892c0e-52e0-4cd9-8133-c0ef07b4a709",
         "name": "lostItemFeesPolicyName",
         "description": "Test lost item fee policy",
         "chargeAmountItem": {
@@ -121,8 +153,7 @@ Feature: Reusable function to initi circulation request
         "replacedLostItemProcessingFee": true,
         "replacementProcessingFee": 0.0,
         "replacementAllowed": true,
-        "lostItemReturned": "Charge",
-        "id": "ed892c0e-52e0-4cd9-8133-c0ef07b4a709"
+        "lostItemReturned": "Charge"
       }
       """
     When method POST

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/create-circulation-request.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/create-circulation-request.feature
@@ -11,9 +11,10 @@ Feature: Reusable function to init circulation request
     * def userId = karate.get('userId', randomUuid)
     * def holdingId = karate.get('holdingId', globalHoldingId1)
     * def instanceId = karate.get('instanceId', globalInstanceId1)
+    * def tenantId = karate.get('tenantId', tenant)
 
     Given path 'circulation/requests'
-    And header x-okapi-tenant = tenant
+    And header x-okapi-tenant = tenantId
     And request
       """
       {

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/create-piece-with-holding.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/create-piece-with-holding.feature
@@ -1,5 +1,5 @@
 Feature: Create piece with holding id
-  # Parameters: pieceId, poLineId, titleId, holdingId, format
+  # Parameters: pieceId, poLineId, titleId, holdingId, receivingTenantId, format
 
   Background:
     * url baseUrl
@@ -9,6 +9,7 @@ Feature: Create piece with holding id
     * def poLineId = karate.get('poLineId')
     * def titleId = karate.get('titleId')
     * def holdingId = karate.get('holdingId', globalHoldingId1)
+    * def receivingTenantId = karate.get('receivingTenantId', null)
     * def format = karate.get('format', "Physical")
     Given path 'orders/pieces'
     And request
@@ -18,6 +19,7 @@ Feature: Create piece with holding id
       poLineId: "#(poLineId)",
       titleId: "#(titleId)",
       holdingId: "#(holdingId)",
+      receivingTenantId: "#(receivingTenantId)",
       format: "#(format)"
     }
     """

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/receive-piece-with-holding.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/receive-piece-with-holding.feature
@@ -1,0 +1,39 @@
+Feature: Receive piece with Holding ID
+  # parameters: pieceId, poLineId, holdingId
+
+  Background:
+    * url baseUrl
+
+  Scenario: Receive piece with Holding ID
+    * def holdingId = karate.get('holdingId', globalHoldingId1)
+    * def tenantId = karate.get('tenantId', null)
+    Given path 'orders/check-in'
+    And request
+    """
+      {
+        toBeCheckedIn: [
+          {
+            checkedIn: 1,
+            checkInPieces: [
+              {
+                id: "#(pieceId)",
+                itemStatus: "In process",
+                displayOnHolding: false,
+                enumeration: "#(pieceId)",
+                chronology: "#(pieceId)",
+                supplement: true,
+                discoverySuppress: true,
+                holdingId: "#(holdingId)",
+                receivingTenantId: "#(tenantId)",
+                createItem: "true"
+              }
+            ],
+            poLineId: "#(poLineId)"
+          }
+        ],
+        totalRecords: 1
+      }
+    """
+    When method POST
+    Then status 200
+    And match $.receivingResults[0].processedSuccessfully == 1

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/user-init-data.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/user-init-data.feature
@@ -48,7 +48,8 @@ Feature:
         "id": "#(userId)",
         "username": "#(userName)",
         "departments": [],
-        "externalSystemId": "#(externalId)"
+        "externalSystemId": "#(externalId)",
+        "type": "staff"
       }
       """
     When method POST

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/user-init-data.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/user-init-data.feature
@@ -2,13 +2,15 @@ Feature:
 
   Background:
     * url baseUrl
+    * def resourceExists = read('classpath:common/resource-exists.feature')
 
   @CreateGroup
-  Scenario: Create User Group
+  Scenario: Create User Group if not exists
     * def id = karate.get('id', '3487f367-3c96-4b84-bf2b-20016a84ac55')
     * def group = karate.get('group', 'lib')
+    * def tenantId = karate.get('tenantId', tenant)
     Given path 'groups'
-    And header x-okapi-tenant = tenant
+    And header x-okapi-tenant = tenantId
     And request
       """
       {

--- a/common/src/main/resources/common/resource-exists.feature
+++ b/common/src/main/resources/common/resource-exists.feature
@@ -1,0 +1,12 @@
+Feature: Check if resource exists by a provided field
+  # resourcePath, queryKey, queryVal, tenantId
+
+  Scenario: Check if resource exists
+    * url baseUrl
+    * def queryKey = karate.get('queryKey', 'id');
+    Given path resourcePath
+    And header x-okapi-tenant = tenantId
+    And param query = queryKey + "=" + queryVal
+    When method GET
+    Then status 200
+    * def result = response.totalRecords != 0


### PR DESCRIPTION
## Purpose
[[FAT-16037] Extend Karate coverage for Bind pieces in ECS mode
](https://folio-org.atlassian.net/browse/FAT-16037)

## Approach
- Modify existing bind pieces tests to accept tenants and holdings as parameters
- Run bind pieces tests with ECS params
- Modify existing reusable functions with additional attributes

## Screenshots
Tests that were affected by the changes
![image](https://github.com/user-attachments/assets/c751354e-c3c0-41c6-a2b7-1de5e3e4bba2)
![image](https://github.com/user-attachments/assets/5e91e8f8-66f6-412a-a40c-c784f43703e0)