### PR TITLE
fix(mod-kb-ebsco-java): Fix agreement assignment violating unique name constraint

### DIFF
--- a/mod-kb-ebsco-java/src/main/resources/karate-config.js
+++ b/mod-kb-ebsco-java/src/main/resources/karate-config.js
@@ -61,6 +61,9 @@ function fn() {
     },
     replaceRegex: function(line, regex, newString) {
       return line.replace(new RegExp(regex, "gm"), newString);
+    },
+    now: function() {
+      return java.lang.System.currentTimeMillis();
     }
   };
 

--- a/mod-kb-ebsco-java/src/main/resources/spitfire/mod-kb-ebsco-java/features/setup/setup-resources.feature
+++ b/mod-kb-ebsco-java/src/main/resources/spitfire/mod-kb-ebsco-java/features/setup/setup-resources.feature
@@ -42,8 +42,9 @@ Feature: Setup resources
     * call read(createNoteType)
     * call read(assignNote) {noteName: 'Note 1'}
     * call read(assignNote) {noteName: 'Note 2'}
-    * call read(assignAgreement) {recordId: packageId, recordType: 'EKB-PACKAGE', agreementName: 'Package Agreement'}
-    * call read(assignAgreement) {recordId: resourceId, recordType: 'EKB-TITLE', agreementName: 'Resource Agreement'}
+    * def randomNumber = now()
+    * call read(assignAgreement) {recordId: packageId, recordType: 'EKB-PACKAGE', agreementName: '#("Package Agreement" + randomNumber)'}
+    * call read(assignAgreement) {recordId: resourceId, recordType: 'EKB-TITLE', agreementName: '#("Resource Agreement" + randomNumber)'}
 
     * eval sleep(15000)
 


### PR DESCRIPTION
## Purpose
Fix agreement assinment violating unique name constraint

## Approach
- Add random number to an agreement name in case agreement from previous test runs didn't get unassigned

### Learning
[FAT-19329](https://folio-org.atlassian.net/browse/FAT-19329)
![image](https://github.com/user-attachments/assets/1869b517-0a8f-471e-807b-10f86b72e178)

