### PR TITLE
[FAT- 16038] - Extend Central Ordering Karate tests coverage

### DIFF
--- a/acquisitions/src/main/resources/samples/consortia/orderLines/multi-tenant-order-line.json
+++ b/acquisitions/src/main/resources/samples/consortia/orderLines/multi-tenant-order-line.json
@@ -24,18 +24,20 @@
   "isPackage": false,
   "locations": [
     {
+      "locationId": "#(centralLocationsId)",
+      "tenantId": null,
+      "quantity": 1,
+      "quantityPhysical": 1
+    },
+    {
       "locationId": "#(centralLocationsId2)",
+      "tenantId": null,
       "quantity": 1,
       "quantityPhysical": 1
     },
     {
       "locationId": "#(centralLocationsId3)",
-      "quantity": 1,
-      "quantityPhysical": 1
-    },
-    {
-      "locationId": "b32c5ce2-6738-42db-a291-2796b1c3c4c4",
-      "tenantId": "TBD",
+      "tenantId": null,
       "quantity": 1,
       "quantityPhysical": 1
     }

--- a/acquisitions/src/main/resources/thunderjet/consortia/consortia-orders-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/consortia-orders-junit.feature
@@ -98,16 +98,16 @@ Feature: mod-consortia integration tests
     * call read('order-utils/organizations.feature')
     * call read('order-utils/orders.feature')
 
-  Scenario: Create and open order
+  Scenario: Open order with locations from different tenants
     Given call read('features/open-order-with-locations-from-different-tenants.feature')
 
   Scenario: Reopen order and change instance connection orderLine
     Given call read('features/reopen-and-change-instance-connection-order-with-locations-from-different-tenants.feature')
 
-  Scenario: Test cross-tenant inventory objects creation when working with pieces
+  Scenario: Piece Api Test for cross tenant envs
     Given call read("features/pieces-api-test-for-cross-tenant-envs.feature")
 
-  Scenario: Test bind pieces features in ECS environment
+  Scenario: Bind pieces features in ECS environment
     Given call read("features/bind-pieces-ecs.feature")
 
   @DestroyData

--- a/acquisitions/src/main/resources/thunderjet/consortia/features/open-order-with-locations-from-different-tenants.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/features/open-order-with-locations-from-different-tenants.feature
@@ -489,6 +489,7 @@ Feature: Open order with member tenant location and verify instance, holding, an
 
 
     ## 2. Open order
+
     Given path 'orders/composite-orders', orderId
     When method GET
     And header x-okapi-tenant = centralTenant
@@ -505,6 +506,7 @@ Feature: Open order with member tenant location and verify instance, holding, an
 
 
     ## 3. Check instanceId in poLine after opening order
+
     Given path 'orders/order-lines', poLineId
     And header x-okapi-tenant = centralTenant
     When method GET
@@ -556,6 +558,7 @@ Feature: Open order with member tenant location and verify instance, holding, an
 
 
     ## 6. Unopen order
+
     Given path 'orders/composite-orders', orderId
     When method GET
     Then status 200
@@ -638,9 +641,9 @@ Feature: Open order with member tenant location and verify instance, holding, an
     Then status 204
 
 
-    ## 7. Verify Instance, No Holdings and No Items in both tenents
+    ## 10. Verify Instance, No Holdings and No Items in both tenents
 
-    ## 7.1 Check 'centralTenant'
+    ## 10.1 Check 'centralTenant'
     Given path 'inventory/instances', poLineInstanceId
     And header x-okapi-tenant = centralTenant
     When method GET
@@ -659,7 +662,7 @@ Feature: Open order with member tenant location and verify instance, holding, an
     When method GET
     And match $.totalRecords == 0
 
-    ## 7.2. Check 'universityTenant'
+    ## 10.2. Check 'universityTenant'
     Given path 'inventory/instances', poLineInstanceId
     And header x-okapi-tenant = universityTenant
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/consortia/features/open-order-with-locations-from-different-tenants.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/features/open-order-with-locations-from-different-tenants.feature
@@ -629,7 +629,6 @@ Feature: Open order with member tenant location and verify instance, holding, an
     Then status 204
 
     ## 9.2 Unopen order
-    * def orderResponse = $
     * set orderResponse.workflowStatus = "Pending"
 
     Given path 'orders/composite-orders', orderId
@@ -639,7 +638,7 @@ Feature: Open order with member tenant location and verify instance, holding, an
     Then status 204
 
 
-    ## 7. Verify Instance, Holdings and No Items in tenents
+    ## 7. Verify Instance, No Holdings and No Items in both tenents
 
     ## 7.1 Check 'centralTenant'
     Given path 'inventory/instances', poLineInstanceId

--- a/acquisitions/src/main/resources/thunderjet/consortia/features/pieces-api-test-for-cross-tenant-envs.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/features/pieces-api-test-for-cross-tenant-envs.feature
@@ -23,18 +23,18 @@ Feature: Pieces API tests for cross-tenant envs
     * def titleId = callonce uuid
     * def pieceId = callonce uuid
 
-    * callonce createOrder { id: #(orderId) }
-    * callonce createOrderLine { id: #(poLineId), orderId: #(orderId), isPackage: True }
-    * callonce createTitle { titleId: #(titleId), poLineId: #(poLineId) }
+    * callonce createOrder { id: '#(orderId)' }
+    * callonce createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', isPackage: True }
+    * callonce createTitle { titleId: '#(titleId)', poLineId: '#(poLineId)' }
 
 
   Scenario: Check ShadowInstance, Holding and Item created in member tenant when creating piece
     # Create a new piece
-    * set minimalPiece.id = pieceId;
-    * set minimalPiece.titleId = titleId;
-    * set minimalPiece.poLineId = poLineId;
-    * set minimalPiece.locationId = universityLocationsId;
-    * set minimalPiece.receivingTenantId = universityTenant;
+    * set minimalPiece.id = pieceId
+    * set minimalPiece.titleId = titleId
+    * set minimalPiece.poLineId = poLineId
+    * set minimalPiece.locationId = universityLocationsId
+    * set minimalPiece.receivingTenantId = universityTenant
     Given path 'orders/pieces'
     And header x-okapi-tenant = centralTenant
     And param createItem = true
@@ -73,6 +73,119 @@ Feature: Pieces API tests for cross-tenant envs
     And match response.items[0].holdingsRecordId == '#(holdingId)'
     And match response.items[0].purchaseOrderLineIdentifier == '#(poLineId)'
 
+  Scenario: Check receivingTenantId populated when openining order with 'Instance, Holding'
+`
+    * def orderId = call uuid
+    * def poLineId = call uuid
+
+    ## 1. Create Order
+    * def v = call createOrder { id: '#(orderId)' }
+
+    ## 2. Create OrderLine
+    ## Set 'universityTenant' and 'centralTenant' tenantId for third location
+    ## to verify this tenant in piece receivingTenatId field
+    * def poLine = read('classpath:samples/consortia/orderLines/multi-tenant-order-line.json')
+    * set poLine.id = poLineId
+    * set poLine.purchaseOrderId = orderId
+    * set poLine.locations[1].tenantId = centralTenant
+    * set poLine.locations[1].locationId = centralLocationsId
+    * set poLine.locations[2].tenantId = universityTenant
+    * set poLine.locations[2].locationId = universityLocationsId
+    * set poLine.physical.createInventory = "Instance, Holding"
+
+    Given path 'orders/order-lines'
+    And request poLine
+    When method POST
+    Then status 201
+
+    ## 3. Open order
+
+    Given path 'orders/composite-orders', orderId
+    When method GET
+    And header x-okapi-tenant = centralTenant
+    Then status 200
+
+    * def orderResponse = $
+    * set orderResponse.workflowStatus = "Open"
+
+    Given path 'orders/composite-orders', orderId
+    And header x-okapi-tenant = centralTenant
+    And request orderResponse
+    When method PUT
+    Then status 204
+
+    Given path 'orders/titles'
+    And param query = 'poLineId==' + poLineId
+    When method GET
+    Then status 200
+    * def title = $.titles[0]
+    * def titleId = title.id
+
+    ## 4. Verify pieces that 'universityTenant' and 'centralTenant' contains in receivingTenantId field
+    Given path 'orders/pieces'
+    And header x-okapi-tenant = centralTenant
+    And param query = 'titleId==' + titleId + ' and poLineId==' + poLineId + ' and receivingStatus==("Expected" or "Late" or "Claim delayed" or "Claim sent")'
+    When method GET
+    Then status 200
+    And match $.pieces[*].receivingTenantId contains universityTenant
+    And match $.pieces[*].receivingTenantId contains centralTenant
+
+  Scenario: Check receivingTenantId populated when openining order with 'Instance, Holding, Item'
+  `
+    * def orderId = call uuid
+    * def poLineId = call uuid
+
+    ## 1. Create Order
+    * def v = call createOrder { id: '#(orderId)' }
+
+    ## 2. Create OrderLine
+    ## Set 'universityTenant' and 'centralTenant' tenantId for third location
+    ## to verify this tenant in piece receivingTenatId field
+    * def poLine = read('classpath:samples/consortia/orderLines/multi-tenant-order-line.json')
+    * set poLine.id = poLineId
+    * set poLine.purchaseOrderId = orderId
+    * set poLine.locations[1].tenantId = centralTenant
+    * set poLine.locations[1].locationId = centralLocationsId
+    * set poLine.locations[2].tenantId = universityTenant
+    * set poLine.locations[2].locationId = universityLocationsId
+    * set poLine.physical.createInventory = "Instance, Holding, Item"
+
+    Given path 'orders/order-lines'
+    And request poLine
+    When method POST
+    Then status 201
+
+    ## 3. Open order
+
+    Given path 'orders/composite-orders', orderId
+    When method GET
+    And header x-okapi-tenant = centralTenant
+    Then status 200
+
+    * def orderResponse = $
+    * set orderResponse.workflowStatus = "Open"
+
+    Given path 'orders/composite-orders', orderId
+    And header x-okapi-tenant = centralTenant
+    And request orderResponse
+    When method PUT
+    Then status 204
+
+    Given path 'orders/titles'
+    And param query = 'poLineId==' + poLineId
+    When method GET
+    Then status 200
+    * def title = $.titles[0]
+    * def titleId = title.id
+
+    ## 4. Verify pieces that 'universityTenant' and 'centralTenant' contains in receivingTenantId field
+    Given path 'orders/pieces'
+    And header x-okapi-tenant = centralTenant
+    And param query = 'titleId==' + titleId + ' and poLineId==' + poLineId + ' and receivingStatus==("Expected" or "Late" or "Claim delayed" or "Claim sent")'
+    When method GET
+    Then status 200
+    And match $.pieces[*].receivingTenantId contains universityTenant
+    And match $.pieces[*].receivingTenantId contains centralTenant
 
   Scenario: Check Holding and Item updated in member tenant when updating piece without itemId and deleteHolding=true
     # Get existing holdingId and itemId in specified tenant
@@ -92,11 +205,11 @@ Feature: Pieces API tests for cross-tenant envs
     Then status 204
 
     # Update existing piece
-    * set minimalPiece.id = pieceId;
-    * set minimalPiece.titleId = titleId;
-    * set minimalPiece.poLineId = poLineId;
-    * set minimalPiece.locationId = universityLocationsId;
-    * set minimalPiece.receivingTenantId = universityTenant;
+    * set minimalPiece.id = pieceId
+    * set minimalPiece.titleId = titleId
+    * set minimalPiece.poLineId = poLineId
+    * set minimalPiece.locationId = universityLocationsId
+    * set minimalPiece.receivingTenantId = universityTenant
     Given path 'orders/pieces', pieceId
     And header x-okapi-tenant = centralTenant
     And param createItem = true
@@ -267,12 +380,12 @@ Feature: Pieces API tests for cross-tenant envs
     And def oldHoldingId = response.holdingId
 
     # Update piece
-    * set minimalPiece.id = pieceId;
-    * set minimalPiece.titleId = titleId;
-    * set minimalPiece.poLineId = poLineId;
-    * set minimalPiece.itemId = oldItemId;
-    * set minimalPiece.locationId = universityLocationsId;
-    * set minimalPiece.receivingTenantId = universityTenant;
+    * set minimalPiece.id = pieceId
+    * set minimalPiece.titleId = titleId
+    * set minimalPiece.poLineId = poLineId
+    * set minimalPiece.itemId = oldItemId
+    * set minimalPiece.locationId = universityLocationsId
+    * set minimalPiece.receivingTenantId = universityTenant
     Given path 'orders/pieces', pieceId
     And header x-okapi-tenant = centralTenant
     And param createItem = true
@@ -330,12 +443,12 @@ Feature: Pieces API tests for cross-tenant envs
     And def oldHoldingId = response.holdingId
 
     # Update piece
-    * set minimalPiece.id = pieceId;
-    * set minimalPiece.titleId = titleId;
-    * set minimalPiece.poLineId = poLineId;
-    * set minimalPiece.itemId = oldItemId;
-    * set minimalPiece.locationId = universityLocationsId;
-    * set minimalPiece.receivingTenantId = universityTenant;
+    * set minimalPiece.id = pieceId
+    * set minimalPiece.titleId = titleId
+    * set minimalPiece.poLineId = poLineId
+    * set minimalPiece.itemId = oldItemId
+    * set minimalPiece.locationId = universityLocationsId
+    * set minimalPiece.receivingTenantId = universityTenant
     Given path 'orders/pieces', pieceId
     And header x-okapi-tenant = centralTenant
     And param createItem = true
@@ -478,10 +591,10 @@ Feature: Pieces API tests for cross-tenant envs
 
     # 3.1 Create piece for central
     * def centralPieceId = call uuid
-    * set minimalPiece.id = centralPieceId;
-    * set minimalPiece.titleId = titleId;
-    * set minimalPiece.poLineId = poLineId;
-    * set minimalPiece.locationId = centralLocationsId;
+    * set minimalPiece.id = centralPieceId
+    * set minimalPiece.titleId = titleId
+    * set minimalPiece.poLineId = poLineId
+    * set minimalPiece.locationId = centralLocationsId
     Given path 'orders/pieces'
     And header x-okapi-tenant = centralTenant
     And param createItem = true
@@ -497,11 +610,11 @@ Feature: Pieces API tests for cross-tenant envs
 
     # 3.2 Create piece for university
     * def universityPieceId = call uuid
-    * set minimalPiece.id = universityPieceId;
-    * set minimalPiece.titleId = titleId;
-    * set minimalPiece.poLineId = poLineId;
-    * set minimalPiece.locationId = universityLocationsId;
-    * set minimalPiece.receivingTenantId = universityTenant;
+    * set minimalPiece.id = universityPieceId
+    * set minimalPiece.titleId = titleId
+    * set minimalPiece.poLineId = poLineId
+    * set minimalPiece.locationId = universityLocationsId
+    * set minimalPiece.receivingTenantId = universityTenant
     Given path 'orders/pieces'
     And header x-okapi-tenant = centralTenant
     And param createItem = true
@@ -557,12 +670,12 @@ Feature: Pieces API tests for cross-tenant envs
     And match response.circulationRequests[*].id contains requestId2
 
   Scenario: Change affiliation in Piece and check that item and holding was re-created in correct tenant
-    # Create a new piece
-    * set minimalPiece.id = pieceId;
-    * set minimalPiece.titleId = titleId;
-    * set minimalPiece.poLineId = poLineId;
-    * set minimalPiece.locationId = universityLocationsId;
-    * set minimalPiece.receivingTenantId = universityTenant;
+    # Create piece for central
+    * set minimalPiece.id = pieceId
+    * set minimalPiece.titleId = titleId
+    * set minimalPiece.poLineId = poLineId
+    * set minimalPiece.locationId = universityLocationsId
+    * set minimalPiece.receivingTenantId = universityTenant
     Given path 'orders/pieces'
     And header x-okapi-tenant = centralTenant
     And param createItem = true
@@ -570,11 +683,9 @@ Feature: Pieces API tests for cross-tenant envs
     When method POST
     Then status 201
     And match response.id == '#(pieceId)'
-    And match response.poLineId == '#(poLineId)'
-    And match response.titleId == '#(titleId)'
     And match response.itemId == '#present'
     And match response.holdingId == '#present'
-    And match response.receivingTenantId == '#(universityTenant)'
+    And def itemId1 = response.itemId
     And def holdingId = response.holdingId
 
     # Check the created holding record in specified tenant
@@ -609,6 +720,8 @@ Feature: Pieces API tests for cross-tenant envs
     And def pieceResponse = response
 
     * set pieceResponse.receivingTenantId = centralTenant
+    * set pieceResponse.locationId = centralLocationsId
+    * set pieceResponse.holdingId = null
 
     Given path 'orders/pieces', pieceId
     And header x-okapi-tenant = centralTenant
@@ -616,8 +729,16 @@ Feature: Pieces API tests for cross-tenant envs
     When method PUT
     Then status 204
 
+    # Verify changing of holding
+    Given path 'orders/pieces', pieceId
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    And match holdingId != response.holdingId
+    And def centralHoldingId = response.holdingId
+
     # Check the created holding record in 'centralTenant'
-    Given path '/holdings-storage/holdings/', holdingId
+    Given path '/holdings-storage/holdings/', centralHoldingId
     And header x-okapi-tenant = centralTenant
     When method GET
     Then status 200
@@ -632,9 +753,31 @@ Feature: Pieces API tests for cross-tenant envs
     # Check the created item in 'centralTenant'
     Given path '/inventory/items'
     And header x-okapi-tenant = centralTenant
-    And param query = 'holdingsRecordId=' + holdingId
+    And param query = 'holdingsRecordId=' + centralHoldingId
     When method GET
     Then status 200
     And match response.totalRecords == 1
-    And match response.items[0].holdingsRecordId == '#(holdingId)'
+    And match response.items[0].holdingsRecordId == '#(centralHoldingId)'
     And match response.items[0].purchaseOrderLineIdentifier == '#(poLineId)'
+
+    # Verify that existing shared holding and item, and deletion of items in 'univeristyTenant'
+    Given path '/holdings-storage/holdings/', holdingId
+    And header x-okapi-tenant = universityTenant
+    When method GET
+    Then status 200
+    And match response.instanceId == '#present'
+    And def instanceId = response.instanceId
+
+    # Check the existing shared instance in 'univeristyTenant'
+    Given path '/instance-storage/instances', instanceId
+    And header x-okapi-tenant = universityTenant
+    When method GET
+    Then status 200
+
+    # Verify no item in 'univeristyTenant'
+    Given path '/inventory/items'
+    And header x-okapi-tenant = universityTenant
+    And param query = 'holdingsRecordId=' + holdingId
+    When method GET
+    Then status 200
+    And match response.totalRecords == 0

--- a/acquisitions/src/main/resources/thunderjet/consortia/features/pieces-api-test-for-cross-tenant-envs.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/features/pieces-api-test-for-cross-tenant-envs.feature
@@ -99,7 +99,6 @@ Feature: Pieces API tests for cross-tenant envs
     Then status 201
 
     ## 3. Open order
-
     Given path 'orders/composite-orders', orderId
     When method GET
     And header x-okapi-tenant = centralTenant
@@ -156,7 +155,6 @@ Feature: Pieces API tests for cross-tenant envs
     Then status 201
 
     ## 3. Open order
-
     Given path 'orders/composite-orders', orderId
     When method GET
     And header x-okapi-tenant = centralTenant
@@ -670,7 +668,7 @@ Feature: Pieces API tests for cross-tenant envs
     And match response.circulationRequests[*].id contains requestId2
 
   Scenario: Change affiliation in Piece and check that item and holding was re-created in correct tenant
-    # Create piece for central
+    # 1. Create piece for central
     * set minimalPiece.id = pieceId
     * set minimalPiece.titleId = titleId
     * set minimalPiece.poLineId = poLineId
@@ -688,7 +686,7 @@ Feature: Pieces API tests for cross-tenant envs
     And def itemId1 = response.itemId
     And def holdingId = response.holdingId
 
-    # Check the created holding record in specified tenant
+    # 2.1 Check the created holding record in specified tenant
     Given path '/holdings-storage/holdings/', holdingId
     And header x-okapi-tenant = universityTenant
     When method GET
@@ -696,13 +694,13 @@ Feature: Pieces API tests for cross-tenant envs
     And match response.instanceId == '#present'
     And def instanceId = response.instanceId
 
-    # Check the created shared instance in specified tenant
+    # 2.2 Check the created shared instance in specified tenant
     Given path '/instance-storage/instances', instanceId
     And header x-okapi-tenant = universityTenant
     When method GET
     Then status 200
 
-    # Check the created item in specified tenant
+    # 2.3 Check the created item in specified tenant
     Given path '/inventory/items'
     And header x-okapi-tenant = universityTenant
     And param query = 'holdingsRecordId=' + holdingId
@@ -712,7 +710,7 @@ Feature: Pieces API tests for cross-tenant envs
     And match response.items[0].holdingsRecordId == '#(holdingId)'
     And match response.items[0].purchaseOrderLineIdentifier == '#(poLineId)'
 
-    # Change affliation in the piece
+    # 3. Change affliation in the piece
     Given path 'orders/pieces', pieceId
     And header x-okapi-tenant = centralTenant
     When method GET
@@ -729,7 +727,7 @@ Feature: Pieces API tests for cross-tenant envs
     When method PUT
     Then status 204
 
-    # Verify changing of holding
+    # 4.1 Verify changing of holding
     Given path 'orders/pieces', pieceId
     And header x-okapi-tenant = centralTenant
     When method GET
@@ -737,20 +735,20 @@ Feature: Pieces API tests for cross-tenant envs
     And match holdingId != response.holdingId
     And def centralHoldingId = response.holdingId
 
-    # Check the created holding record in 'centralTenant'
+    # 4.2 Check the created holding record in 'centralTenant'
     Given path '/holdings-storage/holdings/', centralHoldingId
     And header x-okapi-tenant = centralTenant
     When method GET
     Then status 200
     And match response.instanceId == '#present'
 
-    # Check the created shared instance in 'centralTenant'
+    # 4.3 Check the created shared instance in 'centralTenant'
     Given path '/instance-storage/instances', instanceId
     And header x-okapi-tenant = centralTenant
     When method GET
     Then status 200
 
-    # Check the created item in 'centralTenant'
+    # 4.4 Check the created item in 'centralTenant'
     Given path '/inventory/items'
     And header x-okapi-tenant = centralTenant
     And param query = 'holdingsRecordId=' + centralHoldingId
@@ -760,7 +758,7 @@ Feature: Pieces API tests for cross-tenant envs
     And match response.items[0].holdingsRecordId == '#(centralHoldingId)'
     And match response.items[0].purchaseOrderLineIdentifier == '#(poLineId)'
 
-    # Verify that existing shared holding and item, and deletion of items in 'univeristyTenant'
+    # 5.1 Verify that existing shared holding and item, and deletion of items in 'univeristyTenant'
     Given path '/holdings-storage/holdings/', holdingId
     And header x-okapi-tenant = universityTenant
     When method GET
@@ -768,13 +766,13 @@ Feature: Pieces API tests for cross-tenant envs
     And match response.instanceId == '#present'
     And def instanceId = response.instanceId
 
-    # Check the existing shared instance in 'univeristyTenant'
+    # 5.2 Check the existing shared instance in 'univeristyTenant'
     Given path '/instance-storage/instances', instanceId
     And header x-okapi-tenant = universityTenant
     When method GET
     Then status 200
 
-    # Verify no item in 'univeristyTenant'
+    # 5.3 Verify no item in 'univeristyTenant'
     Given path '/inventory/items'
     And header x-okapi-tenant = universityTenant
     And param query = 'holdingsRecordId=' + holdingId

--- a/acquisitions/src/main/resources/thunderjet/consortia/features/reopen-and-change-instance-connection-order-with-locations-from-different-tenants.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/features/reopen-and-change-instance-connection-order-with-locations-from-different-tenants.feature
@@ -12,6 +12,8 @@ Feature: Open order with member tenant location and verify instance, holding, an
 
     * def fundId = callonce uuid1
     * def budgetId = callonce uuid2
+    * def instanceId1 = callonce uuid3
+    * def instanceId2 = callonce uuid4
 
     * def orderId = call uuid
     * def poLineId = call uuid
@@ -30,6 +32,12 @@ Feature: Open order with member tenant location and verify instance, holding, an
     When method GET
     Then status 200
 
+    ## Create new instance
+    * table instances
+      | id                | title        | instanceTypeId        |
+      | instanceId1       | 'instance 1' | centralInstanceTypeId |
+      | instanceId2       | 'instance 2' | centralInstanceTypeId |
+    * def v = call createInstance instances
 
   Scenario: Verify existance of Inventory in member tenant after reopining order with deleteHoldings=true
 
@@ -200,7 +208,7 @@ Feature: Open order with member tenant location and verify instance, holding, an
     And match $.totalRecords == 2
 
 
-  Scenario: Change instance connection for the order to some member tenant, where the shadow instance is located.
+  Scenario: Change instance connection 'MOVE' for the order to some member tenant, where the shadow instance is located.
   Verify that associated holdings and items moved to the same tenant
 
     ## 1. Create Order and orderLine
@@ -375,7 +383,8 @@ Feature: Open order with member tenant location and verify instance, holding, an
     Then status 200
 
 
-    ## 7. Change 'first' poLine instance 'centralInstanceId1' connection to the 'centralInstanceId2' that has shadow instance in 'universityTenant
+    ## 7. Change 'first' poLine instance 'centralInstanceId1' connection to the 'centralInstanceId2'
+    ## that has shadow instance in 'universityTenant
 
     * def requestEntity = { operation: 'Replace Instance Ref', replaceInstanceRef: { holdingsOperation: 'Move', newInstanceId: '#(centralPoLinInstanceId2)' }}
 
@@ -454,3 +463,397 @@ Feature: Open order with member tenant location and verify instance, holding, an
     When method GET
     Then status 200
 
+  Scenario: Change instance connection 'FIND_OR_CREATE' for the order to some member tenant, where the shadow instance is located.
+  Verify that associated holdings and items moved to the same tenant
+
+    ## 1. Create Order and orderLine
+
+    # 1.1 Create orders
+    * def v = call createOrder { id: '#(orderId)', vendor: '#(centralVendorId)', orderType: 'One-Time', ongoing: null }
+
+    # 1.2 Create order lines with location in member and newly created holdingId in central tenant
+    Given path 'orders/order-lines'
+
+    * def orderLine = read('classpath:samples/consortia/orderLines/multi-tenant-order-line.json')
+    * set orderLine.id = poLineId
+    * set orderLine.purchaseOrderId = orderId
+    * set orderLine.cost.listUnitPrice = 100
+    * set orderLine.fundDistribution[0].fundId = fundId
+    * set orderLine.locations[2].tenantId = universityTenant
+    * set orderLine.locations[2].locationId = universityLocationsId
+    * set orderLine.titleOrPackage = 'title 1'
+
+    And header x-okapi-tenant = centralTenant
+    And request orderLine
+    When method POST
+    Then status 201
+
+    ## 2. Open order
+
+    Given path 'orders/composite-orders', orderId
+    When method GET
+    And header x-okapi-tenant = centralTenant
+    Then status 200
+
+    * def orderResponse = $
+    * set orderResponse.workflowStatus = "Open"
+
+    Given path 'orders/composite-orders', orderId
+    And header x-okapi-tenant = centralTenant
+    And request orderResponse
+    When method PUT
+    Then status 204
+
+
+    ## 3. Verify Instance, Holding, Item in 'centralTenant'
+
+    # 3.1 Check the order line have an instanceId 'centralInstanceId1'
+    Given path 'orders/order-lines', poLineId
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    And match $.instanceId == '#present'
+    * def centralPoLinInstanceId1 = $.instanceId
+
+    # 3.2 Check instances in 'centralTenant'
+    Given path 'inventory/instances', centralPoLinInstanceId1
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+
+    # 3.3 Check holdings with location in 'centralTenat'
+    Given path 'holdings-storage/holdings'
+    And param query = 'instanceId==' + centralPoLinInstanceId1
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    And match $.totalRecords == 2
+    * def centralPoLineHoldingId1 = response.holdingsRecords[0].id
+    * def centralPoLineHoldingId2 = response.holdingsRecords[1].id
+
+    # 3.4 Check items in 'centralTenant'
+    Given path 'inventory/items'
+    And param query = 'purchaseOrderLineIdentifier==' + poLineId
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    And match $.totalRecords == 2
+    * def centralPoLineItemId1 = response.items[0].id
+    * def centralPoLineItemId2 = response.items[1].id
+
+
+    ## 4. Verify Shadow Instance, Holding, Item in 'universityTenant'
+
+    # 4.1 Check instances in 'universityTenant'
+    Given path 'inventory/instances', centralPoLinInstanceId1
+    And header x-okapi-tenant = universityTenant
+    When method GET
+    Then status 200
+
+    # 4.2 Check holdings with location in 'universityTenant'
+    Given path 'holdings-storage/holdings'
+    And param query = 'instanceId==' + centralPoLinInstanceId1
+    And header x-okapi-tenant = universityTenant
+    When method GET
+    Then status 200
+    And match $.totalRecords == 2
+    * def universityPoLineHoldingId1 = response.holdingsRecords[0].id
+    * def universityPoLineHoldingId2 = response.holdingsRecords[1].id
+
+    # 4.3 Check items in 'universityTenant'
+    Given path 'inventory/items'
+    And header x-okapi-tenant = universityTenant
+    And param query = 'purchaseOrderLineIdentifier==' + poLineId
+    When method GET
+    And match $.totalRecords == 2
+    * def universityPoLineItemId1 = response.items[0].id
+    * def universityPoLineItemId2 = response.items[1].id
+
+    ## 5. Change 'first' poLine instance 'centralInstanceId1' connection to the 'instanceId1'
+    ## that has shadow instance in 'universityTenant
+    * def requestEntity = { operation: 'Replace Instance Ref', replaceInstanceRef: { holdingsOperation: 'Find or Create', newInstanceId: '#(instanceId1)' }}
+
+    Given path 'orders/order-lines', poLineId
+    And header x-okapi-tenant = centralTenant
+    And request requestEntity
+    When method PATCH
+    Then status 204
+
+    # 5.2 Check instance moving from 'centralPoLinInstanceId1' to 'instanceId1'
+    Given path 'orders/order-lines', poLineId
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    And match $.instanceId == instanceId1
+
+    ## 6. Verify Instance, Holdings and Items 'centralTenant'
+    Given path 'inventory/instances', instanceId1
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+
+    ## 6.1 Check both Holdings moved to 'instanceId1'
+    Given path 'holdings-storage/holdings'
+    And param query = 'instanceId==' + instanceId1
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    And match $.totalRecords == 2
+    * def newCentralPoLineHoldingId1 = response.holdingsRecords[0].id
+    * def newCentralPoLineHoldingId2 = response.holdingsRecords[1].id
+
+    Given path 'holdings-storage/holdings', newCentralPoLineHoldingId1
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    And match $.instanceId == instanceId1
+
+    Given path 'holdings-storage/holdings', newCentralPoLineHoldingId2
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    And match $.instanceId == instanceId1
+
+    ## 6.2 Check both items moved to new holding
+    Given path 'inventory/items'
+    And param query = 'purchaseOrderLineIdentifier==' + poLineId
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    And match $.items[*].holdingsRecordId contains newCentralPoLineHoldingId1
+    And match $.items[*].holdingsRecordId contains newCentralPoLineHoldingId2
+
+
+    ## 7. Verify Shadow Instance, Holdings and items moving from 'centralPoLinInstanceId1' to 'instanceId1'
+    ## after changing instance connection in 'universityTenant'
+
+    Given path 'inventory/instances', instanceId1
+    And header x-okapi-tenant = universityTenant
+    When method GET
+    Then status 200
+
+    Given path 'holdings-storage/holdings'
+    And param query = 'instanceId==' + instanceId1
+    And header x-okapi-tenant = universityTenant
+    When method GET
+    Then status 200
+    And match $.totalRecords == 2
+    * def newUniversityPoLineHoldingId1 = response.holdingsRecords[0].id
+    * def newUniversityPoLineHoldingId2 = response.holdingsRecords[1].id
+
+    Given path 'holdings-storage/holdings', newUniversityPoLineHoldingId1
+    And header x-okapi-tenant = universityTenant
+    When method GET
+    Then status 200
+    And match $.instanceId == instanceId1
+
+    Given path 'holdings-storage/holdings', newUniversityPoLineHoldingId2
+    And header x-okapi-tenant = universityTenant
+    When method GET
+    Then status 200
+    And match $.instanceId == instanceId1
+
+    ## 7.2 Check both items moved to new holding
+    Given path 'inventory/items'
+    And param query = 'purchaseOrderLineIdentifier==' + poLineId
+    And header x-okapi-tenant = universityTenant
+    When method GET
+    Then status 200
+    And match $.items[*].holdingsRecordId contains newUniversityPoLineHoldingId1
+    And match $.items[*].holdingsRecordId contains newUniversityPoLineHoldingId2
+
+  Scenario: Change instance connection 'CREATE' for the order to some member tenant, where the shadow instance is located.
+  Verify that associated holdings and items moved to the same tenant
+    ## 1. Create Order and orderLine
+
+    # 1.1 Create orders
+    * def v = call createOrder { id: '#(orderId)', vendor: '#(centralVendorId)', orderType: 'One-Time', ongoing: null }
+
+    # 1.2 Create order lines with location in member and newly created holdingId in central tenant
+    Given path 'orders/order-lines'
+
+    * def orderLine = read('classpath:samples/consortia/orderLines/multi-tenant-order-line.json')
+    * set orderLine.id = poLineId
+    * set orderLine.purchaseOrderId = orderId
+    * set orderLine.cost.listUnitPrice = 100
+    * set orderLine.fundDistribution[0].fundId = fundId
+    * set orderLine.locations[2].tenantId = universityTenant
+    * set orderLine.locations[2].locationId = universityLocationsId
+    * set orderLine.titleOrPackage = 'title 1'
+
+    And header x-okapi-tenant = centralTenant
+    And request orderLine
+    When method POST
+    Then status 201
+
+    ## 2. Open order
+
+    Given path 'orders/composite-orders', orderId
+    When method GET
+    And header x-okapi-tenant = centralTenant
+    Then status 200
+
+    * def orderResponse = $
+    * set orderResponse.workflowStatus = "Open"
+
+    Given path 'orders/composite-orders', orderId
+    And header x-okapi-tenant = centralTenant
+    And request orderResponse
+    When method PUT
+    Then status 204
+
+
+    ## 3. Verify Instance, Holding, Item in 'centralTenant'
+
+    # 3.1 Check the order line have an instanceId 'centralInstanceId1'
+    Given path 'orders/order-lines', poLineId
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    And match $.instanceId == '#present'
+    * def centralPoLinInstanceId1 = $.instanceId
+
+    # 3.2 Check instances in 'centralTenant'
+    Given path 'inventory/instances', centralPoLinInstanceId1
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+
+    # 3.3 Check holdings with location in 'centralTenat'
+    Given path 'holdings-storage/holdings'
+    And param query = 'instanceId==' + centralPoLinInstanceId1
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    And match $.totalRecords == 2
+    * def centralPoLineHoldingId1 = response.holdingsRecords[0].id
+    * def centralPoLineHoldingId2 = response.holdingsRecords[1].id
+
+    # 3.4 Check items in 'centralTenant'
+    Given path 'inventory/items'
+    And param query = 'purchaseOrderLineIdentifier==' + poLineId
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    And match $.totalRecords == 2
+    * def centralPoLineItemId1 = response.items[0].id
+    * def centralPoLineItemId2 = response.items[1].id
+
+
+    ## 4. Verify Shadow Instance, Holding, Item in 'universityTenant'
+
+    # 4.1 Check instances in 'universityTenant'
+    Given path 'inventory/instances', centralPoLinInstanceId1
+    And header x-okapi-tenant = universityTenant
+    When method GET
+    Then status 200
+
+    # 4.2 Check holdings with location in 'universityTenant'
+    Given path 'holdings-storage/holdings'
+    And param query = 'instanceId==' + centralPoLinInstanceId1
+    And header x-okapi-tenant = universityTenant
+    When method GET
+    Then status 200
+    And match $.totalRecords == 2
+    * def universityPoLineHoldingId1 = response.holdingsRecords[0].id
+    * def universityPoLineHoldingId2 = response.holdingsRecords[1].id
+
+    # 4.3 Check items in 'universityTenant'
+    Given path 'inventory/items'
+    And header x-okapi-tenant = universityTenant
+    And param query = 'purchaseOrderLineIdentifier==' + poLineId
+    When method GET
+    And match $.totalRecords == 2
+    * def universityPoLineItemId1 = response.items[0].id
+    * def universityPoLineItemId2 = response.items[1].id
+
+    ## 5. Change 'first' poLine instance 'centralInstanceId1' connection to the 'instanceId2'
+    ## that has shadow instance in 'universityTenant
+    * def requestEntity = { operation: 'Replace Instance Ref', replaceInstanceRef: { holdingsOperation: 'Create', newInstanceId: '#(instanceId2)' }}
+
+    Given path 'orders/order-lines', poLineId
+    And header x-okapi-tenant = centralTenant
+    And request requestEntity
+    When method PATCH
+    Then status 204
+
+    # 5.2 Check instance moving from 'centralPoLinInstanceId1' to 'centralPoLinInstanceId2'
+    Given path 'orders/order-lines', poLineId
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    And match $.instanceId == instanceId2
+
+    ## 6. Verify Instance, Holdings and Items 'centralTenant'
+    Given path 'inventory/instances', instanceId1
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+
+    ## 6.1 Check both Holdings moved to 'centralPoLineInstanceId2'
+    Given path 'holdings-storage/holdings'
+    And param query = 'instanceId==' + instanceId2
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    And match $.totalRecords == 2
+    * def newCentralPoLineHoldingId1 = response.holdingsRecords[0].id
+    * def newCentralPoLineHoldingId2 = response.holdingsRecords[1].id
+
+    Given path 'holdings-storage/holdings', newCentralPoLineHoldingId1
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    And match $.instanceId == instanceId2
+
+    Given path 'holdings-storage/holdings', newCentralPoLineHoldingId2
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    And match $.instanceId == instanceId2
+
+    ## 6.2 Check both items moved to new holding
+    Given path 'inventory/items'
+    And param query = 'purchaseOrderLineIdentifier==' + poLineId
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    And match $.items[*].holdingsRecordId contains newCentralPoLineHoldingId1
+    And match $.items[*].holdingsRecordId contains newCentralPoLineHoldingId2
+
+
+    ## 7. Verify Shadow Instance, Holdings and items moving from 'centralPoLinInstanceId1' to 'instanceId1'
+    ## after changing instance connection in 'universityTenant'
+
+    Given path 'inventory/instances', instanceId2
+    And header x-okapi-tenant = universityTenant
+    When method GET
+    Then status 200
+
+    Given path 'holdings-storage/holdings'
+    And param query = 'instanceId==' + instanceId2
+    And header x-okapi-tenant = universityTenant
+    When method GET
+    Then status 200
+    And match $.totalRecords == 2
+    * def newUniversityPoLineHoldingId1 = response.holdingsRecords[0].id
+    * def newUniversityPoLineHoldingId2 = response.holdingsRecords[1].id
+
+    Given path 'holdings-storage/holdings', newUniversityPoLineHoldingId1
+    And header x-okapi-tenant = universityTenant
+    When method GET
+    Then status 200
+    And match $.instanceId == instanceId2
+
+    Given path 'holdings-storage/holdings', newUniversityPoLineHoldingId2
+    And header x-okapi-tenant = universityTenant
+    When method GET
+    Then status 200
+    And match $.instanceId == instanceId2
+
+    ## 7.2 Check both items moved to new holding
+    Given path 'inventory/items'
+    And param query = 'purchaseOrderLineIdentifier==' + poLineId
+    And header x-okapi-tenant = universityTenant
+    When method GET
+    Then status 200
+    And match $.items[*].holdingsRecordId contains newUniversityPoLineHoldingId1
+    And match $.items[*].holdingsRecordId contains newUniversityPoLineHoldingId2

--- a/acquisitions/src/main/resources/thunderjet/consortia/features/reopen-and-change-instance-connection-order-with-locations-from-different-tenants.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/features/reopen-and-change-instance-connection-order-with-locations-from-different-tenants.feature
@@ -765,8 +765,10 @@ Feature: Open order with member tenant location and verify instance, holding, an
     * def universityPoLineItemId1 = response.items[0].id
     * def universityPoLineItemId2 = response.items[1].id
 
+
     ## 5. Change 'first' poLine instance 'centralInstanceId1' connection to the 'instanceId2'
     ## that has shadow instance in 'universityTenant
+
     * def requestEntity = { operation: 'Replace Instance Ref', replaceInstanceRef: { holdingsOperation: 'Create', newInstanceId: '#(instanceId2)' }}
 
     Given path 'orders/order-lines', poLineId
@@ -782,7 +784,9 @@ Feature: Open order with member tenant location and verify instance, holding, an
     Then status 200
     And match $.instanceId == instanceId2
 
+
     ## 6. Verify Instance, Holdings and Items 'centralTenant'
+
     Given path 'inventory/instances', instanceId1
     And header x-okapi-tenant = centralTenant
     When method GET

--- a/mod-consortia/src/main/resources/thunderjet/mod-consortia/consortia-junit.feature
+++ b/mod-consortia/src/main/resources/thunderjet/mod-consortia/consortia-junit.feature
@@ -75,61 +75,89 @@ Feature: mod-consortia integration tests
     # define custom login
     * def login = read('classpath:common-consortia/initData.feature@Login')
 
-  Scenario: Create ['central', 'university', 'college'] tenants and set up admins
-    * call read('classpath:common-consortia/tenant-and-local-admin-setup.feature@SetupTenant') { tenant: '#(centralTenant)', admin: '#(consortiaAdmin)'}
-    * call read('classpath:common-consortia/tenant-and-local-admin-setup.feature@SetupTenant') { tenant: '#(universityTenant)', admin: '#(universityUser1)'}
-    * call read('classpath:common-consortia/tenant-and-local-admin-setup.feature@SetupTenant') { tenant: '#(collegeTenant)', admin: '#(collegeUser1)'}
-
-    # create users in all tenants
-    * call read('classpath:common-consortia/create-users.feature@CreateUsers')
-
-    # add 'consortia.all' (for consortia management) and 'tags.all' (for publish coordinator tests) permissions to main users
-    * call login consortiaAdmin
-    * call read('classpath:common-consortia/initData.feature@PutPermissions') { desiredPermissions: ['consortia.all', 'tags.all']}
-
-    * call login universityUser1
-    * call read('classpath:common-consortia/initData.feature@PutPermissions') { desiredPermissions: ['consortia.all', 'tags.all']}
-
-    * call login collegeUser1
-    * call read('classpath:common-consortia/initData.feature@PutPermissions') { desiredPermissions: ['consortia.all', 'tags.all']}
-
-  Scenario: Consortium api tests
-    * call read('features/consortium.feature')
-
-  Scenario: Tenant api tests
-    * call read('features/tenant.feature')
-
-  Scenario: verify and setup 'consortiaAdmin' for all tenants
-    * call read('features/consortia-admin-verification-and-setup.feature')
-
-  Scenario: verify 'consortia-system-user' in all tenants
-    * call read('features/consortia-system-users-verification.feature')
-
-  Scenario: User-Tenant associations api tests
-    * call read('features/user-tenant-associations.feature')
-
-  Scenario: verify users with shadow or patron types not processed by consortia pipeline
-    * call read('features/consortia-skip-not-required-user-types.feature')
-
-  Scenario: verify user update scenarios
-    * call read('features/consortia-user-update.feature')
-
-  Scenario: verify user type update scenarios
-    * call read('features/consortia-user-type-update.feature')
-
-  Scenario: Publish coordinator tests
-    * call read('features/publish-coordinator.feature')
-
-  Scenario: Sharing Instances api tests
-    * call read('features/sharing-instance.feature')
-
-  Scenario: Sharing Settings api tests
-    * call read('features/sharing-setting.feature')
-
-  Scenario: Sharing Patron Groups Settings api tests
-    * call read('features/sharing-patron-groups-setting.feature')
+#  Scenario: Create ['central', 'university', 'college'] tenants and set up admins
+#    * call read('classpath:common-consortia/tenant-and-local-admin-setup.feature@SetupTenant') { tenant: '#(centralTenant)', admin: '#(consortiaAdmin)'}
+#    * call read('classpath:common-consortia/tenant-and-local-admin-setup.feature@SetupTenant') { tenant: '#(universityTenant)', admin: '#(universityUser1)'}
+#    * call read('classpath:common-consortia/tenant-and-local-admin-setup.feature@SetupTenant') { tenant: '#(collegeTenant)', admin: '#(collegeUser1)'}
+#
+#    # create users in all tenants
+#    * call read('classpath:common-consortia/create-users.feature@CreateUsers')
+#
+#    # add 'consortia.all' (for consortia management) and 'tags.all' (for publish coordinator tests) permissions to main users
+#    * call login consortiaAdmin
+#    * call read('classpath:common-consortia/initData.feature@PutPermissions') { desiredPermissions: ['consortia.all', 'tags.all']}
+#
+#    * call login universityUser1
+#    * call read('classpath:common-consortia/initData.feature@PutPermissions') { desiredPermissions: ['consortia.all', 'tags.all']}
+#
+#    * call login collegeUser1
+#    * call read('classpath:common-consortia/initData.feature@PutPermissions') { desiredPermissions: ['consortia.all', 'tags.all']}
+#
+#  Scenario: Consortium api tests
+#    * call read('features/consortium.feature')
+#
+#  Scenario: Tenant api tests
+#    * call read('features/tenant.feature')
+#
+#  Scenario: verify and setup 'consortiaAdmin' for all tenants
+#    * call read('features/consortia-admin-verification-and-setup.feature')
+#
+#  Scenario: verify 'consortia-system-user' in all tenants
+#    * call read('features/consortia-system-users-verification.feature')
+#
+#  Scenario: User-Tenant associations api tests
+#    * call read('features/user-tenant-associations.feature')
+#
+#  Scenario: verify users with shadow or patron types not processed by consortia pipeline
+#    * call read('features/consortia-skip-not-required-user-types.feature')
+#
+#  Scenario: verify user update scenarios
+#    * call read('features/consortia-user-update.feature')
+#
+#  Scenario: verify user type update scenarios
+#    * call read('features/consortia-user-type-update.feature')
+#
+#  Scenario: Publish coordinator tests
+#    * call read('features/publish-coordinator.feature')
+#
+#  Scenario: Sharing Instances api tests
+#    * call read('features/sharing-instance.feature')
+#
+#  Scenario: Sharing Settings api tests
+#    * call read('features/sharing-setting.feature')
+#
+#  Scenario: Sharing Patron Groups Settings api tests
+#    * call read('features/sharing-patron-groups-setting.feature')
 
   Scenario: Destroy created ['central', 'university', 'college'] tenants
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: '#(universityTenant)'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: '#(collegeTenant)'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: '#(centralTenant)'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1719409122040'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'university1719409122040'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1719912128303'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1719899902762'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1722258079872'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1722261819564'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1722262178666'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1722262570131'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1722331149419'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1722336908779'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1722422118697'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1722429467025'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'university1722258079872'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'university1719912128303'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'university1719899902762'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant8736577701056880039'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant7603423786823616876'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant6921140751453861793'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant5623514250690567528'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant5461225824722944766'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant3789221714791444003'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant4445833120440460974'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant3502621786568451976'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant3139234542087438220'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant2693551796343322237'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant2130648717426472269'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant1847001532379159916'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant331053015990274944'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant304551601843426835'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testmodgobi1722417643263'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testmodgobi1722332157283'}

--- a/mod-consortia/src/main/resources/thunderjet/mod-consortia/consortia-junit.feature
+++ b/mod-consortia/src/main/resources/thunderjet/mod-consortia/consortia-junit.feature
@@ -75,89 +75,61 @@ Feature: mod-consortia integration tests
     # define custom login
     * def login = read('classpath:common-consortia/initData.feature@Login')
 
-#  Scenario: Create ['central', 'university', 'college'] tenants and set up admins
-#    * call read('classpath:common-consortia/tenant-and-local-admin-setup.feature@SetupTenant') { tenant: '#(centralTenant)', admin: '#(consortiaAdmin)'}
-#    * call read('classpath:common-consortia/tenant-and-local-admin-setup.feature@SetupTenant') { tenant: '#(universityTenant)', admin: '#(universityUser1)'}
-#    * call read('classpath:common-consortia/tenant-and-local-admin-setup.feature@SetupTenant') { tenant: '#(collegeTenant)', admin: '#(collegeUser1)'}
-#
-#    # create users in all tenants
-#    * call read('classpath:common-consortia/create-users.feature@CreateUsers')
-#
-#    # add 'consortia.all' (for consortia management) and 'tags.all' (for publish coordinator tests) permissions to main users
-#    * call login consortiaAdmin
-#    * call read('classpath:common-consortia/initData.feature@PutPermissions') { desiredPermissions: ['consortia.all', 'tags.all']}
-#
-#    * call login universityUser1
-#    * call read('classpath:common-consortia/initData.feature@PutPermissions') { desiredPermissions: ['consortia.all', 'tags.all']}
-#
-#    * call login collegeUser1
-#    * call read('classpath:common-consortia/initData.feature@PutPermissions') { desiredPermissions: ['consortia.all', 'tags.all']}
-#
-#  Scenario: Consortium api tests
-#    * call read('features/consortium.feature')
-#
-#  Scenario: Tenant api tests
-#    * call read('features/tenant.feature')
-#
-#  Scenario: verify and setup 'consortiaAdmin' for all tenants
-#    * call read('features/consortia-admin-verification-and-setup.feature')
-#
-#  Scenario: verify 'consortia-system-user' in all tenants
-#    * call read('features/consortia-system-users-verification.feature')
-#
-#  Scenario: User-Tenant associations api tests
-#    * call read('features/user-tenant-associations.feature')
-#
-#  Scenario: verify users with shadow or patron types not processed by consortia pipeline
-#    * call read('features/consortia-skip-not-required-user-types.feature')
-#
-#  Scenario: verify user update scenarios
-#    * call read('features/consortia-user-update.feature')
-#
-#  Scenario: verify user type update scenarios
-#    * call read('features/consortia-user-type-update.feature')
-#
-#  Scenario: Publish coordinator tests
-#    * call read('features/publish-coordinator.feature')
-#
-#  Scenario: Sharing Instances api tests
-#    * call read('features/sharing-instance.feature')
-#
-#  Scenario: Sharing Settings api tests
-#    * call read('features/sharing-setting.feature')
-#
-#  Scenario: Sharing Patron Groups Settings api tests
-#    * call read('features/sharing-patron-groups-setting.feature')
+  Scenario: Create ['central', 'university', 'college'] tenants and set up admins
+    * call read('classpath:common-consortia/tenant-and-local-admin-setup.feature@SetupTenant') { tenant: '#(centralTenant)', admin: '#(consortiaAdmin)'}
+    * call read('classpath:common-consortia/tenant-and-local-admin-setup.feature@SetupTenant') { tenant: '#(universityTenant)', admin: '#(universityUser1)'}
+    * call read('classpath:common-consortia/tenant-and-local-admin-setup.feature@SetupTenant') { tenant: '#(collegeTenant)', admin: '#(collegeUser1)'}
+
+    # create users in all tenants
+    * call read('classpath:common-consortia/create-users.feature@CreateUsers')
+
+    # add 'consortia.all' (for consortia management) and 'tags.all' (for publish coordinator tests) permissions to main users
+    * call login consortiaAdmin
+    * call read('classpath:common-consortia/initData.feature@PutPermissions') { desiredPermissions: ['consortia.all', 'tags.all']}
+
+    * call login universityUser1
+    * call read('classpath:common-consortia/initData.feature@PutPermissions') { desiredPermissions: ['consortia.all', 'tags.all']}
+
+    * call login collegeUser1
+    * call read('classpath:common-consortia/initData.feature@PutPermissions') { desiredPermissions: ['consortia.all', 'tags.all']}
+
+  Scenario: Consortium api tests
+    * call read('features/consortium.feature')
+
+  Scenario: Tenant api tests
+    * call read('features/tenant.feature')
+
+  Scenario: verify and setup 'consortiaAdmin' for all tenants
+    * call read('features/consortia-admin-verification-and-setup.feature')
+
+  Scenario: verify 'consortia-system-user' in all tenants
+    * call read('features/consortia-system-users-verification.feature')
+
+  Scenario: User-Tenant associations api tests
+    * call read('features/user-tenant-associations.feature')
+
+  Scenario: verify users with shadow or patron types not processed by consortia pipeline
+    * call read('features/consortia-skip-not-required-user-types.feature')
+
+  Scenario: verify user update scenarios
+    * call read('features/consortia-user-update.feature')
+
+  Scenario: verify user type update scenarios
+    * call read('features/consortia-user-type-update.feature')
+
+  Scenario: Publish coordinator tests
+    * call read('features/publish-coordinator.feature')
+
+  Scenario: Sharing Instances api tests
+    * call read('features/sharing-instance.feature')
+
+  Scenario: Sharing Settings api tests
+    * call read('features/sharing-setting.feature')
+
+  Scenario: Sharing Patron Groups Settings api tests
+    * call read('features/sharing-patron-groups-setting.feature')
 
   Scenario: Destroy created ['central', 'university', 'college'] tenants
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1719409122040'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'university1719409122040'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1719912128303'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1719899902762'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1722258079872'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1722261819564'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1722262178666'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1722262570131'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1722331149419'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1722336908779'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1722422118697'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'central1722429467025'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'university1722258079872'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'university1719912128303'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'university1719899902762'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant8736577701056880039'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant7603423786823616876'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant6921140751453861793'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant5623514250690567528'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant5461225824722944766'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant3789221714791444003'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant4445833120440460974'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant3502621786568451976'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant3139234542087438220'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant2693551796343322237'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant2130648717426472269'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant1847001532379159916'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant331053015990274944'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testtenant304551601843426835'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testmodgobi1722417643263'}
-    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: 'testmodgobi1722332157283'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: '#(universityTenant)'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: '#(collegeTenant)'}
+    * call read('classpath:common-consortia/initData.feature@DeleteTenant') { tenant: '#(centralTenant)'}


### PR DESCRIPTION
## Purpose
https://folio-org.atlassian.net/browse/FAT-16038
## Approach
- Do unopen the order, check appropriate state of Inventory 
-  Inherit Change instance connection test when order has related items from different 
- Change affiliation in Piece and check that item and holding was re-created in correct 
- Open 1 order with Create Instance, Hodling, Item, and another with Create Instance, Holding. In both cases pieces should have receivingTenantId populated
