### PR TITLE
[URGENT] [BLOCKER] Align Core Platform team name in configuration

### DIFF
--- a/teams-assignment.json
+++ b/teams-assignment.json
@@ -15,7 +15,7 @@
     "slackChannel": "#erm-developers"
   },
   {
-    "team": "Core Platform",
+    "team": "Core: Platform",
     "modules": [
       "mod-configuration",
       "mod-permissions",


### PR DESCRIPTION
## Purpose
Jira Development team was renamed, that breaks CI CD Pipeline
