### PR TITLE
fix(mod-quick-marc): Fix linking records feature record update issues

### DIFF
--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-linking-records.feature
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-linking-records.feature
@@ -149,6 +149,7 @@ Feature: linking-records tests
     * set bibRecord.relatedRecordVersion = 8
     * set bibRecord._actionType = 'edit'
     Given path 'records-editor/records', bibRecord.parsedRecordId
+    And retry until responseStatus == 202
     And request bibRecord
     When method PUT
     Then status 202
@@ -178,6 +179,7 @@ Feature: linking-records tests
     When method GET
     Then status 200
     And def bibRecord = response.records.find(x => x.externalIdsHolder.instanceId==instanceId)
+    And retry until bibRecord.parsedRecord.content.fields[*].100.subfields[*].9 == []
     And match bibRecord.parsedRecord.content.fields[*].100 != []
     And match bibRecord.parsedRecord.content.fields[*].100.subfields[*].9 == []
     And match bibRecord.parsedRecord.content.fields[*].240 != []


### PR DESCRIPTION
## Purpose
Fix linking records feature record update issues

## Approach
Add retries

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
[FAT-19289](https://folio-org.atlassian.net/browse/FAT-19289)
