### PR TITLE
Enable the ability to run tests without dependency checking

### DIFF
--- a/mod-circulation-storage/src/main/resources/karate-config.js
+++ b/mod-circulation-storage/src/main/resources/karate-config.js
@@ -10,6 +10,10 @@ function fn() {
 
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
+  var testAdminUsername = karate.properties['testAdminUsername'] || 'test-admin';
+  var testAdminPassword = karate.properties['testAdminPassword'] || 'admin';
+  var testUserUsername = karate.properties['testUserUsername'] || 'test-user';
+  var testUserPassword = karate.properties['testUserPassword'] || 'test';
 
   var config = {
     baseUrl: 'http://localhost:9130',
@@ -17,8 +21,8 @@ function fn() {
     prototypeTenant: 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
-    testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},
-    testUser: {tenant: testTenant, name: 'test-user', password: 'test'},
+    testAdmin: {tenant: testTenant, name: testAdminUsername, password: testAdminPassword},
+    testUser: {tenant: testTenant, name: testUserUsername, password: testUserPassword},
 
     // define global features
     login: karate.read('classpath:common/login.feature'),
@@ -82,6 +86,8 @@ function fn() {
     }
     config.prototypeTenant = '${prototypeTenant}';
     karate.configure('ssl',true);
+  } else if(env == 'dev') {
+    config.checkDepsDuringModInstall = 'false'
   } else if (env != null && env.match(/^ec2-\d+/)) {
     // Config for FOLIO CI "folio-integration" public ec2- dns name
     config.baseUrl = 'http://' + env + ':9130';

--- a/mod-circulation-storage/src/main/resources/vega/mod-circulation-storage/circulation-storage-junit.feature
+++ b/mod-circulation-storage/src/main/resources/vega/mod-circulation-storage/circulation-storage-junit.feature
@@ -4,6 +4,11 @@ Feature: mod-circulation-storage integration tests
     * url baseUrl
     * table modules
       | name                      |
+      | 'mod-login'               |
+      | 'mod-permissions'         |
+      | 'mod-users'               |
+      | 'mod-users-bl'            |
+      | 'mod-pubsub'              |
       | 'mod-circulation-storage' |
       | 'mod-inventory-storage'   |
 

--- a/mod-circulation/src/main/resources/karate-config.js
+++ b/mod-circulation/src/main/resources/karate-config.js
@@ -10,6 +10,10 @@ function fn() {
 
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'] || 'testtenant';
+  var testAdminUsername = karate.properties['testAdminUsername'] || 'test-admin';
+  var testAdminPassword = karate.properties['testAdminPassword'] || 'admin';
+  var testUserUsername = karate.properties['testUserUsername'] || 'test-user';
+  var testUserPassword = karate.properties['testUserPassword'] || 'test';
 
   var config = {
     baseUrl: 'http://localhost:9130',
@@ -17,8 +21,8 @@ function fn() {
     prototypeTenant: 'diku',
 
     testTenant: testTenant,
-    testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},
-    testUser: {tenant: testTenant, name: 'test-user', password: 'test'},
+    testAdmin: {tenant: testTenant, name: testAdminUsername, password: testAdminPassword},
+    testUser: {tenant: testTenant, name: testUserUsername, password: testUserPassword},
 
     // define global features
     login: karate.read('classpath:common/login.feature'),
@@ -83,6 +87,8 @@ function fn() {
     }
     config.prototypeTenant = '${prototypeTenant}';
     karate.configure('ssl',true);
+  } else if(env == 'dev') {
+    config.checkDepsDuringModInstall = 'false'
   } else if (env != null && env.match(/^ec2-\d+/)) {
     // Config for FOLIO CI "folio-integration" public ec2- dns name
     config.baseUrl = 'http://' + env + ':9130';

--- a/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
@@ -6,12 +6,18 @@ Feature: mod-circulation integration tests
       | name                      |
       | 'mod-login'               |
       | 'mod-permissions'         |
-      | 'mod-circulation'         |
-      | 'mod-circulation-storage' |
-      | 'mod-inventory'           |
-      | 'mod-inventory-storage'   |
+      | 'mod-users'               |
+      | 'mod-users-bl'            |
+      | 'mod-configuration'       |
+      | 'mod-settings'            |
       | 'okapi'                   |
       | 'mod-pubsub'              |
+      | 'mod-inventory'           |
+      | 'mod-inventory-storage'   |
+      | 'mod-circulation-storage' |
+      | 'mod-circulation'         |
+      | 'mod-feesfines'           |
+      | 'mod-patron-blocks'       |
       | 'mod-calendar'            |
 
     * table userPermissions

--- a/mod-feesfines/src/main/resources/karate-config.js
+++ b/mod-feesfines/src/main/resources/karate-config.js
@@ -10,6 +10,10 @@ function fn() {
 
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
+  var testAdminUsername = karate.properties['testAdminUsername'] || 'test-admin';
+  var testAdminPassword = karate.properties['testAdminPassword'] || 'admin';
+  var testUserUsername = karate.properties['testUserUsername'] || 'test-user';
+  var testUserPassword = karate.properties['testUserPassword'] || 'test';
 
   var config = {
     baseUrl: 'http://localhost:9130',
@@ -17,8 +21,8 @@ function fn() {
     prototypeTenant: 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
-    testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},
-    testUser: {tenant: testTenant, name: 'test-user', password: 'test'},
+    testAdmin: {tenant: testTenant, name: testAdminUsername, password: testAdminPassword},
+    testUser: {tenant: testTenant, name: testUserUsername, password: testUserPassword},
 
     // define global features
     login: karate.read('classpath:common/login.feature'),
@@ -77,6 +81,8 @@ function fn() {
     }
     config.prototypeTenant = '${prototypeTenant}';
     karate.configure('ssl',true);
+  } else if(env == 'dev') {
+    config.checkDepsDuringModInstall = 'false'
   } else if (env != null && env.match(/^ec2-\d+/)) {
     // Config for FOLIO CI "folio-integration" public ec2- dns name
     config.baseUrl = 'http://' + env + ':9130';

--- a/mod-feesfines/src/main/resources/vega/mod-feesfines/feesfines-junit.feature
+++ b/mod-feesfines/src/main/resources/vega/mod-feesfines/feesfines-junit.feature
@@ -6,11 +6,17 @@ Feature: mod-feesfines integration tests
       | name                                                      |
       | 'mod-login'                                               |
       | 'mod-permissions'                                         |
+      | 'mod-users'                                               |
+      | 'mod-users-bl'                                            |
+      | 'mod-configuration'                                       |
+      | 'mod-settings'                                            |
+      | 'mod-pubsub'                                              |
       | 'mod-feesfines'                                           |
       | 'mod-inventory'                                           |
       | 'mod-inventory-storage'                                   |
       | 'mod-circulation'                                         |
       | 'mod-circulation-storage'                                 |
+      | 'mod-calendar'                                            |
       | 'okapi'                                                   |
 
     * table userPermissions

--- a/mod-patron-blocks/src/main/resources/karate-config.js
+++ b/mod-patron-blocks/src/main/resources/karate-config.js
@@ -10,6 +10,10 @@ function fn() {
 
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
+  var testAdminUsername = karate.properties['testAdminUsername'] || 'test-admin';
+  var testAdminPassword = karate.properties['testAdminPassword'] || 'admin';
+  var testUserUsername = karate.properties['testUserUsername'] || 'test-user';
+  var testUserPassword = karate.properties['testUserPassword'] || 'test';
 
   var config = {
     baseUrl: 'http://localhost:9130',
@@ -17,8 +21,8 @@ function fn() {
     prototypeTenant: 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
-    testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},
-    testUser: {tenant: testTenant, name: 'test-user', password: 'test', barcode: 125091},
+    testAdmin: {tenant: testTenant, name: testAdminUsername, password: testAdminPassword},
+    testUser: {tenant: testTenant, name: testUserUsername, password: testUserPassword, barcode: 125091},
 
     // define global features
     login: karate.read('classpath:common/login.feature'),
@@ -80,6 +84,8 @@ function fn() {
     }
     config.prototypeTenant = '${prototypeTenant}';
     karate.configure('ssl',true);
+  } else if(env == 'dev') {
+    config.checkDepsDuringModInstall = 'false'
   } else if (env != null && env.match(/^ec2-\d+/)) {
     // Config for FOLIO CI "folio-integration" public ec2- dns name
     config.baseUrl = 'http://' + env + ':9130';

--- a/mod-patron-blocks/src/main/resources/vega/mod-patron-blocks/patron-blocks-junit.feature
+++ b/mod-patron-blocks/src/main/resources/vega/mod-patron-blocks/patron-blocks-junit.feature
@@ -3,14 +3,21 @@ Feature: mod-patron-blocks integration tests
   Background:
     * url baseUrl
     * table modules
-      | name                    |
-      | 'mod-login'             |
-      | 'mod-permissions'       |
-      | 'mod-patron-blocks'     |
-      | 'mod-inventory'         |
-      | 'mod-inventory-storage' |
-      | 'mod-circulation'       |
-      | 'mod-feesfines'         |
+      | name                      |
+      | 'mod-login'               |
+      | 'mod-permissions'         |
+      | 'mod-users'               |
+      | 'mod-users-bl'            |
+      | 'mod-configuration'       |
+      | 'mod-settings'            |
+      | 'mod-pubsub'              |
+      | 'mod-patron-blocks'       |
+      | 'mod-inventory'           |
+      | 'mod-inventory-storage'   |
+      | 'mod-circulation-storage' |
+      | 'mod-circulation'         |
+      | 'mod-feesfines'           |
+      | 'mod-calendar'            |
 
     * table userPermissions
       | name                                                      |


### PR DESCRIPTION
## Purpose
when enabling modules for a tenant in the karate env "dev", module dependencies are not pulled in.

## Approach
when using the specific karate env "dev", modules are installed without dependency checking in Okapi. It is also possible to target an existing tenant

