### PR TITLE
disable: Vega team modules due to migration to Eureka

### DIFF
--- a/edge-patron/src/test/java/org/folio/LCUserRegistrationTests.java
+++ b/edge-patron/src/test/java/org/folio/LCUserRegistrationTests.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @FolioTest(team = "vega", module = "edge-patron")
+@Disabled("Migrated to Eureka")
 class LCUserRegistrationTests extends TestBase {
 
   public LCUserRegistrationTests() {

--- a/mod-circulation-storage/src/test/java/org/folio/ModCirculationStorageTests.java
+++ b/mod-circulation-storage/src/test/java/org/folio/ModCirculationStorageTests.java
@@ -6,9 +6,11 @@ import org.folio.test.config.TestModuleConfiguration;
 import org.folio.test.services.TestIntegrationService;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @FolioTest(team = "vega", module = "mod-circulation-storage")
+@Disabled("Migrated to Eureka")
 class ModCirculationStorageTests extends TestBase {
 
   private static final String TEST_BASE_PATH = "classpath:vega/mod-circulation-storage/features/";

--- a/mod-circulation/src/test/java/org/folio/ModCirculationTests.java
+++ b/mod-circulation/src/test/java/org/folio/ModCirculationTests.java
@@ -6,9 +6,11 @@ import org.folio.test.config.TestModuleConfiguration;
 import org.folio.test.services.TestIntegrationService;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @FolioTest(team = "vega", module = "mod-circulation")
+@Disabled("Migrated to Eureka")
 class ModCirculationTests extends TestBase {
 
   private static final String TEST_BASE_PATH = "classpath:vega/mod-circulation/features/";

--- a/mod-feesfines/src/test/java/org/folio/FeesFinesApiTests.java
+++ b/mod-feesfines/src/test/java/org/folio/FeesFinesApiTests.java
@@ -6,9 +6,11 @@ import org.folio.test.config.TestModuleConfiguration;
 import org.folio.test.services.TestIntegrationService;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @FolioTest(team = "vega", module = "mod-feesfines")
+@Disabled("Migrated to Eureka")
 class FeesFinesApiTests extends TestBase {
 
     private static final String TEST_BASE_PATH = "classpath:vega/mod-feesfines/features/";

--- a/mod-patron-blocks/src/test/java/org/folio/ModPatronBlocksTests.java
+++ b/mod-patron-blocks/src/test/java/org/folio/ModPatronBlocksTests.java
@@ -6,9 +6,11 @@ import org.folio.test.config.TestModuleConfiguration;
 import org.folio.test.services.TestIntegrationService;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @FolioTest(team = "vega", module = "mod-patron-blocks")
+@Disabled("Migrated to Eureka")
 class ModPatronBlocksTests extends TestBase {
 
   private static final String TEST_BASE_PATH = "classpath:vega/mod-patron-blocks/features/";


### PR DESCRIPTION
This PR includes disabling Okapi tests for modules of Vega team