### PR TITLE
fix retry for quickMARC Bib record creation scenario

### DIFF
--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/setup.feature
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/setup.feature
@@ -323,9 +323,9 @@ Feature: Setup quickMARC
     Given path 'records-editor/records/status'
     And headers headersUser
     And param qmRecordId = recordId
+    And retry until response.status == 'CREATED' || response.status == 'ERROR'
     When method GET
     Then status 200
-    And retry until response.status == 'CREATED' || response.status == 'ERROR'
     And def recordId = response.externalId
     * call read('classpath:spitfire/mod-quick-marc/features/setup/setup.feature@GetRecordById') {recordId: '#(recordId)'}
 


### PR DESCRIPTION
## Purpose
[FAT-12649](https://folio-org.atlassian.net/browse/FAT-12649) fix retry for quickMARC Bib record creation scenario

## Approach
The `retry` step must come before `method` and `status`
<kbd>
![image](https://github.com/user-attachments/assets/3342ea8e-2f6b-476c-9aee-4997a7d8cba3)
</kbd>

