### PR TITLE
[MODFIN-405] Create inactive budget

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-finance/create-inactive-budget.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/create-inactive-budget.feature
@@ -1,0 +1,81 @@
+  # For MODFIN-405
+  Feature: Create inactive budget
+
+    Background:
+      * print karate.info.scenarioName
+
+      * url baseUrl
+      * callonce login testAdmin
+      * def okapitokenAdmin = okapitoken
+      * callonce login testUser
+      * def okapitokenUser = okapitoken
+      * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
+      * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json' }
+      * configure headers = headersUser
+
+      * callonce variables
+
+      * def fundId = call uuid
+      * def budgetId = call uuid
+
+      # Prepare finance data, for all tests
+      * def v = call createFund { id: '#(fundId)' }
+
+
+    @Positive
+    Scenario: Create an inactive budget without any allocation
+      * def v = call createBudget { id: '#(budgetId)', allocated: 0, fundId: '#(fundId)', budgetStatus: 'Inactive' }
+
+      Given path '/finance/budgets', budgetId
+      When method GET
+      Then status 200
+      And match $.budgetStatus == 'Inactive'
+      And match $.allocated == 0
+
+
+    @Positive
+    Scenario: Create an inactive budget with an allocation
+      * def v = call createBudget { id: '#(budgetId)', allocated: 100, fundId: '#(fundId)', budgetStatus: 'Inactive' }
+
+      Given path '/finance/budgets', budgetId
+      When method GET
+      Then status 200
+      And match $.budgetStatus == 'Inactive'
+      And match $.allocated == 100
+
+
+    @Negative
+    Scenario: Try to create a budget with negative allowableEncumbrance or allowableExpenditure
+      Given path 'finance/budgets'
+      And request
+        """
+        {
+          "id": "#(budgetId)",
+          "budgetStatus": "Active",
+          "fundId": "#(fundId)",
+          "name": "#(budgetId)",
+          "fiscalYearId": "#(globalFiscalYearId)",
+          "allocated": 0,
+          "allowableEncumbrance": -1.0,
+          "allowableExpenditure": 100.0
+        }
+        """
+      When method POST
+      Then status 422
+
+      Given path 'finance/budgets'
+      And request
+        """
+        {
+          "id": "#(budgetId)",
+          "budgetStatus": "Active",
+          "fundId": "#(fundId)",
+          "name": "#(budgetId)",
+          "fiscalYearId": globalFiscalYearId,
+          "allocated": 0,
+          "allowableEncumbrance": 100.0,
+          "allowableExpenditure": -1.0
+        }
+        """
+      When method POST
+      Then status 422

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/finance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/finance.feature
@@ -147,5 +147,8 @@ Feature: mod-finance integration tests
   Scenario: Batch transaction API
     Given call read('features/batch-transaction-api.feature')
 
+  Scenario: Create inactive budget
+    Given call read('features/create-inactive-budget.feature')
+
   Scenario: wipe data
     Given call read('classpath:common/destroy-data.feature')

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createBudget.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createBudget.feature
@@ -16,7 +16,7 @@ Feature: budget
     """
     {
       "id": "#(id)",
-      "budgetStatus": "Active",
+      "budgetStatus": "#(budgetStatus)",
       "fundId": "#(fundId)",
       "name": "#(id)",
       "fiscalYearId":"#(fiscalYearId)",

--- a/acquisitions/src/test/java/org/folio/FinanceApiTest.java
+++ b/acquisitions/src/test/java/org/folio/FinanceApiTest.java
@@ -212,6 +212,11 @@ public class FinanceApiTest extends TestBase {
     runFeatureTest("finance-data");
   }
 
+  @Test
+  void createInactiveBudget() {
+    runFeatureTest("create-inactive-budget");
+  }
+
   @BeforeAll
   public void financeApiTestBeforeAll() {
     runFeature("classpath:thunderjet/mod-finance/finance-junit.feature");


### PR DESCRIPTION
## Purpose
[MODFIN-405](https://folio-org.atlassian.net/browse/MODFIN-405) - Current budget is created with incorrect values ​​despite the received error

## Approach
Three new tests:
- Create an inactive budget without any allocation
-  Create an inactive budget with an allocation
-  Try to create a budget with negative allowableEncumbrance or allowableExpenditure (expect a 422)

[mod-finance PR](https://github.com/folio-org/mod-finance/pull/284)