### PR TITLE
[MODFIN-417] Finance-data integration tests should run in parallel

### DIFF
--- a/acquisitions/src/test/java/org/folio/FinanceApiTest.java
+++ b/acquisitions/src/test/java/org/folio/FinanceApiTest.java
@@ -14,6 +14,7 @@ public class FinanceApiTest extends TestBase {
 
   // default module settings
   private static final String TEST_BASE_PATH = "classpath:thunderjet/mod-finance/features/";
+  private static final int THREAD_COUNT = 4;
 
   public FinanceApiTest() {
     super(new TestIntegrationService(
@@ -209,7 +210,7 @@ public class FinanceApiTest extends TestBase {
 
   @Test
   void financeDataTest() {
-    runFeatureTest("finance-data");
+    runFeatureTest("finance-data", THREAD_COUNT);
   }
 
   @Test


### PR DESCRIPTION
## Purpose
[[MODFIN-417] Finance-data integration tests should run in parallel](https://folio-org.atlassian.net/browse/MODFIN-417)

## Approach
- Use custom fund tag to differentiate job ids after creating finance data
- Filter finance data logs by job id's determined by the tag

### Verification
Tested the feature with 1, 2, 4, 8, 16 threads to run scenarios in parallel
![image](https://github.com/user-attachments/assets/db9d9e28-8bd0-46ee-b2dc-c0224de790d8)