### PR TITLE
[MODFISTO-517] Create budgets with batch allocations

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/finance-data.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/finance-data.feature
@@ -274,6 +274,7 @@ Feature: Karate tests for FY finance bulk get/update functionality
     Given path 'finance/finance-data'
     And request requestBody
     When method PUT
+    # TODO: change to 422 after fixing validation in mod-finance
     Then status 500
 
     # Fund update log is updated async, waiting a bit


### PR DESCRIPTION
## Purpose
[MODFISTO-517](https://folio-org.atlassian.net/browse/MODFISTO-517) - Create budget when adding batch allocation to fund without budget

## Approach
- Added new tests
- Fixed unrelated issue with error messages (related to first MODFIN-403 PR)

[mod-finance-storage PR](https://github.com/folio-org/mod-finance-storage/pull/450), [mod-finance PR](https://github.com/folio-org/mod-finance/pull/275)