### PR TITLE
disable: Dreamliner team module due to migration to Eureka

### DIFF
--- a/edge-rtac/src/test/java/org/folio/EdgeRtacTests.java
+++ b/edge-rtac/src/test/java/org/folio/EdgeRtacTests.java
@@ -7,9 +7,11 @@ import org.folio.test.config.TestModuleConfiguration;
 import org.folio.test.services.TestIntegrationService;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 @FolioTest(team = "dreamliner", module = "edge-rtac")
+@Disabled("Migrated to Eureka")
 class EdgeRtacTests extends TestBase {
 
   public EdgeRtacTests() {


### PR DESCRIPTION
This PR includes disabling tests for Dreamliner team