### PR TITLE
fix(mod-quick-marc): Fix relatedRecordVersion for holdings/bibs

### DIFF
--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-holdings-records.feature
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-holdings-records.feature
@@ -277,13 +277,13 @@ Feature: Test quickMARC holdings records
     * def newField = { "tag": "550", "content": "$z Test tag", "indicators": [ "\\", "\\" ], "isProtected":false }
     * fields.push(newField)
     * set record.fields = fields
-    * set record.relatedRecordVersion = 5
+    #version unchanged because 500 tag is absent in mapping rules so inventory record is not updated on previous PUT
+    * set record.relatedRecordVersion = 4
     * set record._actionType = 'edit'
 
     Given path 'records-editor/records', record.parsedRecordId
     And headers headersUser
     And request record
-    And retry until responseStatus == 202
     When method PUT
     Then status 202
 

--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-linking-records.feature
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-linking-records.feature
@@ -146,10 +146,9 @@ Feature: linking-records tests
     * def tag100 = {"tag": "100", "content":'#("$a Johnson" + linkContent)', "indicators": ["\\","1"], "linkDetails":{ "authorityId": #(authorityId),"authorityNaturalId": #(authorityNaturalId), "linkingRuleId": 1} }
     * bibRecord.fields = bibRecord.fields.filter(field => field.tag != "100")
     * bibRecord.fields.push(tag100)
-    * set bibRecord.relatedRecordVersion = 8
+    * set bibRecord.relatedRecordVersion = 7
     * set bibRecord._actionType = 'edit'
     Given path 'records-editor/records', bibRecord.parsedRecordId
-    And retry until responseStatus == 202
     And request bibRecord
     When method PUT
     Then status 202
@@ -179,7 +178,6 @@ Feature: linking-records tests
     When method GET
     Then status 200
     And def bibRecord = response.records.find(x => x.externalIdsHolder.instanceId==instanceId)
-    And retry until bibRecord.parsedRecord.content.fields[*].100.subfields[*].9 == []
     And match bibRecord.parsedRecord.content.fields[*].100 != []
     And match bibRecord.parsedRecord.content.fields[*].100.subfields[*].9 == []
     And match bibRecord.parsedRecord.content.fields[*].240 != []


### PR DESCRIPTION
## Purpose
Fix relatedRecordVersion for holdings/bibs

## Approach
- fix versions for put requests
- remove redundant retries

### Learning
[FAT-19288](https://folio-org.atlassian.net/browse/FAT-19288)
[FAT-19289](https://folio-org.atlassian.net/browse/FAT-19289)
