### PR TITLE
[FAT-16046] Check for null instead of non-present

### DIFF
--- a/mod-fqm-manager/src/main/resources/corsair/mod-fqm-manager/features/query.feature
+++ b/mod-fqm-manager/src/main/resources/corsair/mod-fqm-manager/features/query.feature
@@ -232,7 +232,7 @@ Feature: Query
     And params {includeResults: true, limit: 100, offset:0}
     When method GET
     Then status 200
-    And match $.content contains deep {"users.middle_name":  '#notpresent'}
+    And match $.content contains deep {"users.middle_name": null}
     * def totalRecords = parseInt(response.totalRecords)
     * assert totalRecords > 0
 
@@ -260,7 +260,7 @@ Feature: Query
 #    And params {includeResults: true, limit: 100, offset:0}
 #    When method GET
 #    Then status 200
-#    And match $.content contains deep {user_regions:  '#notpresent'}
+#    And match $.content contains deep {user_regions: null}
 #    * def totalRecords = parseInt(response.totalRecords)
 #    * assert totalRecords > 0
 


### PR DESCRIPTION
`mod-fqm-manager` used to only include non_empty properties during Jackson serialization, however, [this was changed as part of MODFQMMGR-442](https://github.com/folio-org/mod-fqm-manager/commit/f4b54b090b90f910e506fa8421e711f5dfdd4bbd#diff-7bc26be01d3e7c9c566f2a28dc1b5cd87dbdd5cb619184f46eb2bf223bf7825d). This test must be updated to expect this change.