### PR TITLE
[MODFISTO-515] Delete a pending payment to revert creation

### DIFF
--- a/acquisitions/src/main/resources/karate-config.js
+++ b/acquisitions/src/main/resources/karate-config.js
@@ -52,6 +52,7 @@ function fn() {
     createBudget: karate.read('classpath:thunderjet/mod-finance/reusable/createBudget.feature'),
     createTransaction: karate.read('classpath:thunderjet/mod-finance/reusable/createTransaction.feature'),
     createEncumbrance: karate.read('classpath:thunderjet/mod-finance/reusable/createEncumbrance.feature'),
+    createPayment: karate.read('classpath:thunderjet/mod-finance/reusable/createPayment.feature'),
     createPendingPayment: karate.read('classpath:thunderjet/mod-finance/reusable/createPendingPayment.feature'),
     createLedger: karate.read('classpath:thunderjet/mod-finance/reusable/createLedger.feature'),
     createExpenseClass: karate.read('classpath:thunderjet/mod-finance/reusable/createExpenseClass.feature'),

--- a/acquisitions/src/main/resources/karate-config.js
+++ b/acquisitions/src/main/resources/karate-config.js
@@ -51,6 +51,8 @@ function fn() {
     createFundWithParams: karate.read('classpath:thunderjet/mod-finance/reusable/createFundWithParams.feature'),
     createBudget: karate.read('classpath:thunderjet/mod-finance/reusable/createBudget.feature'),
     createTransaction: karate.read('classpath:thunderjet/mod-finance/reusable/createTransaction.feature'),
+    createEncumbrance: karate.read('classpath:thunderjet/mod-finance/reusable/createEncumbrance.feature'),
+    createPendingPayment: karate.read('classpath:thunderjet/mod-finance/reusable/createPendingPayment.feature'),
     createLedger: karate.read('classpath:thunderjet/mod-finance/reusable/createLedger.feature'),
     createExpenseClass: karate.read('classpath:thunderjet/mod-finance/reusable/createExpenseClass.feature'),
     createBudgetExpenseClass: karate.read('classpath:thunderjet/mod-finance/reusable/createBudgetExpenseClass.feature'),

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/allowable-encumbrance-and-expenditure-restrictions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/allowable-encumbrance-and-expenditure-restrictions.feature
@@ -1,17 +1,17 @@
 Feature: Test allowable encumbrance and expenditure restrictions
 
   Background:
+    * print karate.info.scenarioName
+
     * url baseUrl
-    # uncomment below line for development
-#    * callonce dev {tenant: 'testfinance4'}
     * call login testAdmin
     * def okapitokenAdmin = okapitoken
 
     * call login testUser
     * def okapitokenUser = okapitoken
 
-    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json'  }
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json'  }
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json' }
 
     * configure headers = headersUser
     * call variables
@@ -19,69 +19,26 @@ Feature: Test allowable encumbrance and expenditure restrictions
     * def ledgerId = call uuid
 
     # the ledger needs to have restrictEncumbrance=true
-    * call createLedger { 'id': '#(ledgerId)'}
+    * def v = call createLedger { id: '#(ledgerId)' }
 
 
   Scenario Outline: Test allowable encumbrance: remaining encumbrance would be <remaining>
     * def fundId = call uuid
     * def orderId = call uuid
     * def poLineId = call uuid
-    * def encumbranceId = call uuid
 
-    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(ledgerId)' }
+    * def v = call createFund { id: '#(fundId)' }
 
-    Given path 'finance/budgets'
-    And request
-    """
-    {
-      "id": "#(id)",
-      "name": "#(id)",
-      "budgetStatus": "Active",
-      "fundId": "#(fundId)",
-      "fiscalYearId":"#(globalFiscalYearId)",
-      "allocated": <allocated>,
-      "encumbered": <encumbered>,
-      "awaitingPayment": <awaitingPmt>,
-      "expenditures": <expenditures>,
-      "netTransfers": <netTransfers>,
-      "allowableEncumbrance": <allowableEnc>,
-      "allowableExpenditure": 120.0
-    }
-    """
-    When method POST
-    Then status 201
+    * def v = call createBudget { allowableExpenditure: 120.0 }
 
-    Given path 'finance/transactions/batch-all-or-nothing'
-    And request
-    """
-    {
-      "transactionsToCreate": [{
-        "id": "#(encumbranceId)",
-        "amount": <newEnc>,
-        "currency": "USD",
-        "fiscalYearId": "#(globalFiscalYearId)",
-        "source": "User",
-        "fromFundId": "#(fundId)",
-        "transactionType": "Encumbrance",
-        "encumbrance": {
-          "initialAmountEncumbered": <newEnc>,
-          "orderType": "One-Time",
-          "subscription": false,
-          "reEncumber": false,
-          "sourcePurchaseOrderId": "#(orderId)",
-          "sourcePoLineId": "#(poLineId)"
-        }
-      }]
-    }
-    """
-    When method POST
-    Then status <status>
+    * def result = call createEncumbrance { expectedStatus: <status> }
+    * assert status == 204 || result.response.errors[0].code == 'budgetRestrictedEncumbranceError'
 
     Examples:
-      | remaining  | allocated  | netTransfers | encumbered | awaitingPmt | expenditures | allowableEnc | newEnc | status |
-      | positive   | 100        | 10           | 50         | 25          | 17           | 110          | 28     | 204    |
-      | zero       | 100        | 10           | 50         | 25          | 17           | 110          | 29     | 204    |
-      | negative   | 100        | 10           | 50         | 25          | 17           | 110          | 30     | 422    |
+      | remaining  | allocated  | netTransfers | encumbered | awaitingPayment | expenditures | allowableEncumbrance | amount | status |
+      | positive   | 100        | 10           | 50         | 25              | 17           | 110                  | 28     | 204    |
+      | zero       | 100        | 10           | 50         | 25              | 17           | 110                  | 29     | 204    |
+      | negative   | 100        | 10           | 50         | 25              | 17           | 110                  | 30     | 422    |
 
 
   Scenario Outline: Test allowable encumbrance with pending payment: remaining encumbrance would be <remaining>
@@ -90,87 +47,19 @@ Feature: Test allowable encumbrance and expenditure restrictions
     * def invoiceId = call uuid
     * def invoiceLineId = call uuid
     * def poLineId = call uuid
-    * def encumbranceId = call uuid
-    * def pendingPaymentId = call uuid
 
-    * def v = call createFund { 'id': '#(fundId)', 'ledgerId': '#(ledgerId)' }
+    * def v = call createFund { id: '#(fundId)' }
 
-    Given path 'finance/budgets'
-    And request
-      """
-      {
-        "id": "#(id)",
-        "name": "#(id)",
-        "budgetStatus": "Active",
-        "fundId": "#(fundId)",
-        "fiscalYearId":"#(globalFiscalYearId)",
-        "allocated": <allocated>,
-        "encumbered": <encumbered>,
-        "awaitingPayment": <awaitingPmt>,
-        "expenditures": <expenditures>,
-        "netTransfers": <netTransfers>,
-        "allowableEncumbrance": 100.0,
-        "allowableExpenditure": <allowableExp>
-      }
-      """
-    When method POST
-    Then status 201
+    * def v = call createBudget
 
-    Given path 'finance/transactions/batch-all-or-nothing'
-    And request
-      """
-      {
-        "transactionsToCreate": [{
-          "id": "#(encumbranceId)",
-          "amount": <encumbrance>,
-          "currency": "USD",
-          "fiscalYearId": "#(globalFiscalYearId)",
-          "source": "User",
-          "fromFundId": "#(fundId)",
-          "transactionType": "Encumbrance",
-          "encumbrance": {
-            "initialAmountEncumbered": <encumbrance>,
-            "orderType": "One-Time",
-            "subscription": false,
-            "reEncumber": false,
-            "sourcePurchaseOrderId": "#(orderId)",
-            "sourcePoLineId": "#(poLineId)"
-          }
-        }]
-      }
-      """
-    When method POST
-    Then status 204
-
-    Given path 'finance/transactions/batch-all-or-nothing'
-    And request
-      """
-      {
-        "transactionsToCreate": [{
-          "id": "#(pendingPaymentId)",
-          "amount": <amount>,
-          "currency": "USD",
-          "fiscalYearId": "#(globalFiscalYearId)",
-          "source": "User",
-          "fromFundId": "#(fundId)",
-          "transactionType": "Pending payment",
-          "awaitingPayment": {
-            "encumbranceId": "#(encumbranceId)",
-            "releaseEncumbrance": <encumbrance>
-          },
-          "sourceInvoiceId": "#(invoiceId)",
-          "sourceInvoiceLineId": "#(invoiceLineId)"
-        }]
-      }
-      """
-    When method POST
-    Then status <status>
+    * def result = call createPendingPayment { expectedStatus: <status> }
+    * assert status == 204 || result.response.errors[0].code == 'budgetRestrictedEncumbranceError'
 
     Examples:
-      | remaining  | allocated  | netTransfers | encumbered | awaitingPmt | expenditures | allowableExp | encumbrance | amount | status |
-      | positive   | 100        | 10           | 50         | 25          | 25           | 100          | 10          | 9      | 204    |
-      | zero       | 100        | 10           | 50         | 25          | 25           | 100          | 10          | 10     | 204    |
-      | negative   | 100        | 10           | 50         | 25          | 25           | 100          | 10          | 11     | 422    |
+      | remaining  | allocated  | netTransfers | encumbered | awaitingPayment | expenditures | amount | status |
+      | positive   | 100        | 10           | 50         | 25              | 25           | 9      | 204    |
+      | zero       | 100        | 10           | 50         | 25              | 25           | 10     | 204    |
+      | negative   | 100        | 10           | 50         | 25              | 25           | 11     | 422    |
 
 
   Scenario Outline: Test allowable expenditure with pending payment: remaining expenditure would be <remaining>
@@ -182,161 +71,39 @@ Feature: Test allowable encumbrance and expenditure restrictions
     * def encumbranceId = call uuid
     * def pendingPaymentId = call uuid
 
-    * def v = call createFund { 'id': '#(fundId)', 'ledgerId': '#(ledgerId)' }
+    * def v = call createFund { id: '#(fundId)' }
 
-    Given path 'finance/budgets'
-    And request
-    """
-    {
-      "id": "#(id)",
-      "name": "#(id)",
-      "budgetStatus": "Active",
-      "fundId": "#(fundId)",
-      "fiscalYearId":"#(globalFiscalYearId)",
-      "allocated": <allocated>,
-      "encumbered": <encumbered>,
-      "awaitingPayment": <awaitingPmt>,
-      "expenditures": <expenditures>,
-      "netTransfers": <netTransfers>,
-      "allowableEncumbrance": 100.0,
-      "allowableExpenditure": <allowableExp>
-    }
-    """
-    When method POST
-    Then status 201
+    * def v = call createBudget
 
-    Given path 'finance/transactions/batch-all-or-nothing'
-    And request
-    """
-    {
-      "transactionsToCreate": [{
-        "id": "#(encumbranceId)",
-        "amount": <encumbrance>,
-        "currency": "USD",
-        "fiscalYearId": "#(globalFiscalYearId)",
-        "source": "User",
-        "fromFundId": "#(fundId)",
-        "transactionType": "Encumbrance",
-        "encumbrance": {
-          "initialAmountEncumbered": <encumbrance>,
-          "orderType": "One-Time",
-          "subscription": false,
-          "reEncumber": false,
-          "sourcePurchaseOrderId": "#(orderId)",
-          "sourcePoLineId": "#(poLineId)"
-        }
-      }]
-    }
-    """
-    When method POST
-    Then status 204
+    * def v = call createEncumbrance { id: '#(encumbranceId)', amount: <encumbrance> }
 
-    Given path 'finance/transactions/batch-all-or-nothing'
-    And request
-    """
-    {
-      "transactionsToCreate": [{
-        "id": "#(pendingPaymentId)",
-        "amount": <amount>,
-        "currency": "USD",
-        "fiscalYearId": "#(globalFiscalYearId)",
-        "source": "User",
-        "fromFundId": "#(fundId)",
-        "transactionType": "Pending payment",
-        "awaitingPayment": {
-          "encumbranceId": "#(encumbranceId)",
-          "releaseEncumbrance": <encumbrance>
-        },
-        "sourceInvoiceId": "#(invoiceId)",
-        "sourceInvoiceLineId": "#(invoiceLineId)"
-      }]
-    }
-    """
-    When method POST
-    Then status <status>
+    * def result = call createPendingPayment { releaseEncumbrance: true, expectedStatus: <status> }
+    * assert status == 204 || result.response.errors[0].code == 'budgetRestrictedExpendituresError'
 
     Examples:
-      | remaining  | allocated  | netTransfers | encumbered | awaitingPmt | expenditures | allowableExp | encumbrance | amount | status |
-      | positive   | 100        | 10           | 0          | 50          | 50           | 100          | 10          | 9      | 204    |
-      | zero       | 100        | 10           | 0          | 50          | 50           | 100          | 10          | 10     | 204    |
-      | negative   | 100        | 10           | 0          | 50          | 50           | 100          | 10          | 11     | 422    |
+      | remaining  | allocated  | netTransfers | encumbered | awaitingPayment | expenditures | encumbrance | amount | status |
+      | positive   | 100        | 10           | 0          | 50              | 50           | 10          | 9      | 204    |
+      | zero       | 100        | 10           | 0          | 50              | 50           | 10          | 10     | 204    |
+      | negative   | 100        | 10           | 0          | 50              | 50           | 10          | 11     | 422    |
 
 
   Scenario Outline: Test allowable expenditure with payment: remaining expenditure would be <remaining>
     * def fundId = call uuid
     * def invoiceId = call uuid
-    * def pendingPaymentId = call uuid
-    * def paymentId = call uuid
     * def invoiceId = call uuid
     * def invoiceLineId = call uuid
 
-    * def v = call createFund { 'id': '#(fundId)', 'ledgerId': '#(ledgerId)' }
+    * def v = call createFund { id: '#(fundId)' }
 
-    Given path 'finance/budgets'
-    And request
-    """
-    {
-      "id": "#(id)",
-      "name": "#(id)",
-      "budgetStatus": "Active",
-      "fundId": "#(fundId)",
-      "fiscalYearId":"#(globalFiscalYearId)",
-      "allocated": <allocated>,
-      "encumbered": <encumbered>,
-      "awaitingPayment": 0,
-      "expenditures": <expenditures>,
-      "netTransfers": <netTransfers>,
-      "allowableEncumbrance": 100.0,
-      "allowableExpenditure": <allowableExp>
-    }
-    """
-    When method POST
-    Then status 201
+    * def v = call createBudget
 
-    Given path 'finance/transactions/batch-all-or-nothing'
-    And request
-      """
-      {
-        "transactionsToCreate": [{
-          "id": "#(pendingPaymentId)",
-          "amount": <awaitingPmt>,
-          "currency": "USD",
-          "fiscalYearId": "#(globalFiscalYearId)",
-          "source": "User",
-          "fromFundId": "#(fundId)",
-          "transactionType": "Pending payment",
-          "awaitingPayment": {
-            "releaseEncumbrance": false
-          },
-          "sourceInvoiceId": "#(invoiceId)",
-          "sourceInvoiceLineId": "#(invoiceLineId)"
-        }]
-      }
-      """
-    When method POST
-    Then status 204
+    * def v = call createPendingPayment { amount: <ppAmount> }
 
-    Given path 'finance/transactions/batch-all-or-nothing'
-    And request
-    """
-    {
-      "transactionsToCreate": [{
-        "id": "#(paymentId)",
-        "amount": <amount>,
-        "currency": "USD",
-        "fiscalYearId": "#(globalFiscalYearId)",
-        "source": "User",
-        "fromFundId": "#(fundId)",
-        "transactionType": "Payment",
-        "sourceInvoiceId": "#(invoiceId)"
-      }]
-    }
-    """
-    When method POST
-    Then status <status>
+    * def result = call createPayment { amount: <paymentAmount>, expectedStatus: <status> }
+    * assert status == 204 || result.response.errors[0].code == 'budgetRestrictedExpendituresError'
 
     Examples:
-      | remaining  | allocated  | netTransfers | encumbered | awaitingPmt | expenditures | allowableExp | amount | status |
-      | positive   | 100        | 10           | 0          |  10         | 100          | 100          |  8     | 204    |
-      | positive   | 100        | 10           | 0          |  10         | 100          | 100          |  9     | 204    |
-      | positive   | 100        | 10           | 0          |  10         | 100          | 100          | 10     | 204    |
+      | remaining  | allocated  | netTransfers | encumbered | ppAmount | paymentAmount | status |
+      | positive   | 100        | 10           | 0          |  10      |  8            | 204    |
+      | positive   | 100        | 10           | 0          |  10      |  9            | 204    |
+      | positive   | 100        | 10           | 0          |  10      | 10            | 204    |

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/batch-transaction-api.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/batch-transaction-api.feature
@@ -1,168 +1,203 @@
-# For https://issues.folio.org/browse/MODFISTO-458
-@parallel=false
+# For MODFISTO-458, MODFISTO-515
 Feature: Batch Transaction API
 
-  Background:
-    * print karate.info.scenarioName
+Background:
+  * print karate.info.scenarioName
 
-    * url baseUrl
-    * callonce login testUser
-    * def okapitokenUser = okapitoken
+  * url baseUrl
+  * callonce login testUser
+  * def okapitokenUser = okapitoken
 
-    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
-    * configure headers = headersUser
+  * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
+  * configure headers = headersUser
 
-    * callonce variables
-
-    * def fundId = callonce uuid1
-    * def budgetId = callonce uuid2
-    * def orderId = callonce uuid3
-    * def poLineId1 = callonce uuid4
-    * def poLineId2 = callonce uuid5
-    * def poLineId3 = callonce uuid6
-    * def invoiceId = callonce uuid7
-    * def invoiceLineId1 = callonce uuid8
-    * def invoiceLineId2 = callonce uuid9
-    * def encumbranceId1 = callonce uuid10
-    * def encumbranceId2 = callonce uuid11
-    * def encumbranceId3 = callonce uuid12
-    * def allocationId = callonce uuid13
-    * def pendingPaymentId1 = callonce uuid14
-    * def pendingPaymentId2 = callonce uuid15
+  * callonce variables
 
 
-  Scenario: Create fund and budget
-    * def v = call createFund { id: '#(fundId)' }
-    * def v = call createBudget { id: '#(budgetId)', allocated: 100, fundId: '#(fundId)', status: 'Active' }
+Scenario: Use the batch transaction API to create, update and delete transactions
+  * def fundId = call uuid
+  * def budgetId = call uuid
+  * def orderId = call uuid
+  * def poLineId1 = call uuid
+  * def poLineId2 = call uuid
+  * def poLineId3 = call uuid
+  * def invoiceId = call uuid
+  * def invoiceLineId1 = call uuid
+  * def invoiceLineId2 = call uuid
+  * def encumbranceId1 = call uuid
+  * def encumbranceId2 = call uuid
+  * def encumbranceId3 = call uuid
+  * def allocationId = call uuid
+  * def pendingPaymentId1 = call uuid
+  * def pendingPaymentId2 = call uuid
+
+  * print "Create fund and budget"
+  * def v = call createFund { id: '#(fundId)' }
+  * def v = call createBudget { id: '#(budgetId)', allocated: 100, fundId: '#(fundId)', status: 'Active' }
+
+  * print "Create initial transactions"
+  * table encumbrances
+    | id             | amount | description     | poLineId  |
+    | encumbranceId1 | 10     | 'encumbrance 1' | poLineId1 |
+    | encumbranceId2 | 5      | 'encumbrance 2' | poLineId2 |
+    | encumbranceId3 | 3      | 'encumbrance 3' | poLineId3 |
+  * def v = call createEncumbrance encumbrances
 
 
-  Scenario Outline: Create initial transactions with the old API
-    * def id = <id>
-    * def amount = <amount>
-    * def description = "<description>"
-    * def sourcePoLineId = <sourcePoLineId>
+  * print "Call the batch transaction API to create, update and delete transactions"
 
-    Given path 'finance/transactions/batch-all-or-nothing'
-    And request
-    """
-    {
-      "transactionsToCreate": [{
-        "id": "#(id)",
-        "amount": #(amount),
+  Given path 'finance/transactions', encumbranceId3
+  When method GET
+  Then status 200
+  * def encumbrance3 = $
+  * set encumbrance3.encumbrance.status = "Released"
+
+  Given path 'finance/transactions/batch-all-or-nothing'
+  And request
+  """
+  {
+    "transactionsToCreate": [
+      {
+        "id": "#(pendingPaymentId1)",
+        "amount": 10,
         "currency": "USD",
-        "description": "#(description)",
+        "fiscalYearId": "#(globalFiscalYearId)",
+        "source": "Invoice",
+        "fromFundId": "#(fundId)",
+        "transactionType": "Pending payment",
+        "awaitingPayment": {
+          "encumbranceId": "#(encumbranceId1)",
+          "releaseEncumbrance": true
+        },
+        "sourceInvoiceId": "#(invoiceId)",
+        "sourceInvoiceLineId": "#(invoiceLineId1)"
+      },
+      {
+        "id": "#(pendingPaymentId2)",
+        "amount": 9,
+        "currency": "USD",
+        "fiscalYearId": "#(globalFiscalYearId)",
+        "source": "Invoice",
+        "fromFundId": "#(fundId)",
+        "transactionType": "Pending payment",
+        "awaitingPayment": {
+          "releaseEncumbrance": false
+        },
+        "sourceInvoiceId": "#(invoiceId)",
+        "sourceInvoiceLineId": "#(invoiceLineId2)"
+      },
+      {
+        "id": "#(allocationId)",
+        "amount": 7,
+        "currency": "USD",
+        "description": "To allocation",
         "fiscalYearId": "#(globalFiscalYearId)",
         "source": "User",
-        "fromFundId": "#(fundId)",
-        "transactionType": "Encumbrance",
-        "encumbrance" : {
-          "initialAmountEncumbered": #(amount),
-          "status": "Unreleased",
-          "orderType": "One-Time",
-          "subscription": false,
-          "reEncumber": false,
-          "sourcePurchaseOrderId": "#(orderId)",
-          "sourcePoLineId": "#(sourcePoLineId)"
-        }
-      }]
-    }
-    """
-    When method POST
-    Then status 204
-
-    Examples:
-      | id             | amount | description   | sourcePoLineId |
-      | encumbranceId1 | 10     | encumbrance 1 | poLineId1      |
-      | encumbranceId2 | 5      | encumbrance 2 | poLineId2      |
-      | encumbranceId3 | 3      | encumbrance 3 | poLineId3      |
+        "toFundId": "#(fundId)",
+        "transactionType": "Allocation"
+      }
+    ],
+    "transactionsToUpdate": [
+      "#(encumbrance3)"
+    ],
+    "idsOfTransactionsToDelete": [
+      "#(encumbranceId2)"
+    ]
+  }
+  """
+  When method POST
+  Then status 204
 
 
-  Scenario: Call the batch transaction API to create, update and delete transactions
-    Given path 'finance/transactions', encumbranceId3
-    When method GET
-    Then status 200
-    * def encumbrance3 = $
-    * set encumbrance3.encumbrance.status = "Released"
+  * print "Check resulting transactions and budget"
 
-    Given path 'finance/transactions/batch-all-or-nothing'
-    And request
+  Given path 'finance/transactions'
+  And param query = 'fromFundId==' + fundId
+  When method GET
+  Then status 200
+  And match $.totalRecords == 4
+
+  Given path 'finance/transactions'
+  And param query = 'toFundId==' + fundId
+  When method GET
+  Then status 200
+  # the second allocation is the initial allocation for the fund
+  And match $.totalRecords == 2
+
+  # Note: budgets are not updated when an encumbrance is deleted
+  Given path '/finance/budgets', budgetId
+  When method GET
+  Then status 200
+  And match $.allocated == 107
+  And match $.available == 83
+  And match $.expenditures == 0
+  And match $.credits == 0
+  And match $.encumbered == 5
+  And match $.awaitingPayment == 19
+  And match $.unavailable == 24
+
+
+Scenario Outline: Create and delete a pending payment with an encumbrance - releaseEncumbrance: <releaseEncumbrance>
+  * def fundId = call uuid
+  * def budgetId = call uuid
+  * def orderId = call uuid
+  * def poLineId = call uuid
+  * def invoiceId = call uuid
+  * def invoiceLineId = call uuid
+  * def encumbranceId = call uuid
+  * def pendingPaymentId = call uuid
+  * def releaseEncumbrance = <releaseEncumbrance>
+
+  * print "Create fund and budget"
+  * def v = call createFund { id: '#(fundId)' }
+  * def v = call createBudget { id: '#(budgetId)', allocated: 100, fundId: '#(fundId)', status: 'Active' }
+
+  * print "Create the encumbrance and pending payment"
+  * def v = call createEncumbrance { id: '#(encumbranceId)', amount: 10 }
+  * def v = call createPendingPayment { id: '#(pendingPaymentId)', amount: 5, fromFundId: '#(fundId)', encumbranceId: '#(encumbranceId)', releaseEncumbrance: '#(releaseEncumbrance)' }
+
+
+  * print "Delete the pending payment"
+
+  Given path 'finance/transactions/batch-all-or-nothing'
+  And request
     """
     {
-      "transactionsToCreate": [
-        {
-          "id": "#(pendingPaymentId1)",
-          "amount": 10,
-          "currency": "USD",
-          "fiscalYearId": "#(globalFiscalYearId)",
-          "source": "Invoice",
-          "fromFundId": "#(fundId)",
-          "transactionType": "Pending payment",
-          "awaitingPayment": {
-            "encumbranceId": "#(encumbranceId1)",
-            "releaseEncumbrance": true
-          },
-          "sourceInvoiceId": "#(invoiceId)",
-          "sourceInvoiceLineId": "#(invoiceLineId1)"
-        },
-        {
-          "id": "#(pendingPaymentId2)",
-          "amount": 9,
-          "currency": "USD",
-          "fiscalYearId": "#(globalFiscalYearId)",
-          "source": "Invoice",
-          "fromFundId": "#(fundId)",
-          "transactionType": "Pending payment",
-          "awaitingPayment": {
-            "releaseEncumbrance": false
-          },
-          "sourceInvoiceId": "#(invoiceId)",
-          "sourceInvoiceLineId": "#(invoiceLineId2)"
-        },
-        {
-          "id": "#(allocationId)",
-          "amount": 7,
-          "currency": "USD",
-          "description": "To allocation",
-          "fiscalYearId": "#(globalFiscalYearId)",
-          "source": "User",
-          "toFundId": "#(fundId)",
-          "transactionType": "Allocation"
-        }
-      ],
-      "transactionsToUpdate": [
-        #(encumbrance3)
-      ],
       "idsOfTransactionsToDelete": [
-        "#(encumbranceId2)"
+        "#(pendingPaymentId)"
       ]
     }
     """
-    When method POST
-    Then status 204
+  When method POST
+  Then status 204
 
 
-  Scenario: Check resulting transactions and budget
-    Given path 'finance/transactions'
-    And param query = 'fromFundId==' + fundId
-    When method GET
-    Then status 200
-    And match $.totalRecords == 4
+  * print "Check resulting transactions and budget"
 
-    Given path 'finance/transactions'
-    And param query = 'toFundId==' + fundId
-    When method GET
-    Then status 200
-    # the second allocation is the initial allocation for the fund
-    And match $.totalRecords == 2
+  Given path 'finance/transactions', pendingPaymentId
+  When method GET
+  Then status 404
 
-    # Note: budgets are not updated when an encumbrance is deleted
-    Given path '/finance/budgets', budgetId
-    When method GET
-    Then status 200
-    And match $.allocated == 107
-    And match $.available == 83
-    And match $.expenditures == 0
-    And match $.credits == 0
-    And match $.encumbered == 5
-    And match $.awaitingPayment == 19
-    And match $.unavailable == 24
+  Given path 'finance/transactions', encumbranceId
+  When method GET
+  Then status 200
+  And match $.amount == releaseEncumbrance ? 0 : 10
+  And match $.encumbrance.initialAmountEncumbered == 10
+  And match $.encumbrance.amountAwaitingPayment == 0
+  And match $.encumbrance.status == releaseEncumbrance ? 'Released' : 'Unreleased'
+
+  Given path '/finance/budgets', budgetId
+  When method GET
+  Then status 200
+  And match $.allocated == 100
+  And match $.available == releaseEncumbrance ? 100 : 90
+  And match $.expenditures == 0
+  And match $.credits == 0
+  And match $.encumbered == releaseEncumbrance ? 0 : 10
+  And match $.awaitingPayment == 0
+  And match $.unavailable == releaseEncumbrance ? 0 : 10
+
+Examples:
+  | releaseEncumbrance  |
+  | true                |
+  | false               |

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/batch-transaction-api.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/batch-transaction-api.feature
@@ -154,7 +154,7 @@ Scenario Outline: Create and delete a pending payment with an encumbrance - rele
 
   * print "Create the encumbrance and pending payment"
   * def v = call createEncumbrance { id: '#(encumbranceId)', amount: 10 }
-  * def v = call createPendingPayment { id: '#(pendingPaymentId)', amount: 5, fromFundId: '#(fundId)', encumbranceId: '#(encumbranceId)', releaseEncumbrance: '#(releaseEncumbrance)' }
+  * def v = call createPendingPayment { id: '#(pendingPaymentId)', amount: 5, encumbranceId: '#(encumbranceId)', releaseEncumbrance: '#(releaseEncumbrance)' }
 
 
   * print "Delete the pending payment"

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createBudget.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createBudget.feature
@@ -10,6 +10,12 @@ Feature: budget
     * def fiscalYearId = karate.get('fiscalYearId', globalFiscalYearId)
     * def budgetStatus = karate.get('budgetStatus', 'Active')
     * def statusExpenseClasses = karate.get('statusExpenseClasses', [])
+    * def allowableEncumbrance = karate.get('allowableEncumbrance', 100.0)
+    * def allowableExpenditure = karate.get('allowableExpenditure', 100.0)
+    * def awaitingPayment = karate.get('awaitingPayment', 0)
+    * def encumbered = karate.get('encumbered', 0)
+    * def expenditures = karate.get('expenditures', 0)
+    * def netTransfers = karate.get('netTransfers', 0)
 
     Given path 'finance/budgets'
     And request
@@ -21,8 +27,12 @@ Feature: budget
       "name": "#(id)",
       "fiscalYearId":"#(fiscalYearId)",
       "allocated": "#(allocated)",
-      "allowableEncumbrance": 100.0,
-      "allowableExpenditure": 100.0,
+      "awaitingPayment": "#(awaitingPayment)",
+      "encumbered": "#(encumbered)",
+      "expenditures": "#(expenditures)",
+      "netTransfers": "#(netTransfers)",
+      "allowableEncumbrance": "#(allowableEncumbrance)",
+      "allowableExpenditure": "#(allowableExpenditure)",
       "statusExpenseClasses": "#(statusExpenseClasses)"
     }
     """

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createEncumbrance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createEncumbrance.feature
@@ -1,0 +1,34 @@
+Feature: Create an encumbrance
+
+  Background:
+    * url baseUrl
+
+  Scenario: Create an encumbrance
+    * def id = karate.get('id', uuid())
+    * def fiscalYearId = karate.get('fiscalYearId', globalFiscalYearId)
+    * def description = karate.get('description', null)
+    * def sourcePurchaseOrderId = karate.get('orderId', null)
+    * def sourcePoLineId = karate.get('poLineId', null)
+    * def expenseClassId = karate.get('expenseClassId', null)
+    * def transactionEncumbrance = { initialAmountEncumbered: '#(amount)', status: 'Unreleased', sourcePurchaseOrderId: '#(sourcePurchaseOrderId)', sourcePoLineId: '#(sourcePoLineId)', orderType: 'One-Time', subscription: false, reEncumber: false }
+
+    Given path 'finance-storage/transactions/batch-all-or-nothing'
+    And request
+      """
+      {
+      "transactionsToCreate": [{
+        "id": "#(id)",
+        "amount": "#(amount)",
+        "currency": "USD",
+        "description": "#(description)",
+        "encumbrance": "#(transactionEncumbrance)",
+        "expenseClassId": "#(expenseClassId)",
+        "fiscalYearId": "#(fiscalYearId)",
+        "fromFundId": "#(fundId)",
+        "source": "User",
+        "transactionType": "Encumbrance"
+      }]
+      }
+      """
+    When method POST
+    Then status 204

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createEncumbrance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createEncumbrance.feature
@@ -11,6 +11,7 @@ Feature: Create an encumbrance
     * def sourcePoLineId = karate.get('poLineId', null)
     * def expenseClassId = karate.get('expenseClassId', null)
     * def transactionEncumbrance = { initialAmountEncumbered: '#(amount)', status: 'Unreleased', sourcePurchaseOrderId: '#(sourcePurchaseOrderId)', sourcePoLineId: '#(sourcePoLineId)', orderType: 'One-Time', subscription: false, reEncumber: false }
+    * def expectedStatus = karate.get('expectedStatus', 204)
 
     Given path 'finance-storage/transactions/batch-all-or-nothing'
     And request
@@ -31,4 +32,4 @@ Feature: Create an encumbrance
       }
       """
     When method POST
-    Then status 204
+    Then assert responseStatus == expectedStatus

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createPayment.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createPayment.feature
@@ -1,38 +1,36 @@
-Feature: Create a pending payment
+Feature: Create a payment
 
   Background:
     * url baseUrl
 
-  Scenario: Create a pending payment
+  Scenario: Create a payment
     * def id = karate.get('id', uuid())
     * def fiscalYearId = karate.get('fiscalYearId', globalFiscalYearId)
     * def description = karate.get('description', null)
+    * def expenseClassId = karate.get('expenseClassId', null)
+    * def encumbranceId = karate.get('encumbranceId', null)
     * def fromFundId = karate.get('fundId', null)
     * def sourceInvoiceId = karate.get('invoiceId', null)
     * def sourceInvoiceLineId = karate.get('invoiceLineId', null)
-    * def expenseClassId = karate.get('expenseClassId', null)
-    * def encumbranceId = karate.get('encumbranceId', null)
-    * def releaseEncumbrance = karate.get('releaseEncumbrance', false)
-    * def awaitingPayment = { encumbranceId: '#(encumbranceId)', releaseEncumbrance: '#(releaseEncumbrance)' }
     * def expectedStatus = karate.get('expectedStatus', 204)
 
-    Given path 'finance-storage/transactions/batch-all-or-nothing'
+    Given path 'finance/transactions/batch-all-or-nothing'
     And request
       """
       {
         "transactionsToCreate": [{
           "id": "#(id)",
           "amount": "#(amount)",
-          "awaitingPayment": "#(awaitingPayment)",
           "currency": "USD",
           "description": "#(description)",
           "expenseClassId": "#(expenseClassId)",
           "fiscalYearId": "#(fiscalYearId)",
-          "fromFundId": "#(fromFundId)",
           "source": "User",
+          "fromFundId": "#(fundId)",
+          "transactionType": "Payment",
+          "paymentEncumbranceId": "#(encumbranceId)",
           "sourceInvoiceId": "#(sourceInvoiceId)",
-          "sourceInvoiceLineId": "#(sourceInvoiceLineId)",
-          "transactionType": "Pending payment"
+          "sourceInvoiceLineId": "#(sourceInvoiceLineId)"
         }]
       }
       """

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createPendingPayment.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createPendingPayment.feature
@@ -1,0 +1,43 @@
+Feature: Create a pending payment
+
+  Background:
+    * url baseUrl
+
+  Scenario: Create a pending payment
+    * def id = karate.get('id', uuid())
+    * def fiscalYearId = karate.get('fiscalYearId', globalFiscalYearId)
+    * def description = karate.get('description', null)
+    * def fromFundId = karate.get('fromFundId', null)
+    * def toFundId = karate.get('toFundId', null)
+    * def sourcePurchaseOrderId = karate.get('orderId', null)
+    * def sourcePoLineId = karate.get('poLineId', null)
+    * def sourceInvoiceId = karate.get('invoiceId', null)
+    * def sourceInvoiceLineId = karate.get('invoiceLineId', null)
+    * def expenseClassId = karate.get('expenseClassId', null)
+    * def encumbranceId = karate.get('encumbranceId', null)
+    * def releaseEncumbrance = karate.get('releaseEncumbrance', false)
+    * def awaitingPayment = { encumbranceId: '#(encumbranceId)', releaseEncumbrance: '#(releaseEncumbrance)' }
+
+    Given path 'finance-storage/transactions/batch-all-or-nothing'
+    And request
+      """
+      {
+        "transactionsToCreate": [{
+          "id": "#(id)",
+          "amount": "#(amount)",
+          "awaitingPayment": "#(awaitingPayment)",
+          "currency": "USD",
+          "description": "#(description)",
+          "expenseClassId": "#(expenseClassId)",
+          "fiscalYearId": "#(fiscalYearId)",
+          "fromFundId": "#(fromFundId)",
+          "toFundId": "#(toFundId)",
+          "source": "User",
+          "sourceInvoiceId": "#(sourceInvoiceId)",
+          "sourceInvoiceLineId": "#(sourceInvoiceLineId)",
+          "transactionType": "Pending payment"
+        }]
+      }
+      """
+    When method POST
+    Then status 204


### PR DESCRIPTION
## Purpose
[MODFISTO-515](https://folio-org.atlassian.net/browse/MODFISTO-515) - Support deleting pending payments with batch transaction API

## Approach
- New tests for the batch API, to delete a pending payment
- Fixed and updated the tests to check the allowable encumbrance/expenditures (previously the test for expenditures was actually checking encumbrance; also it is more realistic to create a pending payment before creating a payment - this way the test will be less dependent on the implementation)

[mod-finance-storage PR](https://github.com/folio-org/mod-finance-storage/pull/465)