### PR TITLE
[MODORDERS-1210] Implement API to change piece statuses in batch

### DIFF
--- a/acquisitions/src/main/resources/karate-config.js
+++ b/acquisitions/src/main/resources/karate-config.js
@@ -76,6 +76,7 @@ function fn() {
     openOrder: read('classpath:thunderjet/mod-orders/reusable/open-order.feature'),
     unopenOrder: read('classpath:thunderjet/mod-orders/reusable/unopen-order.feature'),
     closeOrder: read('classpath:thunderjet/mod-orders/reusable/close-order.feature'),
+    cancelOrder: read('classpath:thunderjet/mod-orders/reusable/cancel-order.feature'),
     getOrderLine: karate.read('classpath:thunderjet/mod-orders/reusable/get-order-line.feature'),
     createOrderLine: karate.read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature'),
     createOrderLineWithInstance: karate.read('classpath:thunderjet/mod-orders/reusable/create-order-line-with-instance.feature'),
@@ -84,6 +85,7 @@ function fn() {
     createTitle: karate.read('classpath:thunderjet/mod-orders/reusable/create-title.feature'),
     createPiece: karate.read('classpath:thunderjet/mod-orders/reusable/create-piece.feature'),
     createPieceWithHolding: karate.read('classpath:thunderjet/mod-orders/reusable/create-piece-with-holding.feature'),
+    updatePiecesBatchStatus: karate.read('classpath:thunderjet/mod-orders/reusable/update-pieces-batch-status.feature'),
 
     // invoices
     createInvoice: read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature'),

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createBudget.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createBudget.feature
@@ -20,7 +20,7 @@ Feature: budget
       "fundId": "#(fundId)",
       "name": "#(id)",
       "fiscalYearId":"#(fiscalYearId)",
-      "allocated": #(allocated),
+      "allocated": "#(allocated)",
       "allowableEncumbrance": 100.0,
       "allowableExpenditure": 100.0,
       "statusExpenseClasses": "#(statusExpenseClasses)"

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/pieces-batch-update-status.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/pieces-batch-update-status.feature
@@ -1,0 +1,98 @@
+Feature: Update Pieces statuses in batch
+
+  Background:
+    * url baseUrl
+
+    * callonce loginAdmin testAdmin
+    * def okapitokenAdmin = okapitoken
+    * callonce loginRegularUser testUser
+    * def okapitokenUser = okapitoken
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json'  }
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': '*/*'  }
+    * configure retry = { count: 5, interval: 1000 }
+    * configure headers = headersAdmin
+
+    * callonce variables
+    * def fundId = callonce uuid
+    * def budgetId = callonce uuid1
+    * def orderId = callonce uuid2
+    * def poLineId = callonce uuid3
+    * def titleId = callonce uuid4
+    * def pieceId1 = callonce uuid5
+    * def pieceId2 = callonce uuid6
+    * def pieceId3 = callonce uuid7
+
+    ### Before All ###
+    # 1. Prepare finance data
+    * def v = callonce createFund { id: '#(fundId)' }
+    * def v = callonce createBudget { id: '#(budgetId)', allocated: 100, fundId: '#(fundId)', status: 'Active' }
+
+    # 2. Prepare acquisitions data
+    * def v = callonce createOrder { id: '#(orderId)' }
+    * def v = callonce createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', fundId: '#(fundId)', isPackage: true }
+    * def v = callonce openOrder { orderId: '#(orderId)' }
+    * def v = callonce createTitle { titleId: '#(titleId)', poLineId: '#(poLineId)' }
+
+    # 3. Prepare pieces data
+    * table pieceData
+      | pieceId  | titleId | poLineId |
+      | pieceId1 | titleId | poLineId |
+      | pieceId2 | titleId | poLineId |
+      | pieceId3 | titleId | poLineId |
+    * def v = callonce createPiece pieceData
+    * configure headers = headersUser
+
+  @Positive
+  Scenario: Update once Piece status in batch to received and verify PoLine receipt status
+    # 1. Update once Piece status in batch to "Unreceivable"
+    * def v = call updatePiecesBatchStatus { pieceIds: ["#(pieceId1)"], receivingStatus: 'Unreceivable' }
+    # 2. Verify PoLine receipt status is "Partially Received"
+    * def v = call read('@verifyPoLineReceiptStatus') { _poLineId: '#(poLineId)', _receiptStatus: 'Partially Received' }
+
+  @Positive
+  Scenario: Update all Piece statuses in batch to received and verify PoLine receipt status
+    # 1. Update once Piece status in batch to "Received"
+    * def v = call updatePiecesBatchStatus { pieceIds: ["#(pieceId1)", "#(pieceId2)", "#(pieceId3)"], receivingStatus: 'Received' }
+    # 2. Verify PoLine receipt status is "Fully Received"
+    * def v = call read('@verifyPoLineReceiptStatus') { _poLineId: '#(poLineId)', _receiptStatus: 'Fully Received' }
+
+  @Positive
+  Scenario: Update all Piece statuses in batch to expected and verify PoLine receipt status
+    # 1. Update once Piece status in batch to "Expected"
+    * def v = call updatePiecesBatchStatus { pieceIds: ["#(pieceId1)", "#(pieceId2)", "#(pieceId3)"], receivingStatus: 'Expected' }
+    # 2. Verify PoLine receipt status is "Awaiting Receipt"
+    * def v = call read('@verifyPoLineReceiptStatus') { _poLineId: '#(poLineId)', _receiptStatus: 'Awaiting Receipt' }
+
+  @Negative
+  Scenario: Update Piece statuses in batch with wrong Receiving Status
+    * def badStatus = 'Bad Status'
+
+    Given path 'orders/pieces-batch/status'
+    And request { pieceIds: ["#(pieceId1)", "#(pieceId2)", "#(pieceId3)"], receivingStatus: '#(badStatus)' }
+    When method PUT
+    Then status 400
+
+  @Negative
+  Scenario: Update Piece statuses in batch with wrong Piece ID
+    * def invalidPieceId = call uuid
+
+    Given path 'orders/pieces-batch/status'
+    And request { pieceIds: ["#(invalidPieceId)", "#(pieceId2)", "#(pieceId3)"], receivingStatus: 'Received' }
+    When method PUT
+    Then status 400
+
+  @Negative
+  Scenario: Update Piece statuses in batch with Cancelled/Ongoing PoLine
+    # 1. Cancel Order so that PoLine receipt status is "Cancelled"
+    * def v = call cancelOrder { orderId: "#(orderId)" }
+    # 2. Update Pieces statuses in batch to "Received"
+    * def v = call updatePiecesBatchStatus { pieceIds: ["#(pieceId1)", "#(pieceId2)", "#(pieceId3)"], receivingStatus: 'Received' }
+    # 3. Verify PoLine receipt status is not modified
+    * def v = call read('@verifyPoLineReceiptStatus') { _poLineId: '#(poLineId)', _receiptStatus: 'Cancelled' }
+
+  @ignore @VerifyPoLineReceiptStatus
+  Scenario: Verify PoLine receipt status
+    Given path 'orders/order-lines', _poLineId
+    And retry until response.receiptStatus == _receiptStatus
+    When method GET
+    Then status 200

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/pieces-batch-update-status.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/pieces-batch-update-status.feature
@@ -1,6 +1,8 @@
+# https://folio-org.atlassian.net/browse/MODORDERS-1210
 Feature: Update Pieces statuses in batch
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
 
     * callonce loginAdmin testAdmin
@@ -9,7 +11,7 @@ Feature: Update Pieces statuses in batch
     * def okapitokenUser = okapitoken
     * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json'  }
     * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': '*/*'  }
-    * configure retry = { count: 5, interval: 1000 }
+    * configure retry = { count: 10, interval: 5000 }
     * configure headers = headersAdmin
 
     * callonce variables
@@ -46,49 +48,126 @@ Feature: Update Pieces statuses in batch
   Scenario: Update once Piece status in batch to received and verify PoLine receipt status
     # 1. Update once Piece status in batch to "Unreceivable"
     * def v = call updatePiecesBatchStatus { pieceIds: ["#(pieceId1)"], receivingStatus: 'Unreceivable' }
+
     # 2. Verify PoLine receipt status is "Partially Received"
-    * def v = call read('@verifyPoLineReceiptStatus') { _poLineId: '#(poLineId)', _receiptStatus: 'Partially Received' }
+    * def v = call read('@VerifyPoLineReceiptStatus') { _poLineId: '#(poLineId)', _receiptStatus: 'Partially Received' }
+
+    # 3. Verify Piece receiving status is "Unreceivable"
+    * table verifyPieceData
+      | _pieceId | _receivingStatus |
+      | pieceId1 | 'Unreceivable'   |
+    * def v = call read('@VerifyPieceReceivingStatus') verifyPieceData
+
+    # 4. Verify Piece status change audit events
+    * table verifyPieceAuditData
+      | _pieceId | _receivingStatus | _eventCount |
+      | pieceId1 | 'Unreceivable'   | 2           |
+    * def v = call read('@VerifyPieceAuditEvents') verifyPieceAuditData
+
 
   @Positive
   Scenario: Update all Piece statuses in batch to received and verify PoLine receipt status
     # 1. Update once Piece status in batch to "Received"
-    * def v = call updatePiecesBatchStatus { pieceIds: ["#(pieceId1)", "#(pieceId2)", "#(pieceId3)"], receivingStatus: 'Received' }
+    * def v = call updatePiecesBatchStatus { pieceIds: ["#(pieceId2)", "#(pieceId3)"], receivingStatus: 'Received' }
+
     # 2. Verify PoLine receipt status is "Fully Received"
-    * def v = call read('@verifyPoLineReceiptStatus') { _poLineId: '#(poLineId)', _receiptStatus: 'Fully Received' }
+    * def v = call read('@VerifyPoLineReceiptStatus') { _poLineId: '#(poLineId)', _receiptStatus: 'Fully Received' }
+
+    # 3. Verify Piece receiving status is "Unreceivable"
+    * table verifyPieceData
+      | _pieceId | _receivingStatus |
+      | pieceId2 | 'Received'       |
+      | pieceId3 | 'Received'       |
+    * def v = call read('@VerifyPieceReceivingStatus') verifyPieceData
+
+    # 4. Verify Piece status change audit events
+    * table verifyPieceAuditData
+      | _pieceId | _receivingStatus | _eventCount |
+      | pieceId2 | 'Received'       | 2           |
+      | pieceId3 | 'Received'       | 2           |
+    * def v = call read('@VerifyPieceAuditEvents') verifyPieceAuditData
+
 
   @Positive
   Scenario: Update all Piece statuses in batch to expected and verify PoLine receipt status
     # 1. Update once Piece status in batch to "Expected"
     * def v = call updatePiecesBatchStatus { pieceIds: ["#(pieceId1)", "#(pieceId2)", "#(pieceId3)"], receivingStatus: 'Expected' }
+
     # 2. Verify PoLine receipt status is "Awaiting Receipt"
-    * def v = call read('@verifyPoLineReceiptStatus') { _poLineId: '#(poLineId)', _receiptStatus: 'Awaiting Receipt' }
+    * def v = call read('@VerifyPoLineReceiptStatus') { _poLineId: '#(poLineId)', _receiptStatus: 'Awaiting Receipt' }
+
+    # 3. Verify Piece receiving status is "Unreceivable"
+    * table verifyPieceData
+      | _pieceId | _receivingStatus |
+      | pieceId1 | 'Expected'       |
+      | pieceId2 | 'Expected'       |
+      | pieceId3 | 'Expected'       |
+    * def v = call read('@VerifyPieceReceivingStatus') verifyPieceData
+
+    # 4. Verify Piece status change audit events
+    * table verifyPieceAuditData
+      | _pieceId | _receivingStatus | _eventCount |
+      | pieceId1 | 'Expected'       | 3           |
+      | pieceId2 | 'Expected'       | 3           |
+      | pieceId3 | 'Expected'       | 3           |
+    * def v = call read('@VerifyPieceAuditEvents') verifyPieceAuditData
+
 
   @Negative
   Scenario: Update Piece statuses in batch with wrong Receiving Status
+    # 1. Update Pieces statuses in batch to "Bad Status"
     * def badStatus = 'Bad Status'
-
     Given path 'orders/pieces-batch/status'
     And request { pieceIds: ["#(pieceId1)", "#(pieceId2)", "#(pieceId3)"], receivingStatus: '#(badStatus)' }
     When method PUT
     Then status 400
 
-  @Negative
-  Scenario: Update Piece statuses in batch with wrong Piece ID
-    * def invalidPieceId = call uuid
+    # 2. Verify Piece receiving status is not modified
+    * table verifyPieceData
+      | _pieceId | _receivingStatus |
+      | pieceId1 | 'Expected'       |
+      | pieceId2 | 'Expected'       |
+      | pieceId3 | 'Expected'       |
+    * def v = call read('@VerifyPieceReceivingStatus') verifyPieceData
 
+
+  @Negative
+  Scenario: Update Piece statuses in batch with invalid Piece ID
+    # 1. Update Pieces statuses in batch with one invalid piece ID
+    * def invalidPieceId = call uuid
     Given path 'orders/pieces-batch/status'
     And request { pieceIds: ["#(invalidPieceId)", "#(pieceId2)", "#(pieceId3)"], receivingStatus: 'Received' }
     When method PUT
     Then status 400
 
+    # 2. Verify Piece receiving status is not modified
+    * table verifyPieceData
+      | _pieceId | _receivingStatus |
+      | pieceId1 | 'Expected'       |
+      | pieceId2 | 'Expected'       |
+      | pieceId3 | 'Expected'       |
+    * def v = call read('@VerifyPieceReceivingStatus') verifyPieceData
+
+
   @Negative
   Scenario: Update Piece statuses in batch with Cancelled/Ongoing PoLine
     # 1. Cancel Order so that PoLine receipt status is "Cancelled"
     * def v = call cancelOrder { orderId: "#(orderId)" }
+
     # 2. Update Pieces statuses in batch to "Received"
     * def v = call updatePiecesBatchStatus { pieceIds: ["#(pieceId1)", "#(pieceId2)", "#(pieceId3)"], receivingStatus: 'Received' }
+
     # 3. Verify PoLine receipt status is not modified
-    * def v = call read('@verifyPoLineReceiptStatus') { _poLineId: '#(poLineId)', _receiptStatus: 'Cancelled' }
+    * def v = call read('@VerifyPoLineReceiptStatus') { _poLineId: '#(poLineId)', _receiptStatus: 'Cancelled' }
+
+    # 4. Verify Piece receiving status is modified
+    * table verifyPieceData
+      | _pieceId | _receivingStatus |
+      | pieceId1 | 'Received'       |
+      | pieceId2 | 'Received'       |
+      | pieceId3 | 'Received'       |
+    * def v = call read('@VerifyPieceReceivingStatus') verifyPieceData
+
 
   @ignore @VerifyPoLineReceiptStatus
   Scenario: Verify PoLine receipt status
@@ -96,3 +175,21 @@ Feature: Update Pieces statuses in batch
     And retry until response.receiptStatus == _receiptStatus
     When method GET
     Then status 200
+
+  @ignore @VerifyPieceReceivingStatus
+  Scenario: Verify Piece receiving status
+    Given path 'orders/pieces', _pieceId
+    When method GET
+    Then status 200
+    And match response.receivingStatus == _receivingStatus
+
+
+  @ignore @VerifyPieceAuditEvents
+  Scenario: Verify Piece receiving status
+    Given path '/audit-data/acquisition/piece/' + _pieceId + '/status-change-history'
+    And retry until response.totalItems == _eventCount
+    When method GET
+    Then status 200
+    And match response.pieceAuditEvents[*].pieceId contains _pieceId
+    And match response.pieceAuditEvents[*].action contains "Edit"
+    And match response.pieceAuditEvents[*].pieceSnapshot.map.receivingStatus contains _receivingStatus

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
@@ -279,6 +279,9 @@ Feature: mod-orders integration tests
   Scenario: Update inventory ownership changes order data
     Given call read("features/update-inventory-ownership-changes-order-data.feature")
 
+  Scenario: Update Pieces statuses in batch
+    Given call read("features/pieces-batch-update-status.feature")
+
   # These 2 have to be called with OrdersApiTest - this comment is here as a reminder
 #  Scenario: Create pieces for an open order in parallel
 #    Given call read("features/parallel-create-piece.feature")

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/update-pieces-batch-status.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/update-pieces-batch-status.feature
@@ -1,0 +1,18 @@
+@ignore
+Feature: Update pieces statuses in batch
+  # parameters: pieceIds, receivingStatus
+
+  Background:
+    * url baseUrl
+
+  Scenario: updatePiecesBatchStatus
+    Given path 'orders/pieces-batch/status'
+    And request
+      """
+      {
+        "pieceIds": "#(pieceIds)",
+        "receivingStatus": "#(receivingStatus)",
+      }
+      """
+    When method PUT
+    Then status 204

--- a/acquisitions/src/test/java/org/folio/OrdersApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersApiTest.java
@@ -432,6 +432,11 @@ public class OrdersApiTest extends TestBase {
     runFeatureTest("check-order-total-fields-calculated-correctly.feature");
   }
 
+  @Test
+  void updatePiecesBatchStatus() {
+    runFeatureTest("pieces-batch-update-status.feature");
+  }
+
   @BeforeAll
   public void ordersApiTestBeforeAll() {
     runFeature("classpath:thunderjet/mod-orders/orders-junit.feature");


### PR DESCRIPTION
## Purpose
[[MODORDERS-1210] Implement API to change piece statuses in batch](https://folio-org.atlassian.net/browse/MODORDERS-1210)

## Approach
Add new feature to cover the new piece batch status update API endpoint

## Screenshots
Bind pieces failing as mod-settings is missing, when enabled then busybee is unable to start all modules locally for me
![image](https://github.com/user-attachments/assets/2c02ecea-a5ce-4ec9-aa62-61574d8353b6)
![image](https://github.com/user-attachments/assets/44238ae6-f78f-4563-8635-a4c1a46345d2)
