### PR TITLE
[MODINVOICE-573] Fix an existing test to use the new parameter

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/approve-or-cancel-invoice-with-polinepaymentstatus-parameter.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/approve-or-cancel-invoice-with-polinepaymentstatus-parameter.feature
@@ -78,7 +78,7 @@
       And match $.errors[0].code == 'poLinePaymentStatusNotPresent'
 
       * print "Approve the invoice using the poLinePaymentStatus parameter"
-      * def v = call approveInvoice { poLinePaymentStatus: 'Fully Paid'}
+      * def v = call approveInvoice { poLinePaymentStatus: 'Fully Paid' }
 
       * print "Check the order line payment status after approving"
       Given path 'orders/order-lines', poLineId
@@ -96,7 +96,7 @@
       And match $.errors[0].code == 'poLinePaymentStatusNotPresent'
 
       * print "Cancel the invoice using the poLinePaymentStatus parameter"
-      * def v = call cancelInvoice { poLinePaymentStatus: 'Cancelled'}
+      * def v = call cancelInvoice { poLinePaymentStatus: 'Cancelled' }
 
       * print "Check the order line payment status after cancelling"
       Given path 'orders/order-lines', poLineId

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/approve-or-cancel-invoice-with-polinepaymentstatus-parameter.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/approve-or-cancel-invoice-with-polinepaymentstatus-parameter.feature
@@ -78,13 +78,7 @@
       And match $.errors[0].code == 'poLinePaymentStatusNotPresent'
 
       * print "Approve the invoice using the poLinePaymentStatus parameter"
-      * call getInvoice
-      * set invoice.status = 'Approved'
-      Given path 'invoice/invoices', invoiceId
-      And param poLinePaymentStatus = 'Fully Paid'
-      And request invoice
-      When method PUT
-      Then status 204
+      * def v = call approveInvoice { poLinePaymentStatus: 'Fully Paid'}
 
       * print "Check the order line payment status after approving"
       Given path 'orders/order-lines', poLineId
@@ -102,13 +96,7 @@
       And match $.errors[0].code == 'poLinePaymentStatusNotPresent'
 
       * print "Cancel the invoice using the poLinePaymentStatus parameter"
-      * call getInvoice
-      * set invoice.status = 'Cancelled'
-      Given path 'invoice/invoices', invoiceId
-      And param poLinePaymentStatus = 'Cancelled'
-      And request invoice
-      When method PUT
-      Then status 204
+      * def v = call cancelInvoice { poLinePaymentStatus: 'Cancelled'}
 
       * print "Check the order line payment status after cancelling"
       Given path 'orders/order-lines', poLineId

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/reusable/approve-invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/reusable/approve-invoice.feature
@@ -1,10 +1,12 @@
 Feature: Approve invoice
-  # parameters: invoiceId
+  # parameters: invoiceId, poLinePaymentStatus?
 
   Background:
     * url baseUrl
 
   Scenario: Approve invoice
+    * def poLinePaymentStatus = karate.get('poLinePaymentStatus', null)
+
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200
@@ -13,6 +15,7 @@ Feature: Approve invoice
     * set invoice.status = 'Approved'
 
     Given path 'invoice/invoices', invoiceId
+    And param poLinePaymentStatus = poLinePaymentStatus
     And request invoice
     When method PUT
     Then status 204

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/reusable/cancel-invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/reusable/cancel-invoice.feature
@@ -1,10 +1,12 @@
 Feature: Cancel invoice
-  # parameters: invoiceId
+  # parameters: invoiceId, poLinePaymentStatus?
 
   Background:
     * url baseUrl
 
   Scenario: Cancel invoice
+    * def poLinePaymentStatus = karate.get('poLinePaymentStatus', null)
+
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200
@@ -13,6 +15,7 @@ Feature: Cancel invoice
     * set invoice.status = 'Cancelled'
 
     Given path 'invoice/invoices', invoiceId
+    And param poLinePaymentStatus = poLinePaymentStatus
     And request invoice
     When method PUT
     Then status 204

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-order-total-fields-calculated-correctly.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-order-total-fields-calculated-correctly.feature
@@ -211,7 +211,7 @@ Feature: Check that order total fields are calculated correctly
       | invoiceLineId  | invoiceId  | poLineId | fundId | total |
       | invoiceLineId1 | invoiceId2 | poLineId | fundId | -100  |
     * def v = call createInvoiceLine invoiceLinesData
-    * def v = call approveInvoice invoiceLinesData
+    * def v = call approveInvoice { invoiceId: '#(invoiceId2)', poLinePaymentStatus: 'Fully Paid'}
     * def v = call payInvoice invoiceLinesData
 
     # 3. Check that total fields are calculated correctly


### PR DESCRIPTION
## Purpose
[MODINVOICE-573](https://folio-org.atlassian.net/browse/MODINVOICE-573) - Updating order status when approving or cancelling an invoice against a previous fiscal year

This is an update to the [previous PR](https://github.com/folio-org/folio-integration-tests/pull/1730).

## Approach
- Fix an existing test to use the new parameter
- Added the parameter to `approveInvoice` and `cancelInvoice` to simplify
