### PR TITLE
FAT-16870 - MODSENDER-69 - Update the permission name.

### DIFF
--- a/mod-sender/src/main/resources/vega/mod-sender/sender-junit.feature
+++ b/mod-sender/src/main/resources/vega/mod-sender/sender-junit.feature
@@ -11,7 +11,7 @@ Feature: mod-sender integration tests
 
     * table userPermissions
       | name                                |
-      | 'sender.message-delivery'           |
+      | 'sender.message-delivery.post'      |
       | 'users.item.post'                   |
 
   Scenario: create tenant and users for testing


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/FAT-16870

## Purpose
Update the mod-sender permission as part of https://folio-org.atlassian.net/browse/MODSENDER-69

## Approach
Merge at the same time as https://github.com/folio-org/mod-sender/pull/59

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
