### PR TITLE
[MODORDERS-1174] Use CQL query to filter pieces based on user affiliations

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/consortia/consortia-orders-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/consortia-orders-junit.feature
@@ -89,13 +89,16 @@ Feature: mod-consortia integration tests
   @SetupConsortia
   Scenario: Setup Consortia
     # 1. Create Consortia
-    * call read('tenant-utils/consortium.feature')
+    * call read('tenant-utils/consortium.feature@CreateConsortium')
 
     # 2. Add 2 tenants to consortium
     * call read('tenant-utils/tenant.feature')
 
     # 3. Add permissions to consortia_admin
     * call read('tenant-utils/add-permissions-for-admin.feature')
+
+    # 4. Enable central ordering
+    * call read('tenant-utils/consortium.feature@EnableCentralOrdering')
 
   @InitData
   Scenario: Prepare data

--- a/acquisitions/src/main/resources/thunderjet/consortia/features/pieces-api-test-for-cross-tenant-envs.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/features/pieces-api-test-for-cross-tenant-envs.feature
@@ -811,7 +811,7 @@ Feature: Pieces API tests for cross-tenant envs
     And param query = 'titleId==' + titleId2
     When method GET
     Then status 200
-    And match response.totalRecords == 3
+    And match response.totalRecords == 2
     And match response.pieces == '#[2]'
     And match response.pieces[*].id contains pieceId1
     And match response.pieces[*].id contains pieceId2

--- a/acquisitions/src/main/resources/thunderjet/consortia/tenant-utils/consortium.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/tenant-utils/consortium.feature
@@ -5,6 +5,7 @@ Feature: Consortium object in mod-consortia api tests
     * call login consortiaAdmin
     * configure headers = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(centralTenant)', 'Accept': 'application/json' }
 
+  @CreateConsortium
   Scenario: Create, Read, Update a consortium for positive cases
     * def consortiumName = 'Consortium name for test'
 
@@ -13,3 +14,10 @@ Feature: Consortium object in mod-consortia api tests
     And request { id: '#(consortiumId)', name: '#(consortiumName)' }
     When method POST
     And match response == { id: '#(consortiumId)', name: '#(consortiumName)' }
+
+  @EnableCentralOrdering
+  Scenario: Enable central ordering for a consortium
+    Given path '/orders-storage/settings'
+    And request { key: 'ALLOW_ORDERING_WITH_AFFILIATED_LOCATIONS', value: 'true' }
+    When method POST
+    Then status 201


### PR DESCRIPTION
## Purpose
[[MODORDERS-1174] Filter pieces based on user affiliations](https://folio-org.atlassian.net/browse/MODORDERS-1174)

## Approach
- Update tests to enable central ordering and filter pieces correctly

## Screenshots
### ConsortiaOrdersApiTest
![image](https://github.com/user-attachments/assets/79e86419-280a-418a-990f-7a7286e7fa22)