### PR TITLE
[MODORDERS-1253] Change pending distribution with inactive budget

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/change-pending-distribution-with-inactive-budget.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/change-pending-distribution-with-inactive-budget.feature
@@ -1,0 +1,94 @@
+# For MODORDERS-1253
+Feature: Change pending distribution with inactive budget
+
+  Background:
+    * url baseUrl
+    * print karate.info.scenarioName
+
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json' }
+
+    * callonce variables
+
+    # Common part for all tests in this feature
+
+    * def fundId1 = call uuid
+    * def fundId2 = call uuid
+    * def budgetId1 = call uuid
+    * def budgetId2 = call uuid
+    * def orderId = call uuid
+    * def poLineId = call uuid
+
+    * print '1. Prepare finances, create 2 funds and 2 budgets'
+    * configure headers = headersAdmin
+    * def v = call createFund { id: '#(fundId1)' }
+    * def v = call createBudget { id: '#(budgetId1)', fundId: '#(fundId1)', allocated: 1000 }
+    * def v = call createFund { id: '#(fundId2)' }
+    * def v = call createBudget { id: '#(budgetId2)', fundId: '#(fundId2)', allocated: 1000 }
+    * configure headers = headersUser
+
+    * print '2. Create order and line'
+    * def v = call createOrder { id: '#(orderId)' }
+    * def v = call createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', fundId: '#(fundId1)' }
+
+    * print '3. Open the order'
+    * def v = call openOrder { orderId: '#(orderId)' }
+
+    * print '4. Unopen the order'
+    * def v = call unopenOrder { orderId: '#(orderId)' }
+
+    * print '5. Make budget 1 inactive'
+    * configure headers = headersAdmin
+    Given path 'finance/budgets', budgetId1
+    When method GET
+    Then status 200
+    * def budget = $
+    * set budget.budgetStatus = 'Inactive'
+    Given path 'finance/budgets', budgetId1
+    And request budget
+    When method PUT
+    Then status 204
+    * configure headers = headersUser
+
+
+  @Positive
+  Scenario: Change the fund distribution to use fund 2
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+
+    * def poLine = $
+    * set poLine.fundDistribution[0].fundId = fundId2
+    * remove poLine.fundDistribution[0].encumbrance
+
+    Given path 'orders/order-lines', poLineId
+    And request poLine
+    When method PUT
+    Then status 204
+
+
+  @Positive
+  Scenario: Remove the fund distribution
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+
+    * def poLine = $
+    * remove poLine.fundDistribution
+
+    Given path 'orders/order-lines', poLineId
+    And request poLine
+    When method PUT
+    Then status 204
+
+
+  @Positive
+  Scenario: Delete the po line
+    Given path 'orders/order-lines', poLineId
+    When method DELETE
+    Then status 204

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
@@ -277,7 +277,10 @@ Feature: mod-orders integration tests
     Given call read("features/pieces-batch-update-status.feature")
 
   Scenario: Open Orders with PoLines
-    Given call read("open-orders-with-poLines.feature")
+    Given call read("features/open-orders-with-poLines.feature")
+
+  Scenario: Change pending distribution with inactive budget
+    Given call read("features/change-pending-distribution-with-inactive-budget.feature")
 
   # These 2 have to be called with OrdersApiTest - this comment is here as a reminder
   #  Scenario: Create pieces for an open order in parallel

--- a/acquisitions/src/test/java/org/folio/OrdersApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersApiTest.java
@@ -437,6 +437,11 @@ public class OrdersApiTest extends TestBase {
     runFeatureTest("open-orders-with-poLines.feature");
   }
 
+  @Test
+  void changePendingDistributionWithInactiveBudget() {
+    runFeatureTest("change-pending-distribution-with-inactive-budget.feature");
+  }
+
   @BeforeAll
   public void ordersApiTestBeforeAll() {
     runFeature("classpath:thunderjet/mod-orders/orders-junit.feature");


### PR DESCRIPTION
## Purpose
[MODORDERS-1253](https://folio-org.atlassian.net/browse/MODORDERS-1253) - User can edit fund distribution for unopened order with inactive budget in POL

## Approach
Added a new test with the scenarios in MODORDERS-1253.

[mod-orders PR](https://github.com/folio-org/mod-orders/pull/1093)