### PR TITLE
Fat 19290 entitle minimal set of applications

### DIFF
--- a/common/src/main/resources/common/eureka/application.feature
+++ b/common/src/main/resources/common/eureka/application.feature
@@ -5,14 +5,13 @@ Feature: Applications
 
   @applicationSearch
   Scenario: searchApplication
-    Given path 'applications'
-    When method GET
-    Then status 200
-    * def totalAmount = get response.totalRecords
 
     Given path 'applications'
-    And param limit = totalAmount
+    And param limit = requiredApplications.length
+    And param query = orWhereQuery('name', requiredApplications)
     When method GET
     Then status 200
     * def appIds = response.applicationDescriptors.map(x => x.id)
+    * def receivedAppNames = response.applicationDescriptors.map(x => x.name)
+    Then match receivedAppNames contains requiredApplications
     * karate.set('applicationIds', appIds)

--- a/edge-patron/src/main/resources/karate-config.js
+++ b/edge-patron/src/main/resources/karate-config.js
@@ -37,6 +37,13 @@ function fn() {
     },
     random_uuid: function() {
       return java.util.UUID.randomUUID() + '';
+    },
+
+    orWhereQuery: function(field, values) {
+      var orStr = ' or ';
+      var string = '(' + field + '=(' + values.map(x => '"' + x + '"').join(orStr) + '))';
+
+      return string;
     }
   };
   if (env == 'snapshot-2') {

--- a/mod-batch-print/src/main/resources/karate-config.js
+++ b/mod-batch-print/src/main/resources/karate-config.js
@@ -45,6 +45,13 @@ function fn() {
       for (var i = 0; i < 5; i++)
         text += possible.charAt(Math.floor(Math.random() * possible.length));
       return text;
+    },
+
+    orWhereQuery: function(field, values) {
+      var orStr = ' or ';
+      var string = '(' + field + '=(' + values.map(x => '"' + x + '"').join(orStr) + '))';
+
+      return string;
     }
   };
 

--- a/mod-batch-print/src/main/resources/odin/mod-batch-print/batch-print-junit-eureka.feature
+++ b/mod-batch-print/src/main/resources/odin/mod-batch-print/batch-print-junit-eureka.feature
@@ -15,5 +15,7 @@ Feature: mod-batch-print integration tests
       | 'batch-print.print.read'                |
       | 'batch-print.print.write'               |
 
+    * def requiredApplications = ['app-platform-complete', 'app-platform-minimal']
+
   Scenario: create tenant and users for testing
     Given call read('classpath:common/eureka/setup-users.feature')

--- a/mod-calendar/src/main/resources/bama/mod-calendar/calendar-junit-eureka.feature
+++ b/mod-calendar/src/main/resources/bama/mod-calendar/calendar-junit-eureka.feature
@@ -12,5 +12,7 @@ Feature: mod-calendar integration tests
       | 'calendar.endpoint.calendars.allOpenings.get'         |
       | 'calendar.endpoint.calendars.surroundingOpenings.get' |
 
+    * def requiredApplications = ['app-platform-complete', 'app-platform-minimal']
+
   Scenario: create tenant and users for testing
     Given call read('classpath:common/eureka/setup-users.feature')

--- a/mod-calendar/src/main/resources/karate-config.js
+++ b/mod-calendar/src/main/resources/karate-config.js
@@ -45,6 +45,13 @@ function fn() {
       for (var i = 0; i < 5; i++)
         text += possible.charAt(Math.floor(Math.random() * possible.length));
       return text;
+    },
+
+    orWhereQuery: function(field, values) {
+      var orStr = ' or ';
+      var string = '(' + field + '=(' + values.map(x => '"' + x + '"').join(orStr) + '))';
+
+      return string;
     }
   };
 

--- a/mod-circulation-storage/src/main/resources/karate-config.js
+++ b/mod-circulation-storage/src/main/resources/karate-config.js
@@ -52,6 +52,13 @@ function fn() {
     pause: function(millis) {
       var Thread = Java.type('java.lang.Thread');
       Thread.sleep(millis);
+    },
+
+    orWhereQuery: function(field, values) {
+      var orStr = ' or ';
+      var string = '(' + field + '=(' + values.map(x => '"' + x + '"').join(orStr) + '))';
+
+      return string;
     }
   };
 

--- a/mod-circulation/src/main/resources/karate-config.js
+++ b/mod-circulation/src/main/resources/karate-config.js
@@ -52,6 +52,13 @@ function fn() {
     pause: function(millis) {
       var Thread = Java.type('java.lang.Thread');
       Thread.sleep(millis);
+    },
+
+    orWhereQuery: function(field, values) {
+      var orStr = ' or ';
+      var string = '(' + field + '=(' + values.map(x => '"' + x + '"').join(orStr) + '))';
+
+      return string;
     }
   };
 

--- a/mod-copycat/src/main/resources/folijet/mod-copycat/copycat-junit-eureka.feature
+++ b/mod-copycat/src/main/resources/folijet/mod-copycat/copycat-junit-eureka.feature
@@ -11,5 +11,7 @@ Feature: mod-copycat integration tests
       | 'copycat.profiles.item.put'                               |
       | 'copycat.profiles.item.delete'                            |
 
+    * def requiredApplications = ['app-platform-complete', 'app-platform-minimal']
+
   Scenario: create tenant and users for testing
     Given call read('classpath:common/eureka/setup-users.feature')

--- a/mod-copycat/src/main/resources/karate-config.js
+++ b/mod-copycat/src/main/resources/karate-config.js
@@ -45,6 +45,13 @@ function fn() {
       for (var i = 0; i < 5; i++)
         text += possible.charAt(Math.floor(Math.random() * possible.length));
       return text;
+    },
+
+    orWhereQuery: function(field, values) {
+      var orStr = ' or ';
+      var string = '(' + field + '=(' + values.map(x => '"' + x + '"').join(orStr) + '))';
+
+      return string;
     }
   };
 

--- a/mod-entities-links/src/main/resources/karate-config.js
+++ b/mod-entities-links/src/main/resources/karate-config.js
@@ -57,6 +57,13 @@ function fn() {
     },
     sleep: function(seconds) {
       java.lang.Thread.sleep(seconds * 1000);
+    },
+
+    orWhereQuery: function(field, values) {
+      var orStr = ' or ';
+      var string = '(' + field + '=(' + values.map(x => '"' + x + '"').join(orStr) + '))';
+
+      return string;
     }
   };
 

--- a/mod-feesfines/src/main/resources/karate-config.js
+++ b/mod-feesfines/src/main/resources/karate-config.js
@@ -47,6 +47,13 @@ function fn() {
       for (var i = 0; i < 5; i++)
         text += possible.charAt(Math.floor(Math.random() * possible.length));
       return text;
+    },
+
+    orWhereQuery: function(field, values) {
+      var orStr = ' or ';
+      var string = '(' + field + '=(' + values.map(x => '"' + x + '"').join(orStr) + '))';
+
+      return string;
     }
   };
 

--- a/mod-fqm-manager/src/main/resources/karate-config.js
+++ b/mod-fqm-manager/src/main/resources/karate-config.js
@@ -44,6 +44,13 @@ function fn() {
       for (var i = 0; i < 5; i++)
         text += possible.charAt(Math.floor(Math.random() * possible.length));
       return text;
+    },
+
+    orWhereQuery: function(field, values) {
+      var orStr = ' or ';
+      var string = '(' + field + '=(' + values.map(x => '"' + x + '"').join(orStr) + '))';
+
+      return string;
     }
   };
 

--- a/mod-kb-ebsco-java/src/main/resources/karate-config.js
+++ b/mod-kb-ebsco-java/src/main/resources/karate-config.js
@@ -61,7 +61,14 @@ function fn() {
     },
     replaceRegex: function(line, regex, newString) {
       return line.replace(new RegExp(regex, "gm"), newString);
-    }
+    },
+
+     orWhereQuery: function(field, values) {
+       var orStr = ' or ';
+       var string = '(' + field + '=(' + values.map(x => '"' + x + '"').join(orStr) + '))';
+
+       return string;
+     }
   };
 
   if (env == 'snapshot-2') {

--- a/mod-linked-data/src/main/resources/citation/mod-linked-data/eureka/linked-data-junit.feature
+++ b/mod-linked-data/src/main/resources/citation/mod-linked-data/eureka/linked-data-junit.feature
@@ -48,5 +48,7 @@ Feature: mod-linked-data integration tests
       | 'mod-settings.global.write.ui-quick-marc.lccn-duplicate-check.manage' |
       | 'mod-settings.global.read.ui-quick-marc.lccn-duplicate-check.manage' |
 
+    * def requiredApplications = ['app-platform-complete', 'app-platform-minimal', 'app-linked-data', 'app-fqm', 'app-acquisitions']
+
   Scenario: create tenant and users for testing
     Given call read('classpath:common/eureka/setup-users.feature')

--- a/mod-linked-data/src/main/resources/karate-config.js
+++ b/mod-linked-data/src/main/resources/karate-config.js
@@ -74,6 +74,13 @@ function fn() {
 
     sleep: function(seconds) {
       java.lang.Thread.sleep(seconds * 1000)
+    },
+
+    orWhereQuery: function(field, values) {
+        var orStr = ' or ';
+        var string = '(' + field + '=(' + values.map(x => '"' + x + '"').join(orStr) + '))';
+
+        return string;
     }
   };
 

--- a/mod-lists/src/main/resources/karate-config.js
+++ b/mod-lists/src/main/resources/karate-config.js
@@ -47,6 +47,13 @@ function fn() {
       for (var i = 0; i < 5; i++)
         text += possible.charAt(Math.floor(Math.random() * possible.length));
       return text;
+    },
+
+    orWhereQuery: function(field, values) {
+      var orStr = ' or ';
+      var string = '(' + field + '=(' + values.map(x => '"' + x + '"').join(orStr) + '))';
+
+      return string;
     }
   };
 

--- a/mod-notes/src/main/resources/karate-config.js
+++ b/mod-notes/src/main/resources/karate-config.js
@@ -28,6 +28,13 @@ function fn() {
     // define global functions
     uuid: function () {
       return java.util.UUID.randomUUID() + ''
+    },
+
+    orWhereQuery: function(field, values) {
+      var orStr = ' or ';
+      var string = '(' + field + '=(' + values.map(x => '"' + x + '"').join(orStr) + '))';
+
+      return string;
     }
   };
 

--- a/mod-patron-blocks/src/main/resources/karate-config.js
+++ b/mod-patron-blocks/src/main/resources/karate-config.js
@@ -47,6 +47,13 @@ function fn() {
       for (var i = 0; i < 5; i++)
         text += possible.charAt(Math.floor(Math.random() * possible.length));
       return text;
+    },
+
+    orWhereQuery: function(field, values) {
+      var orStr = ' or ';
+      var string = '(' + field + '=(' + values.map(x => '"' + x + '"').join(orStr) + '))';
+
+      return string;
     }
   };
 

--- a/mod-quick-marc/src/main/resources/karate-config.js
+++ b/mod-quick-marc/src/main/resources/karate-config.js
@@ -51,6 +51,13 @@ function fn() {
 
     setSystemProperty: function(name, property) {
       java.lang.System.setProperty(name, property);
+    },
+
+    orWhereQuery: function(field, values) {
+      var orStr = ' or ';
+      var string = '(' + field + '=(' + values.map(x => '"' + x + '"').join(orStr) + '))';
+
+      return string;
     }
   };
 

--- a/mod-search/src/test/resources/karate-config.js
+++ b/mod-search/src/test/resources/karate-config.js
@@ -67,6 +67,13 @@ function fn() {
 
     facet: function (id, totalRecords) {
       return { "id": id, "totalRecords": totalRecords };
+    },
+
+    orWhereQuery: function(field, values) {
+      var orStr = ' or ';
+      var string = '(' + field + '=(' + values.map(x => '"' + x + '"').join(orStr) + '))';
+
+      return string;
     }
   };
 


### PR DESCRIPTION
* Changed how applications are installed in tenants during testing. Now we retrieve only needed apps specified by developers.
* Optimized apps retrieval by removing unneeded anymore get request to understand the maximum amount
* Added a check after retrieving apps that all needed apps are present
* Write an additional JS function to generate cql query to for apps retrieval and added it to all modules' configs