### PR TITLE
MODRTAC-123: Test display summary info for pieces without items

### DIFF
--- a/edge-rtac/src/main/resources/core_platform/edge-rtac/features/rtac-from-order-piece.feature
+++ b/edge-rtac/src/main/resources/core_platform/edge-rtac/features/rtac-from-order-piece.feature
@@ -51,8 +51,23 @@ Feature: rtac from order piece tests
     # open order
     * call read('classpath:core_platform/edge-rtac/features/util/initData.feature@OpenOrder') { extOrderId: #(orderId) }
 
-    # create piece
-    * call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostPiece') { extLocationsId: #(locationId), extPoLineId: #(poLineId) }
+    # create piece with display summary
+    * def displaySummary1 = 'test display summary'
+    * call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostPiece') { extLocationsId: #(locationId), extPoLineId: #(poLineId), extDisplaySummary: #(displaySummary1) }
+
+    # create piece with enumeration and chronology
+    * def displaySummary2 = ""
+    * def chronology1 = 'test chronology'
+    * def enumeration1 = 'test enumeration'
+    * call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostPiece') { extLocationsId: #(locationId), extPoLineId: #(poLineId), extEnumeration: #(enumeration1), extChronology: #(chronology1), extDisplaySummary: #(displaySummary2) }
+
+    # create piece with enumeration and chronology
+    * def enumeration2 = ""
+    * call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostPiece') { extLocationsId: #(locationId), extPoLineId: #(poLineId), extEnumeration: #(enumeration2), extChronology: #(chronology1), extDisplaySummary: #(displaySummary2) }
+
+    # create piece without volume
+    * def chronology2 = ""
+    * call read('classpath:core_platform/edge-rtac/features/util/initData.feature@PostPiece') { extLocationsId: #(locationId), extPoLineId: #(poLineId), extEnumeration: #(enumeration2), extChronology: #(chronology2), extDisplaySummary: #(displaySummary2) }
 
     Given url edgeUrl
     And path 'rtac'
@@ -63,3 +78,7 @@ Feature: rtac from order piece tests
     When method GET
     Then status 200
     And match $.holdings[0].holdings[*].status contains 'Expected'
+    And match $.holdings[0].holdings[*].volume contains '(test display summary)'
+    And match $.holdings[0].holdings[*].volume contains '(test enumeration test chronology)'
+    And match $.holdings[0].holdings[*].volume contains '(test chronology)'
+    And match $.holdings[0].holdings[*].volume contains ''

--- a/edge-rtac/src/main/resources/core_platform/edge-rtac/features/util/initData.feature
+++ b/edge-rtac/src/main/resources/core_platform/edge-rtac/features/util/initData.feature
@@ -222,6 +222,9 @@ Feature: init data for edge-rtac
     * def titleId = $.titles[0].id
 
     * def pieceId = callonce random_uuid
+    * def extDisplaySummary = karate.get('extDisplaySummary', '')
+    * def extEnumeration = karate.get('extEnumeration', '')
+    * def extChronology = karate.get('extChronology', '')
     Given path 'orders/pieces'
     And request
     """
@@ -231,6 +234,9 @@ Feature: init data for edge-rtac
       locationId: "#(extLocationsId)",
       poLineId: "#(extPoLineId)",
       titleId: "#(titleId)",
+      displaySummary: "#(extDisplaySummary)",
+      enumeration: "#(extEnumeration)",
+      chronology: "#(extChronology)",
       displayToPublic: true,
       displayOnHolding: true
     }

--- a/edge-rtac/src/main/resources/core_platform/edge-rtac/features/util/order/create-budget.feature
+++ b/edge-rtac/src/main/resources/core_platform/edge-rtac/features/util/order/create-budget.feature
@@ -5,7 +5,7 @@ Feature: budget
 
   Scenario: createBudget
     * def fundId = karate.get('fundId', '5e4fbdab-f1b1-4be8-9c33-d3c41ec9a696')
-    * def fiscalYearId = karate.get('fiscalYearId', 'ac2164c7-ba3d-1bc2-a12c-e35ceccbfaf2')
+    * def fiscalYearId = karate.get('fiscalYearId', 'ac2164c7-ba3d-1bc2-a12c-e35ceccbfaf3')
     * def budgetStatus = karate.get('budgetStatus', 'Active')
     * def statusExpenseClasses = karate.get('statusExpenseClasses', [])
 


### PR DESCRIPTION
## Purpose
[MODRTAC-123](https://folio-org.atlassian.net/browse/MODRTAC-123): Show display summary info for pieces without items

## Visuals
![image](https://github.com/user-attachments/assets/6a6bcfb7-d8bc-425f-aa8e-6dde8c3e5518)

