### PR TITLE
[MODORDERS-1226]. Update validation to prevent opening an order without po lines

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-orders-with-poLines.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-orders-with-poLines.feature
@@ -1,4 +1,4 @@
-# For https://folio-org.atlassian.net/browse/MODORDERS-1226
+# For MODORDERS-1226
 Feature: Open Orders with PoLines
 
   Background:
@@ -17,51 +17,38 @@ Feature: Open Orders with PoLines
 
     * callonce variables
 
-    # Define reusable functions
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
+    * def fundId = call uuid
+    * def budgetId = call uuid
+
+    * configure headers = headersAdmin
+    * def v = callonce createFund { id: '#(fundId)' }
+    * def v = callonce createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 1000 }
+    * configure headers = headersUser
 
   @Positive
   Scenario: Open Orders with PoLines
-   # Generate unique UUIDs
-    * def fundId = call uuid
-    * def budgetId = call uuid
     * def orderId = call uuid
 
-    * print '1. Prepare finances'
-    * configure headers = headersAdmin
-    * def v = call createFund { id: '#(fundId)' }
-    * def v = call createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 1000 }
-
-    * print '2. Create composite order'
+    * print '1. Create composite order'
     * def v = call createOrder { id: '#(orderId)' }
 
-    * print '3. Create order lines'
+    * print '2. Create order lines'
     * table statusTable
-      | paymentStatus          | receiptStatus          |
-      | 'Awaiting Payment'     | 'Awaiting Receipt'     |
+      | paymentStatus      | receiptStatus      |
+      | 'Awaiting Payment' | 'Awaiting Receipt' |
     * def v = call createOrderLine statusTable
 
-    * print '4. Open the order'
+    * print '3. Open the order'
     * def v = call openOrder { orderId: '#(orderId)' }
 
   @Negative
   Scenario: Open Orders with PoLines - Throw Exception
-    # Generate unique UUIDs
-    * def fundId = call uuid
-    * def budgetId = call uuid
     * def orderId = call uuid
 
-    * print '1. Prepare finances'
-    * configure headers = headersAdmin
-    * def v = call createFund { id: '#(fundId)' }
-    * def v = call createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 1000 }
-
-    * print '2. Create composite order'
+    * print '1. Create composite order'
     * def v = call createOrder { id: '#(orderId)' }
 
-    * print '3. Open the order'
+    * print '2. Open the order'
     Given path 'orders/composite-orders', orderId
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-orders-with-poLines.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-orders-with-poLines.feature
@@ -1,0 +1,82 @@
+# For https://folio-org.atlassian.net/browse/MODORDERS-1226
+Feature: Open Orders with PoLines
+
+  Background:
+    * url baseUrl
+    * print karate.info.scenarioName
+
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json' }
+
+    * configure headers = headersUser
+
+    * callonce variables
+
+    # Define reusable functions
+    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
+    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
+    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
+
+  @Positive
+  Scenario: Open Orders with PoLines
+   # Generate unique UUIDs
+    * def fundId = call uuid
+    * def budgetId = call uuid
+    * def orderId = call uuid
+
+    * print '1. Prepare finances'
+    * configure headers = headersAdmin
+    * def v = call createFund { id: '#(fundId)' }
+    * def v = call createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 1000 }
+
+    * print '2. Create composite order'
+    * def v = call createOrder { id: '#(orderId)' }
+
+    * print '3. Create order lines'
+    * table statusTable
+      | paymentStatus          | receiptStatus          |
+      | 'Awaiting Payment'     | 'Awaiting Receipt'     |
+    * def v = call createOrderLine statusTable
+
+    * print '4. Open the order'
+    * def v = call openOrder { orderId: '#(orderId)' }
+
+  @Negative
+  Scenario: Open Orders with PoLines - Throw Exception
+    # Generate unique UUIDs
+    * def fundId = call uuid
+    * def budgetId = call uuid
+    * def orderId = call uuid
+
+    * print '1. Prepare finances'
+    * configure headers = headersAdmin
+    * def v = call createFund { id: '#(fundId)' }
+    * def v = call createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 1000 }
+
+    * print '2. Create composite order'
+    * def v = call createOrder { id: '#(orderId)' }
+
+    * print '3. Open the order'
+    Given path 'orders/composite-orders', orderId
+    When method GET
+    Then status 200
+
+    * def orderResponse = $
+    * set orderResponse.workflowStatus = 'Open'
+    * remove order.compositePoLines
+
+    Given path 'orders/composite-orders', orderId
+    And request orderResponse
+    When method PUT
+    Then status 422
+
+    And match each $.errors[*].code == 'compositeOrderMissingPoLines'
+    And match each $.errors[*].message == 'Composite order is missing poLines for Open operations'
+    And match $.errors[*].paremeters == []
+    And match $.total_records == 1
+

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
@@ -276,11 +276,14 @@ Feature: mod-orders integration tests
   Scenario: Update Pieces statuses in batch
     Given call read("features/pieces-batch-update-status.feature")
 
+  Scenario: Open Orders with PoLines
+    Given call read("open-orders-with-poLines.feature")
+
   # These 2 have to be called with OrdersApiTest - this comment is here as a reminder
-#  Scenario: Create pieces for an open order in parallel
-#    Given call read("features/parallel-create-piece.feature")
-#  Scenario: Update order lines for the same open orders in parallel
-#    Given call read("features/parallel-update-order-lines-same-order.feature")
+  #  Scenario: Create pieces for an open order in parallel
+  #    Given call read("features/parallel-create-piece.feature")
+  #  Scenario: Update order lines for the same open orders in parallel
+  #    Given call read("features/parallel-update-order-lines-same-order.feature")
 
   Scenario: wipe data
     Given call read('classpath:common/destroy-data.feature')

--- a/acquisitions/src/test/java/org/folio/OrdersApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersApiTest.java
@@ -432,6 +432,11 @@ public class OrdersApiTest extends TestBase {
     runFeatureTest("pieces-batch-update-status.feature");
   }
 
+  @Test
+  void openOrdersWithPoLines() {
+    runFeatureTest("open-orders-with-poLines.feature");
+  }
+
   @BeforeAll
   public void ordersApiTestBeforeAll() {
     runFeature("classpath:thunderjet/mod-orders/orders-junit.feature");


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODORDERS-1226>

## Approach

- Add supplementary tests
- Test output for `mod-orders` and `cross-modules` folders:

![image](https://github.com/user-attachments/assets/d2cf4db3-532f-4853-a868-0f02007f38d4)
![image](https://github.com/user-attachments/assets/d17e6b0b-4998-40b4-8750-5240c9dbf913)
