### PR TITLE
FAT-19376 / MSEARCH-989: Use new fields in classification object

### DIFF
--- a/mod-linked-data/src/main/resources/citation/mod-linked-data/features/import-bib/samples/expected-search-response.json
+++ b/mod-linked-data/src/main/resources/citation/mod-linked-data/features/import-bib/samples/expected-search-response.json
@@ -23,8 +23,9 @@
   ],
   "classifications": [
     {
-      "number": "PZ3.P785",
-      "source": "lc"
+      "type":"lc",
+      "number":"PZ3.P785",
+      "additionalNumber":"Si"
     }
   ],
   "subjects": [


### PR DESCRIPTION
## Purpose
The response structure of `GET search/linked-data-works` API got updated for MSEARCH-989. Purpose of this PR is to update the integration tests accordingly.
