### PR TITLE
Update Slack notifications for core-platform team

### DIFF
--- a/teams-assignment.json
+++ b/teams-assignment.json
@@ -24,7 +24,7 @@
       "mod-authtoken",
       "mod-login"
     ],
-    "slackChannel": "#core-platform"
+    "slackChannel": "#core-platform-jenkins"
   },
   {
     "team": "Corsair",


### PR DESCRIPTION
## Purpose
The core-platform team would like notifications for testing to go to a different Slack Channel, `#core-platform-jenkins`

## Approach
Update the team assignments settings per recommendation from @eldiiar-duishenaliev
