### PR TITLE
[MODORDERS-369]. Allow manual setting of workflowStatus via composite_orders API

### DIFF
--- a/acquisitions/src/main/resources/karate-config.js
+++ b/acquisitions/src/main/resources/karate-config.js
@@ -64,10 +64,13 @@ function fn() {
 
     // orders
     createOrder: karate.read('classpath:thunderjet/mod-orders/reusable/create-order.feature'),
-    createOrderLine: karate.read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature'),
+    updateOrder: karate.read('classpath:thunderjet/mod-orders/reusable/update-order.feature'),
     openOrder: read('classpath:thunderjet/mod-orders/reusable/open-order.feature'),
     unopenOrder: read('classpath:thunderjet/mod-orders/reusable/unopen-order.feature'),
     closeOrder: read('classpath:thunderjet/mod-orders/reusable/close-order.feature'),
+    createOrderLine: karate.read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature'),
+    updateOrderLine: karate.read('classpath:thunderjet/mod-orders/reusable/update-order-line.feature'),
+    validateCompositeOrders: karate.read('classpath:thunderjet/mod-orders/reusable/validate-composite-orders.feature'),
 
     // invoices
     createInvoice: read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature'),

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/update-purchase-order-with-order-lines.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/update-purchase-order-with-order-lines.feature
@@ -1,0 +1,73 @@
+# For MODORDERS-369
+Feature: Update purchase order with order lines
+
+  Background:
+    * url baseUrl
+
+    * call login testAdmin
+    * def okapitokenAdmin = okapitoken
+
+    * call login testUser
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json' }
+
+    * configure headers = headersUser
+
+    * callonce variables
+
+  @Positive
+  Scenario: Update purchase order with order lines
+    * def fundId = call uuid
+    * def budgetId = call uuid
+    * def orderId1 = call uuid
+    * def orderId2 = call uuid
+    * def poLineId1 = call uuid
+    * def poLineId2 = call uuid
+
+    ### 1. Create fund and budgets
+    * configure headers = headersAdmin
+    * def v = call createFund { id: '#(fundId)', code: '#(fundId)' }
+    * def v = call createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 1000 }
+    * configure headers = headersUser
+
+    ### 2. Create orders and order lines
+    * def ongoingObj = { "interval": 123, "isSubscription": true, "renewalDate": "2022-05-08T00:00:00.000+00:00" }
+    * table orders
+      | id       | orderId  | orderType  | ongoing    |
+      | orderId1 | orderId1 | 'One-Time' | null       |
+      | orderId2 | orderId2 | 'Ongoing'  | ongoingObj |
+    * def v = call createOrder orders
+
+    * table orderLines
+      | id        | orderId  | orderType  | listUnitPrice |
+      | poLineId1 | orderId1 | 'One-Time' | 50.0          |
+      | poLineId2 | orderId2 | 'Ongoing'  | 50.0          |
+    * def v = call createOrderLine orderLines
+
+    ### 3. Open orders
+    * def v = call openOrder orders
+
+    ### 4. Validate composite orders after opening
+    * table ordersToValidate
+      | id       | workflowStatus | titleOrPackage | paymentStatus      | receiptStatus      |
+      | orderId1 | 'Open'         | 'test'         | 'Awaiting Payment' | 'Awaiting Receipt' |
+      | orderId2 | 'Open'         | 'test'         | 'Ongoing'          | 'Ongoing'          |
+    * def v = call validateCompositeOrders ordersToValidate
+
+    ### 5. Update order lines with cancelled statuses
+    # order workflow status is affected (async processing)
+    * table orderLinesUpdated
+      | id        | titleOrPackage  | paymentStatus | receiptStatus |
+      | poLineId1 | 'testCancelled' | 'Cancelled'   | 'Cancelled'   |
+      | poLineId2 | 'testCancelled' | 'Cancelled'   | 'Cancelled'   |
+    * def v = call updateOrderLine orderLinesUpdated
+
+    ### 6. Validate composite orders after order line update
+    * table compositeOrdersToValidate
+      | id       | workflowStatus | titleOrPackage  | paymentStatus | receiptStatus |
+      | orderId1 | 'Closed'       | 'testCancelled' | 'Cancelled'   | 'Cancelled'   |
+      | orderId2 | 'Closed'       | 'testCancelled' | 'Cancelled'   | 'Cancelled'   |
+    * def v = call validateCompositeOrders compositeOrdersToValidate
+

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/update-purchase-order-workflow-status.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/update-purchase-order-workflow-status.feature
@@ -1,0 +1,88 @@
+# For MODORDERS-369
+Feature: Update purchase order workflow status
+
+  Background:
+    * url baseUrl
+
+    * call login testAdmin
+    * def okapitokenAdmin = okapitoken
+
+    * call login testUser
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json' }
+
+    * configure headers = headersUser
+
+    * callonce variables
+
+  @Positive
+  Scenario: Update purchase order workflow status
+    * def fundId = call uuid
+    * def budgetId = call uuid
+    * def orderId1 = call uuid
+    * def orderId2 = call uuid
+    * def poLineId1 = call uuid
+    * def poLineId2 = call uuid
+
+    ### 1. Create fund and budgets
+    * configure headers = headersAdmin
+    * def v = call createFund { id: '#(fundId)', code: '#(fundId)' }
+    * def v = call createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 1000 }
+    * configure headers = headersUser
+
+    ### 2. Create orders and order lines
+    * def ongoingObj = { "interval": 123, "isSubscription": true, "renewalDate": "2022-05-08T00:00:00.000+00:00" }
+    * table orders
+      | id       | orderId  | orderType  | ongoing    |
+      | orderId1 | orderId1 | 'One-Time' | null       |
+      | orderId2 | orderId2 | 'Ongoing'  | ongoingObj |
+    * def v = call createOrder orders
+
+    * table orderLines
+      | id        | orderId  | orderType  | listUnitPrice |
+      | poLineId1 | orderId1 | 'One-Time' | 50.0          |
+      | poLineId2 | orderId2 | 'Ongoing'  | 50.0          |
+    * def v = call createOrderLine orderLines
+
+    ### 3. Open orders
+    * def v = call openOrder orders
+
+    ### 4. Validate composite orders after opening
+    * table ordersToValidate
+      | id       | workflowStatus | titleOrPackage | paymentStatus      | receiptStatus      |
+      | orderId1 | 'Open'         | 'test'         | 'Awaiting Payment' | 'Awaiting Receipt' |
+      | orderId2 | 'Open'         | 'test'         | 'Ongoing'          | 'Ongoing'          |
+    * def v = call validateCompositeOrders ordersToValidate
+
+    ### 5. Update orders workflow status with Pending (i.e. unopen)
+    # affects order line statuses (sync processing)
+    * table ordersUpdated
+      | id       | workflowStatus |
+      | orderId1 | 'Pending'      |
+      | orderId2 | 'Pending'      |
+    * def v = call updateOrder ordersUpdated
+
+    ### 6. Validate composite orders that only order workflow status is updated
+    * table ordersToValidate
+      | id       | workflowStatus | titleOrPackage | paymentStatus | receiptStatus |
+      | orderId1 | 'Pending'      | 'test'         | 'Pending'     | 'Pending'     |
+      | orderId2 | 'Pending'      | 'test'         | 'Pending'     | 'Pending'     |
+    * def v = call validateCompositeOrders ordersToValidate
+
+    ### 7. Update orders workflow status with Closed
+    # does not affect order line statuses
+    * table ordersUpdated
+      | id       | workflowStatus |
+      | orderId1 | 'Closed'       |
+      | orderId2 | 'Closed'       |
+    * def v = call updateOrder ordersUpdated
+
+    ### 8. Validate composite orders again that only order workflow status is updated
+    * table ordersToValidate
+      | id       | workflowStatus | titleOrPackage | paymentStatus | receiptStatus |
+      | orderId1 | 'Closed'       | 'test'         | 'Pending'     | 'Pending'     |
+      | orderId2 | 'Closed'       | 'test'         | 'Pending'     | 'Pending'     |
+    * def v = call validateCompositeOrders ordersToValidate
+

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/update-order-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/update-order-line.feature
@@ -1,0 +1,23 @@
+@ignore
+Feature: Update order line
+  # parameters: id, titleOrPackage?, paymentStatus?, receiptStatus?, listUnitPrice?
+
+  Background:
+    * url baseUrl
+
+  Scenario: updateOrderLine
+    Given path '/orders/order-lines', id
+    When method GET
+    Then status 200
+
+    * def poLine = $
+    * set poLine.titleOrPackage = karate.get('titleOrPackage', poLine.titleOrPackage)
+    * set poLine.paymentStatus = karate.get('paymentStatus', poLine.paymentStatus)
+    * set poLine.receiptStatus = karate.get('receiptStatus', poLine.receiptStatus)
+    * set poLine.cost.listUnitPrice = karate.get('listUnitPrice', poLine.cost.listUnitPrice)
+    * set poLine.cost.poLineEstimatedPrice = karate.get('listUnitPrice', poLine.cost.listUnitPrice)
+
+    Given path 'orders/order-lines', id
+    And request poLine
+    When method PUT
+    Then status 204

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/update-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/update-order.feature
@@ -1,0 +1,25 @@
+@ignore
+Feature: Update order
+  # parameters: id, vendor?, orderType?, ongoing?, reEncumber?, acqUnitIds?, workflowStatus?
+
+  Background:
+    * url baseUrl
+
+  Scenario: createOrder
+    Given path 'orders/composite-orders', id
+    When method GET
+    Then status 200
+
+    * def order = $
+    * set order.vendor = karate.get('vendor', order.vendor)
+    * set order.orderType = karate.get('orderType', order.orderType)
+    * set order.ongoing = karate.get('ongoing', order.ongoing)
+    * set order.reEncumber = karate.get('reEncumber', order.reEncumber)
+    * set order.acqUnitIds = karate.get('acqUnitIds', order.acqUnitIds)
+    * set order.workflowStatus = karate.get('workflowStatus', order.workflowStatus)
+    * remove order.compositePoLines
+
+    Given path 'orders/composite-orders', id
+    And request order
+    When method PUT
+    Then status 204

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/validate-composite-orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/validate-composite-orders.feature
@@ -1,0 +1,15 @@
+@ignore
+Feature: Validate composite orders
+  # parameters: id, workflowStatus, titleOrPackage, paymentStatus, receiptStatus
+
+  Background:
+    * url baseUrl
+
+  Scenario: validateCompositeOrders
+    Given path 'orders/composite-orders', id
+    When method GET
+    Then status 200
+    And match $.workflowStatus == workflowStatus
+    And match each $.compositePoLines[*].titleOrPackage == titleOrPackage
+    And match each $.compositePoLines[*].paymentStatus == paymentStatus
+    And match each $.compositePoLines[*].receiptStatus == receiptStatus

--- a/acquisitions/src/test/java/org/folio/OrdersApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersApiTest.java
@@ -402,6 +402,16 @@ public class OrdersApiTest extends TestBase {
     runFeatureTest("bind-piece.feature");
   }
 
+  @Test
+  void updatePurchaseOrderWithOrderLines() {
+    runFeatureTest("update-purchase-order-with-order-lines.feature");
+  }
+
+  @Test
+  void updatePurchaseOrderWorkflowStatus() {
+    runFeatureTest("update-purchase-order-workflow-status.feature");
+  }
+
   @BeforeAll
   public void ordersApiTestBeforeAll() {
     runFeature("classpath:thunderjet/mod-orders/orders-junit.feature");


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODORDERS-369>

## Approach

- Add order update tests to verify that changing order workflow status can be done from the API, i.e. no async processing is involved or prevents this action from succeeding
- Add order line update tests which verify that changing order line statuses from the API can affect order workflow status via async processing (Vert.X EventBus) 