### PR TITLE
[FAT-17480] Add temporary handling of mod-inventory-storage install using consortium data cache

### DIFF
--- a/mod-inventory/src/main/resources/folijet/mod-inventory/features/consortia/consortia-inventory-junit.feature
+++ b/mod-inventory/src/main/resources/folijet/mod-inventory/features/consortia/consortia-inventory-junit.feature
@@ -21,6 +21,9 @@ Feature: mod-inventory ECS tests
     * call read('classpath:common-consortia/tenant-and-local-admin-setup.feature@SetupTenant') { tenant: '#(universityTenant)', admin: '#(universityUser1)'}
     * call read('classpath:common-consortia/tenant-and-local-admin-setup.feature@SetupTenant') { tenant: '#(collegeTenant)', admin: '#(collegeUser1)'}
 
+    # Temporary fix, should be removed after implementing proper consortium data cache handling during install operation at mod-inventory-storage
+    * call pause 360000
+
     # add 'consortia.all' (for consortia management) and 'tags.all' (for publish coordinator tests) permissions to main users
     * call login consortiaAdmin
     * call read('classpath:common-consortia/initData.feature@PutPermissions') { desiredPermissions: ['consortia.all', 'tags.all']}


### PR DESCRIPTION
## Purpose
Temporarily fix update ownership tests
## Approach
add a timeout to wait until the cache reload
