### PR TITLE
[MODINVOSTO-187] Increase retry intervals for audit event testing

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/audit-event-invoice-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/audit-event-invoice-line.feature
@@ -5,7 +5,7 @@ Feature: Audit events for Invoice Line
     * url baseUrl
     * callonce login testUser
     * configure headers = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json' }
-    * configure retry = { count: 10, interval: 5000 }
+    * configure retry = { count: 10, interval: 10000 }
 
     ### Before All ###
     * callonce variables

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/audit-event-invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/audit-event-invoice.feature
@@ -5,7 +5,7 @@ Feature: Audit events for Invoice
     * url baseUrl
     * callonce login testUser
     * configure headers = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json' }
-    * configure retry = { count: 10, interval: 5000 }
+    * configure retry = { count: 10, interval: 10000 }
 
     ### Before All ###
     * callonce variables


### PR DESCRIPTION
## Purpose
[[MODINVOSTO-187] Implement audit outbox pattern for sending kafka events about invoice updates](https://folio-org.atlassian.net/browse/MODINVOSTO-187)
[[MODINVOSTO-188] Implement audit outbox pattern for sending kafka events about invoice line updates](https://folio-org.atlassian.net/browse/MODINVOSTO-188)

## Approach
- Increase time interval to let audit consumer process events

## Associated Reports
https://folio-org.atlassian.net/browse/FAT-17421
https://folio-org.atlassian.net/browse/FAT-17422

## Screenshots
![image](https://github.com/user-attachments/assets/6b86d34e-0efe-4247-84d1-4b807d75b0e8)