### PR TITLE
[MODINVOICE-586] Invoice with identical adjustments

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/invoice-with-identical-adjustments.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/invoice-with-identical-adjustments.feature
@@ -1,0 +1,65 @@
+  # For MODINVOICE-586
+  Feature: Invoice with identical adjustments
+
+    Background:
+      * url baseUrl
+      * call login testAdmin
+      * def okapitokenAdmin = okapitoken
+
+      * call login testUser
+      * def okapitokenUser = okapitoken
+
+      * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json' }
+      * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json' }
+
+      * configure headers = headersUser
+
+      * call variables
+
+
+    Scenario: Create, approve, pay and cancel an invoice with identical invoice-level adjustments
+      * def fundId = call uuid
+      * def budgetId = call uuid
+      * def invoiceId = call uuid
+      * def invoiceLineId = call uuid
+
+      * print "1. Create finances"
+      * configure headers = headersAdmin
+      * def v = call createFund { id: '#(fundId)' }
+      * def v = call createBudget { id: '#(budgetId)', allocated: 1000, fundId: '#(fundId)', status: 'Active' }
+      * configure headers = headersUser
+
+      * print "2. Create the invoice"
+      * def adj1 =
+      """
+        {
+          "type": "Amount",
+          "description": "adj1",
+          "prorate": "Not prorated",
+          "fundDistributions": [
+            {
+              "distributionType": "amount",
+              "fundId": "#(fundId)",
+              "value": 1
+            }
+          ],
+          "value": 1,
+          "relationToTotal": "In addition to"
+        }
+      """
+      * copy adj2 = adj1
+      * set adj2.description = "adj2"
+      * def adjustments = [ "#(adj1)", "#(adj2)" ]
+      * def v = call createInvoice { id: "#(invoiceId)", adjustments: "#(adjustments)" }
+
+      * print "3. Add an invoice line"
+      * def v = call createInvoiceLine { invoiceLineId: "#(invoiceLineId)", invoiceId: "#(invoiceId)", fundId: "#(fundId)", total: 10 }
+
+      * print "4. Approve the invoice"
+      * def v = call approveInvoice { invoiceId: "#(invoiceId)" }
+
+      * print "5. Pay the invoice"
+      * def v = call payInvoice { invoiceId: "#(invoiceId)" }
+
+      * print "6. Cancel the invoice"
+      * def v = call cancelInvoice { invoiceId: "#(invoiceId)" }

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/invoice.feature
@@ -138,5 +138,8 @@ Feature: mod-invoice integration tests
   Scenario: Check invoice line with VAT adjustments
     Given call read('features/check-invoice-lines-with-vat-adjustments.feature')
 
+  Scenario: Invoice with identical adjustments
+    Given call read('features/invoice-with-identical-adjustments.feature')
+
   Scenario: wipe data
     Given call read('classpath:common/destroy-data.feature')

--- a/acquisitions/src/test/java/org/folio/InvoicesApiTest.java
+++ b/acquisitions/src/test/java/org/folio/InvoicesApiTest.java
@@ -182,6 +182,11 @@ public class InvoicesApiTest extends TestBase {
     runFeatureTest("check-invoice-lines-with-vat-adjustments");
   }
 
+  @Test
+  void invoiceWithIdenticalAdjustments() {
+    runFeatureTest("invoice-with-identical-adjustments");
+  }
+
   @BeforeAll
   public void invoicesApiTestBeforeAll() {
     runFeature("classpath:thunderjet/mod-invoice/invoice-junit.feature");


### PR DESCRIPTION
## Purpose
[MODINVOICE-586](https://folio-org.atlassian.net/browse/MODINVOICE-586) - Error when cancelling a paid invoice with 2 invoice-level adjustments using the same fund and expense class

## Approach
New test: Create, approve, pay and cancel an invoice with identical invoice-level adjustments

[mod-finance-storage PR](https://github.com/folio-org/mod-finance-storage/pull/471)
