### PR TITLE
 Increase token lifetime

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/consortia/consortia-orders-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/consortia-orders-junit.feature
@@ -375,7 +375,7 @@ Feature: mod-consortia integration tests
     * def result = call read('classpath:common-consortia/eureka/initData.feature@Login') { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenant.name)'}
     * call read('tenant-utils/consortium.feature@EnableCentralOrdering') {token: '#(result.token)', tenant: '#(centralTenant)'}
 
-    * call read('classpath:common/eureka/keycloak.feature@configureAccessTokenTime') { 'AccessTokenLifespance' : 1800, testTenant: '#(centralTenant.name)' }
+    * call read('classpath:common/eureka/keycloak.feature@configureAccessTokenTime') { 'AccessTokenLifespance' : 3600, testTenant: '#(centralTenant.name)' }
 
   @InitData
   Scenario: Prepare data

--- a/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/data-export-spring-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/data-export-spring-junit.feature
@@ -129,7 +129,7 @@ Feature: mod-data-export-spring integration tests
   Scenario: create tenant and users for testing
     * def testUser = testAdmin
     Given call read('classpath:common/eureka/setup-users.feature')
-    * call read('classpath:common/eureka/keycloak.feature@configureAccessTokenTime') { 'AccessTokenLifespance' : 1800 }
+    * call read('classpath:common/eureka/keycloak.feature@configureAccessTokenTime') { 'AccessTokenLifespance' : 3600 }
 
   Scenario: init global data
     * call login testAdmin

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/finance-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/finance-junit.feature
@@ -142,7 +142,7 @@ Feature: mod-finance integration tests
   Scenario: create tenant and users for testing
     * def testUser = testAdmin
     Given call read('classpath:common/eureka/setup-users.feature')
-    * call read('classpath:common/eureka/keycloak.feature@configureAccessTokenTime') { 'AccessTokenLifespance' : 1800 }
+    * call read('classpath:common/eureka/keycloak.feature@configureAccessTokenTime') { 'AccessTokenLifespance' : 3600 }
 
   Scenario: init global data
     * call login testAdmin

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/invoice-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/invoice-junit.feature
@@ -136,7 +136,7 @@ Feature: mod-invoice integration tests
   Scenario: create tenant and users for testing
     * def testUser = testAdmin
     Given call read('classpath:common/eureka/setup-users.feature')
-    * call read('classpath:common/eureka/keycloak.feature@configureAccessTokenTime') { 'AccessTokenLifespance' : 1800 }
+    * call read('classpath:common/eureka/keycloak.feature@configureAccessTokenTime') { 'AccessTokenLifespance' : 3600 }
 
   Scenario: init global data
     * call login testAdmin


### PR DESCRIPTION
## Purpose
Increasing token expiration time for Thunderjet Tests

## Approach
Changing token expiration time in root.feature
` * call read('classpath:common/eureka/keycloak.feature@configureAccessTokenTime') { 'AccessTokenLifespance' : 3600 }`

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
