### PR TITLE
FAT-16909 Add missing permission in batch-print-junit.feature

### DIFF
--- a/mod-batch-print/src/main/resources/odin/mod-batch-print/batch-print-junit.feature
+++ b/mod-batch-print/src/main/resources/odin/mod-batch-print/batch-print-junit.feature
@@ -9,13 +9,14 @@ Feature: mod-batch-print integration tests
       | 'mod-batch-print'                   |
 
     * table userPermissions
-      | name                                |
-      | 'batch-print.entries.item.post'     |
-      | 'batch-print.entries.collection.get'|
-      | 'batch-print.entries.item.get'      |
-      | 'batch-print.entries.item.put'      |
-      | 'batch-print.entries.item.delete'   |
-      | 'batch-print.entries.mail.post'     |
+      | name                                    |
+      | 'batch-print.entries.item.post'         |
+      | 'batch-print.entries.collection.get'    |
+      | 'batch-print.entries.item.get'          |
+      | 'batch-print.entries.item.put'          |
+      | 'batch-print.entries.item.delete'       |
+      | 'batch-print.entries.mail.post'         |
+      | 'batch-print.entries.collection.delete' |
 
   Scenario: create tenant and users for testing
     Given call read('classpath:common/setup-users.feature')


### PR DESCRIPTION
## Purpose
Fix failing mod-batch-print test

## Approach
There was permission updated for collection endpoint. Add missing permission to test so that test passes 
