### PR TITLE
[MODINVOICE-585] Update order paymentStatus with parameter when paying instead of approving invoice

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/approve-or-cancel-invoice-with-polinepaymentstatus-parameter.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/approve-or-cancel-invoice-with-polinepaymentstatus-parameter.feature
@@ -18,7 +18,7 @@
 
 
     @Positive
-    Scenario: Approve and cancel the invoice, first without poLinePaymentStatus and then using poLinePaymentStatus
+    Scenario: Pay and cancel the invoice, first without poLinePaymentStatus and then using poLinePaymentStatus
       * def codePrefix = callonce random_string
       * def currentYear = callonce getCurrentYear
       * def pastYear = 2020
@@ -68,19 +68,21 @@
       * print "Add an invoice line linked to the po line, using the past encumbrance, with releaseEncumbrance=true"
       * def v = call createInvoiceLine { invoiceLineId: '#(invoiceLineId)', invoiceId: '#(invoiceId)', poLineId: '#(poLineId)', fundId: '#(fundId)', encumbranceId: '#(pastEncumbranceId)', total: 10, releaseEncumbrance: true }
 
-      * print "Approve the invoice without using the poLinePaymentStatus parameter"
+      * def v = call approveInvoice
+
+      * print "Pay the invoice without using the poLinePaymentStatus parameter"
       * call getInvoice
-      * set invoice.status = 'Approved'
+      * set invoice.status = 'Paid'
       Given path 'invoice/invoices', invoiceId
       And request invoice
       When method PUT
       Then status 400
       And match $.errors[0].code == 'poLinePaymentStatusNotPresent'
 
-      * print "Approve the invoice using the poLinePaymentStatus parameter"
-      * def v = call approveInvoice { poLinePaymentStatus: 'Fully Paid' }
+      * print "Pay the invoice using the poLinePaymentStatus parameter"
+      * def v = call payInvoice { poLinePaymentStatus: 'Fully Paid' }
 
-      * print "Check the order line payment status after approving"
+      * print "Check the order line payment status after paying"
       Given path 'orders/order-lines', poLineId
       When method GET
       Then status 200

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/reusable/approve-invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/reusable/approve-invoice.feature
@@ -1,12 +1,10 @@
 Feature: Approve invoice
-  # parameters: invoiceId, poLinePaymentStatus?
+  # parameters: invoiceId
 
   Background:
     * url baseUrl
 
   Scenario: Approve invoice
-    * def poLinePaymentStatus = karate.get('poLinePaymentStatus', null)
-
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200
@@ -15,7 +13,6 @@ Feature: Approve invoice
     * set invoice.status = 'Approved'
 
     Given path 'invoice/invoices', invoiceId
-    And param poLinePaymentStatus = poLinePaymentStatus
     And request invoice
     When method PUT
     Then status 204

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/reusable/pay-invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/reusable/pay-invoice.feature
@@ -1,10 +1,12 @@
 Feature: Pay invoice
-  # parameters: invoiceId
+  # parameters: invoiceId, poLinePaymentStatus?
 
   Background:
     * url baseUrl
 
   Scenario: Pay invoice
+    * def poLinePaymentStatus = karate.get('poLinePaymentStatus', null)
+
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200
@@ -13,6 +15,7 @@ Feature: Pay invoice
     * set invoice.status = 'Paid'
 
     Given path 'invoice/invoices', invoiceId
+    And param poLinePaymentStatus = poLinePaymentStatus
     And request invoice
     When method PUT
     Then status 204

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-order-total-fields-calculated-correctly.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-order-total-fields-calculated-correctly.feature
@@ -211,8 +211,8 @@ Feature: Check that order total fields are calculated correctly
       | invoiceLineId  | invoiceId  | poLineId | fundId | total |
       | invoiceLineId1 | invoiceId2 | poLineId | fundId | -100  |
     * def v = call createInvoiceLine invoiceLinesData
-    * def v = call approveInvoice { invoiceId: '#(invoiceId2)', poLinePaymentStatus: 'Fully Paid'}
-    * def v = call payInvoice invoiceLinesData
+    * def v = call approveInvoice { invoiceId: '#(invoiceId2)' }
+    * def v = call payInvoice  { invoiceId: '#(invoiceId2)', poLinePaymentStatus: 'Fully Paid' }
 
     # 3. Check that total fields are calculated correctly
     Given path 'orders/composite-orders', orderId


### PR DESCRIPTION
## Purpose
[MODINVOICE-585](https://folio-org.atlassian.net/browse/MODINVOICE-585) - Update order paymentStatus with parameter when paying instead of approving an invoice

## Approach
- Moved the `poLinePaymentStatus` parameter from `approveInvoice` to `payInvoice`.
- Updated the tests to use it when the invoice is paid instead of approved

[mod-invoice PR](https://github.com/folio-org/mod-invoice/pull/531)