### PR TITLE
Re: MODPWD-133: [Password validation] Some special chars breaking regex validation rule for matching against password from the user_name

### DIFF
--- a/mod-password-validator/src/test/resources/samples/rules/no_user_name.json
+++ b/mod-password-validator/src/test/resources/samples/rules/no_user_name.json
@@ -5,7 +5,7 @@
   "validationType": "Strong",
   "state": "Enabled",
   "moduleName": "mod-password-validator",
-  "expression": "^(?:(?!<USER_NAME>).)+$",
+  "expression": "^(?i)(?:(?!<USER_NAME>).)+$",
   "description": "The password must not contain your username",
   "orderNo": 4,
   "errMessageId": "password.usernameDuplicate.invalid",


### PR DESCRIPTION
## Purpose
Fix for older PR: Use the new approach for only validation against username with rule: "no_user_name"

https://folio-org.atlassian.net/browse/MODPWD-133?atlOrigin=eyJpIjoiNjAxY2VjZDJhMTNjNGMxNGFiY2Q5OTI4OTQ0NTFiZmQiLCJwIjoiaiJ9

### Result
<img width="1288" alt="image" src="https://github.com/user-attachments/assets/53388b45-676d-4121-bab1-cbc3eaf7a602" />

