### PR TITLE
Vega - Increasing token expiration time

### DIFF
--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/root.feature
@@ -48,7 +48,7 @@ Feature: Root feature that runs all other mod-circulation features
     * callonce read('classpath:vega/mod-circulation/features/util/initData.feature@PostRulesWithMaterialTypeAndGroup') extFallbackPolicy, extMaterialTypePolicy, extFirstGroupPolicy, extSecondGroupPolicy, extThirdGroupPolicy, extFourthGroupPolicy
 
   Scenario: Run all mod-circulation features
-    * call read('classpath:common/eureka/keycloak.feature@configureAccessTokenTime') { 'AccessTokenLifespance' : 1800 }
+    * call read('classpath:common/eureka/keycloak.feature@configureAccessTokenTime') { 'AccessTokenLifespance' : 3600 }
     * call read('classpath:vega/mod-circulation/features/loans.feature')
     * call read('classpath:vega/mod-circulation/features/requests.feature')
     * call read('classpath:vega/mod-circulation/features/print-events.feature')


### PR DESCRIPTION
## Purpose
Increasing token expiration time for Circulation Tests

## Approach
Changing token expiration time in root.feature
` * call read('classpath:common/eureka/keycloak.feature@configureAccessTokenTime') { 'AccessTokenLifespance' : 3600 }`

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
