### PR TITLE
FAT-16833: Update permission for "POST:/instance-storage/batch/synchronous" endpoint.

### DIFF
--- a/mod-search/src/test/resources/spitfire/mod-search/set-up/tenant-init.feature
+++ b/mod-search/src/test/resources/spitfire/mod-search/set-up/tenant-init.feature
@@ -23,7 +23,7 @@ Feature: Tenant initialization for tests
       | 'search.resources.ids.jobs.get'                           |
       | 'inventory-storage.items.batch.post'                      |
       | 'inventory-storage.holdings.batch.post'                   |
-      | 'inventory-storage.instances.batch.synchronous.post'                  |
+      | 'inventory-storage.instances.batch.synchronous.post'      |
       | 'inventory-storage.authorities.item.post'                 |
       | 'inventory-storage.instances.item.delete'                 |
       | 'inventory-storage.holdings.item.delete'                  |

--- a/mod-search/src/test/resources/spitfire/mod-search/set-up/tenant-init.feature
+++ b/mod-search/src/test/resources/spitfire/mod-search/set-up/tenant-init.feature
@@ -23,7 +23,7 @@ Feature: Tenant initialization for tests
       | 'search.resources.ids.jobs.get'                           |
       | 'inventory-storage.items.batch.post'                      |
       | 'inventory-storage.holdings.batch.post'                   |
-      | 'inventory-storage.instances.batch.post'                  |
+      | 'inventory-storage.instances.batch.synchronous.post'                  |
       | 'inventory-storage.authorities.item.post'                 |
       | 'inventory-storage.instances.item.delete'                 |
       | 'inventory-storage.holdings.item.delete'                  |


### PR DESCRIPTION
## Purpose
[FAT-16833](https://folio-org.atlassian.net/browse/FAT-16833)
Update the permissions in the Karate tests, as the permissions for mod-inventory-storage  have been changed

## Approach
update the feature file with the new permission for the mod-inventory-storage endpoint:
| Method  | Endpoint | Permission|
| ------------- | ------------- | ------------- |
| POST  | /instance-storage/batch/synchronous | inventory-storage.instances.batch.synchronous.post|

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
