### PR TITLE
[MODFQMMGR-685] Add required permission for transaction entity type

### DIFF
--- a/mod-fqm-manager/src/main/resources/corsair/mod-fqm-manager/fqm-junit.feature
+++ b/mod-fqm-manager/src/main/resources/corsair/mod-fqm-manager/fqm-junit.feature
@@ -11,6 +11,7 @@ Feature: mod-fqm-manager integration tests
       | 'mod-circulation'                   |
       | 'mod-circulation-storage'           |
       | 'mod-fqm-manager'                   |
+      | 'mod-finance'                       |
       | 'mod-finance-storage'               |
       | 'mod-orders'                        |
       | 'mod-orders-storage'                |
@@ -36,6 +37,7 @@ Feature: mod-fqm-manager integration tests
       | 'finance.fund-types.collection.get'                         |
       | 'finance.funds.collection.get'                              |
       | 'finance.ledgers.collection.get'                            |
+      | 'finance.transactions.collection.get'                       |
       | 'fqm.entityTypes.collection.get'                            |
       | 'fqm.entityTypes.item.columnValues.get'                     |
       | 'fqm.entityTypes.item.get'                                  |

--- a/mod-lists/src/main/resources/corsair/mod-lists/lists-junit.feature
+++ b/mod-lists/src/main/resources/corsair/mod-lists/lists-junit.feature
@@ -31,6 +31,7 @@ Feature: mod-lists integration tests
       | 'finance.fund-types.collection.get'                         |
       | 'finance.funds.collection.get'                              |
       | 'finance.ledgers.collection.get'                            |
+      | 'finance.transactions.collection.get'                       |
       | 'fqm.query.all'                                             |
       | 'inventory-storage.call-number-types.collection.get'        |
       | 'inventory-storage.classification-types.collection.get'     |


### PR DESCRIPTION
## Purpose
Update corsair integration tests to include permission required to access new transaction entity type, introduced in [MODFQMMGR-685](https://folio-org.atlassian.net/browse/MODFQMMGR-685)
