### PR TITLE
MODLD-596: mod-linked-data - Fix Gatling performance test

### DIFF
--- a/mod-linked-data/src/main/resources/citation/mod-linked-data/create-ref-data.feature
+++ b/mod-linked-data/src/main/resources/citation/mod-linked-data/create-ref-data.feature
@@ -2,7 +2,7 @@ Feature: Create refrerence data
 
   Background:
     * url baseUrl
-    * call login testUser
+    * callonce login testUser
     * def testUserHeaders = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': '*/*' }
     * configure headers = testUserHeaders
 

--- a/mod-linked-data/src/main/resources/citation/mod-linked-data/features/create-bib-api/create-bib-api.feature
+++ b/mod-linked-data/src/main/resources/citation/mod-linked-data/features/create-bib-api/create-bib-api.feature
@@ -1,0 +1,12 @@
+Feature: Create Work and Instance resource using API & validate that they is created in mod-inventory and mod-search
+
+  Background:
+    * url baseUrl
+    * callonce login testUser
+    * def testUserHeaders = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': '*/*' }
+    * configure headers = testUserHeaders
+
+  Scenario: Create Work and Instance resource using API & validate that they is created in mod-inventory and mod-search
+    * call read('create-resource.feature')
+    * call read('inventory-outbound.feature')
+    * call read('search-outbound.feature')

--- a/mod-linked-data/src/main/resources/citation/mod-linked-data/features/create-bib-api/create-bib-api.feature
+++ b/mod-linked-data/src/main/resources/citation/mod-linked-data/features/create-bib-api/create-bib-api.feature
@@ -1,4 +1,4 @@
-Feature: Create Work and Instance resource using API & validate that they is created in mod-inventory and mod-search
+Feature: Create Work and Instance resource using API & validate that they are created in mod-inventory and mod-search
 
   Background:
     * url baseUrl
@@ -6,7 +6,7 @@ Feature: Create Work and Instance resource using API & validate that they is cre
     * def testUserHeaders = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': '*/*' }
     * configure headers = testUserHeaders
 
-  Scenario: Create Work and Instance resource using API & validate that they is created in mod-inventory and mod-search
+  Scenario: Create Work and Instance resource using API & validate that they are created in mod-inventory and mod-search
     * call read('create-resource.feature')
     * call read('inventory-outbound.feature')
     * call read('search-outbound.feature')

--- a/mod-linked-data/src/main/resources/citation/mod-linked-data/features/create-bib-api/create-resource.feature
+++ b/mod-linked-data/src/main/resources/citation/mod-linked-data/features/create-bib-api/create-resource.feature
@@ -18,6 +18,3 @@ Feature: Create Work and Instance resource using API
     * def postInstanceCall = call postResource { resourceRequest: '#(instanceRequest)' }
     And match postInstanceCall.response.resource['http://bibfra.me/vocab/lite/Instance'] contains expectedInstanceResponse
     * def instanceId = postInstanceCall.response.resource['http://bibfra.me/vocab/lite/Instance'].id
-
-    * call read('inventory-outbound.feature')
-    * call read('search-outbound.feature')

--- a/mod-linked-data/src/main/resources/citation/mod-linked-data/features/suppress-flags/suppress-flags.feature
+++ b/mod-linked-data/src/main/resources/citation/mod-linked-data/features/suppress-flags/suppress-flags.feature
@@ -5,6 +5,7 @@ Feature: Suppress Flags in Inventory
     * call login testUser
     * def testUserHeaders = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': '*/*' }
     * configure headers = testUserHeaders
+    * configure retry = { count: 10, interval: 2000 }
 
   Scenario: Create an instance in Inventory, change Suppress Flags and check their values in search index
     # Create a new instance in Linked data

--- a/mod-linked-data/src/main/resources/karate-config.js
+++ b/mod-linked-data/src/main/resources/karate-config.js
@@ -97,13 +97,6 @@ function fn() {
     }
     config.prototypeTenant = '${prototypeTenant}';
     karate.configure('ssl',true);
-  } else if (env == 'ecs') {
-    config.baseUrl = 'https://okapi-linked-data-r.int.aws.folio.org:443';
-    config.admin = {
-      tenant: 'fs09000000',
-      name: 'admin',
-      password: 'LinkedData$01'
-    };
   } else if (env != null && env.match(/^ec2-\d+/)) {
     // Config for FOLIO CI "folio-integration" public ec2- dns name
     config.baseUrl = 'http://' + env + ':9130';

--- a/mod-linked-data/src/test/java/org/folio/CreateResourceSimulation.scala
+++ b/mod-linked-data/src/test/java/org/folio/CreateResourceSimulation.scala
@@ -19,14 +19,16 @@ class CreateResourceSimulation extends Simulation {
     "/_/proxy/tenants/{tenant}" -> Nil,
     "/_/proxy/tenants/{tenant}/modules" -> Nil,
     "/_/proxy/tenants/{tenant}/install" -> Nil,
+    "/users/{userId}" -> Nil,
     "/resource" -> Nil,
   )
   protocol.runner.systemProperty("testTenant", generateTenantId())
 
   val before = scenario("before")
     .exec(karateFeature("classpath:citation/mod-linked-data/linked-data-junit.feature"))
+  val createRefData = scenario("createRefData")
     .exec(karateFeature("classpath:citation/mod-linked-data/create-ref-data.feature"))
-  val create = scenario("create")
+  val createResource = scenario("createResource")
     .repeat(10) {
       exec(karateFeature("classpath:citation/mod-linked-data/features/create-bib-api/create-resource.feature"))
     }
@@ -34,7 +36,8 @@ class CreateResourceSimulation extends Simulation {
 
   setUp(
     before.inject(atOnceUsers(1))
-      .andThen(create.inject(nothingFor(3 seconds), rampUsers(3) during (5 seconds)))
+      .andThen(createRefData.inject(atOnceUsers(1)))
+      .andThen(createResource.inject(nothingFor(3 seconds), rampUsers(3) during (5 seconds)))
       .andThen(after.inject(nothingFor(3 seconds), atOnceUsers(1))),
   ).protocols(protocol)
 

--- a/mod-linked-data/src/test/java/org/folio/ModLinkedDataTest.java
+++ b/mod-linked-data/src/test/java/org/folio/ModLinkedDataTest.java
@@ -33,7 +33,7 @@ class ModLinkedDataTest extends TestBase {
 
   @Test
   void createInstanceAndWorkThroughApi() {
-    runFeatureTest("create-bib-api/create-resource.feature");
+    runFeatureTest("create-bib-api/create-bib-api.feature");
   }
 
   @Test


### PR DESCRIPTION
## Purpose
Fix failing Gatling performance test of mod-linked-data

## Approach
1. Updated the login process to use 'callonce,' ensuring no repeated login attempts occur during performance testing.
2. Previously, performance tests for mod-linked-data included calls to mod-inventory and mod-search, which was unnecessary. This update isolates the performance testing to focus only on mod-linked-data calls.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
