### PR TITLE
[MODORDERS-1272] Fixed permissions for mod-orders tests

### DIFF
--- a/acquisitions/src/main/resources/global/orders.feature
+++ b/acquisitions/src/main/resources/global/orders.feature
@@ -2,7 +2,6 @@ Feature: global orders
 
   Background:
     * url baseUrl
-    * call login testAdmin
 
     * configure headers = { 'Content-Type': 'application/json', 'Accept': 'application/json', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(testTenant)' }
 

--- a/acquisitions/src/main/resources/karate-config.js
+++ b/acquisitions/src/main/resources/karate-config.js
@@ -30,6 +30,8 @@ function fn() {
     dummyUser: {tenant: testTenant, name: 'dummy-user', password: 'dummy'},
 
     // define global features
+    createAdditionalUser: karate.read('classpath:common/eureka/create-additional-user.feature'),
+    getUserIdByUsername: karate.read('classpath:common/eureka/users.feature'),
     login: karate.read('classpath:common/login.feature'),
     loginRegularUser: karate.read('classpath:common/login.feature'),
     loginAdmin: karate.read('classpath:common/login.feature'),

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/acq-units/verify-get-funds-with-query-where-user-has-units.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/acq-units/verify-get-funds-with-query-where-user-has-units.feature
@@ -11,6 +11,9 @@ Feature: Get funds where filter is provided should take into account acquisition
     * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
     * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
 
+    * def res = callonce getUserIdByUsername { user: '#(testUser)' }
+    * def testUserId = res.userId
+
     * callonce variables
 
     * def fundAllowFundViewAcqUnitId = callonce uuid1
@@ -89,14 +92,12 @@ Feature: Get funds where filter is provided should take into account acquisition
     And match funds[*].id contains ["#(fundAllowViewAndRestrictViewAcqId)"]
 
   Scenario: Assign restrict view acquisitions units memberships to user
-    * def result = call read('classpath:common/eureka/users.feature') {user: '#(testUser)'}
-    * def userId = result.userId
     Given path 'acquisitions-units-storage/memberships'
     And headers headersAdmin
     And request
     """
     {
-      "userId": "#(userId)",
+      "userId": "#(testUserId)",
       "acquisitionsUnitId": "#(restrictFundViewAcqUnitId)"
     }
     """
@@ -114,11 +115,9 @@ Feature: Get funds where filter is provided should take into account acquisition
     And match funds[*].id contains ["#(fundRestrictViewAcqId)","#(fundAllowViewAndRestrictViewAcqId)"]
 
   Scenario: Assign allow view acquisitions units memberships to user
-    * def result = call read('classpath:common/eureka/users.feature') {user: '#(testUser)'}
-    * def userId = result.userId
     Given path 'acquisitions-units-storage/memberships'
     And headers headersAdmin
-    And param query = 'acquisitionsUnitId==' + restrictFundViewAcqUnitId + ' and userId==' + userId
+    And param query = 'acquisitionsUnitId==' + restrictFundViewAcqUnitId + ' and userId==' + testUserId
     When method GET
     Then status 200
     * def acqMember = $.acquisitionsUnitMemberships[0]
@@ -144,14 +143,12 @@ Feature: Get funds where filter is provided should take into account acquisition
     And match funds[*].id contains ["#(fundAllowViewAndRestrictViewAcqId)"]
 
   Scenario: Again assign restrict view acquisitions units memberships to user
-    * def result = call read('classpath:common/eureka/users.feature') {user: '#(testUser)'}
-    * def userId = result.userId
     Given path 'acquisitions-units-storage/memberships'
     And headers headersAdmin
     And request
     """
     {
-      "userId": "#(userId)",
+      "userId": "#(testUserId)",
       "acquisitionsUnitId": "#(restrictFundViewAcqUnitId)"
     }
     """
@@ -169,12 +166,10 @@ Feature: Get funds where filter is provided should take into account acquisition
     And match funds[*].id contains ["#(fundAllowViewAcqId)", "#(fundRestrictViewAcqId)","#(fundAllowViewAndRestrictViewAcqId)"]
 
   Scenario Outline: DELETE acquisitions units and memberships <acqUnitId>
-    * def result = call read('classpath:common/eureka/users.feature') {user: '#(testUser)'}
-    * def userId = result.userId
     * def acqUnitId = <acqUnitId>
     Given path 'acquisitions-units-storage/memberships'
     And headers headersAdmin
-    And param query = 'acquisitionsUnitId==' + acqUnitId + ' and userId==' + userId
+    And param query = 'acquisitionsUnitId==' + acqUnitId + ' and userId==' + testUserId
     When method GET
     Then status 200
     * def acqMember = $.acquisitionsUnitMemberships[0]

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/acq-units/verify-get-funds-without-query-where-user-has-units-and-filter-only-by-units.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/acq-units/verify-get-funds-without-query-where-user-has-units-and-filter-only-by-units.feature
@@ -11,6 +11,9 @@ Feature: Get funds without providing filter query should take into account acqui
     * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
     * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
 
+    * def res = callonce getUserIdByUsername { user: '#(testUser)' }
+    * def testUserId = res.userId
+
     * callonce variables
 
     * def fundAllowFundViewAcqUnitId = callonce uuid1
@@ -89,14 +92,12 @@ Feature: Get funds without providing filter query should take into account acqui
     And match funds[*].id contains ["#(fundNoAcqId)", "#(fundAllowViewAcqId)", "#(fundAllowViewAndRestrictViewAcqId)"]
 
   Scenario: Assign restrict view acquisitions units memberships to user
-    * def result = call read('classpath:common/eureka/users.feature') {user: '#(testUser)'}
-    * def userId = result.userId
     Given path 'acquisitions-units-storage/memberships'
     And headers headersAdmin
     And request
     """
     {
-      "userId": "#(userId)",
+      "userId": "#(testUserId)",
       "acquisitionsUnitId": "#(restrictFundViewAcqUnitId)"
     }
     """
@@ -114,11 +115,9 @@ Feature: Get funds without providing filter query should take into account acqui
     And match funds[*].id contains ["#(fundNoAcqId)", "#(fundAllowViewAcqId)", "#(fundRestrictViewAcqId)","#(fundAllowViewAndRestrictViewAcqId)"]
 
   Scenario: Assign allow view acquisitions units memberships to user
-    * def result = call read('classpath:common/eureka/users.feature') {user: '#(testUser)'}
-    * def userId = result.userId
     Given path 'acquisitions-units-storage/memberships'
     And headers headersAdmin
-    And param query = 'acquisitionsUnitId==' + restrictFundViewAcqUnitId + ' and userId==' + userId
+    And param query = 'acquisitionsUnitId==' + restrictFundViewAcqUnitId + ' and userId==' + testUserId
     When method GET
     Then status 200
     * def acqMember = $.acquisitionsUnitMemberships[0]
@@ -144,14 +143,12 @@ Feature: Get funds without providing filter query should take into account acqui
     And match funds[*].id contains ["#(fundNoAcqId)", "#(fundAllowViewAcqId)","#(fundAllowViewAndRestrictViewAcqId)"]
 
   Scenario: Again assign restrict view acquisitions units memberships to user
-    * def result = call read('classpath:common/eureka/users.feature') {user: '#(testUser)'}
-    * def userId = result.userId
     Given path 'acquisitions-units-storage/memberships'
     And headers headersAdmin
     And request
     """
     {
-      "userId": "#(userId)",
+      "userId": "#(testUserId)",
       "acquisitionsUnitId": "#(restrictFundViewAcqUnitId)"
     }
     """
@@ -169,12 +166,10 @@ Feature: Get funds without providing filter query should take into account acqui
     And match funds[*].id contains ["#(fundNoAcqId)", "#(fundAllowViewAcqId)", "#(fundRestrictViewAcqId)","#(fundAllowViewAndRestrictViewAcqId)"]
 
   Scenario Outline: DELETE acquisitions units and memberships <acqUnitId>
-    * def result = call read('classpath:common/eureka/users.feature') {user: '#(testUser)'}
-    * def userId = result.userId
     * def acqUnitId = <acqUnitId>
     Given path 'acquisitions-units-storage/memberships'
     And headers headersAdmin
-    And param query = 'acquisitionsUnitId==' + acqUnitId + ' and userId==' + userId
+    And param query = 'acquisitionsUnitId==' + acqUnitId + ' and userId==' + testUserId
     When method GET
     Then status 200
     * def acqMember = $.acquisitionsUnitMemberships[0]

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/finance-data.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/finance-data.feature
@@ -27,15 +27,15 @@ Feature: Karate tests for FY finance bulk get/update functionality
     * def budgetId1 = callonce uuid { n: 10 }
     * def budgetId2 = callonce uuid { n: 11 }
 
-    * def result = call read('classpath:common/eureka/users.feature') { user: '#(testUser)' }
-    * def userId = result.userId
+    * def res = callonce getUserIdByUsername { user: '#(testUser)' }
+    * def testUserId = res.userId
 
     ### Before All ###
 
     # Create Acq Unit and assign user (each scenario)
     * configure headers = headersAdmin
     * def v = callonce createAcqUnit { id: '#(acqUnitId)', name: '#(acqUnitId)', isDeleted: false, protectCreate: true, protectRead: true, protectUpdate: true, protectDelete: true }
-    * def v = callonce assignUserToAcqUnit { userId: '#(userId)', acquisitionsUnitId: '#(acqUnitId)' }
+    * def v = callonce assignUserToAcqUnit { userId: '#(testUserId)', acquisitionsUnitId: '#(acqUnitId)' }
     * configure headers = headersUser
 
     # Prepare finance data
@@ -171,7 +171,7 @@ Feature: Karate tests for FY finance bulk get/update functionality
 
     # 3. Verify get finance data with acq unit id restrictions, fiscal year id2 should be empty for user after removing acq unit
     * configure headers = headersAdmin
-    * def v = call deleteUserFromAcqUnit { userId: '#(userId)', acquisitionsUnitId: '#(acqUnitId)' }
+    * def v = call deleteUserFromAcqUnit { userId: '#(testUserId)', acquisitionsUnitId: '#(acqUnitId)' }
     * configure headers = headersUser
 
     Given path 'finance/finance-data'
@@ -181,7 +181,7 @@ Feature: Karate tests for FY finance bulk get/update functionality
     And match $.totalRecords == 0
 
     * configure headers = headersAdmin
-    * def v = call assignUserToAcqUnit { userId: '#(userId)', acquisitionsUnitId: '#(acqUnitId)' }
+    * def v = call assignUserToAcqUnit { userId: '#(testUserId)', acquisitionsUnitId: '#(acqUnitId)' }
     * configure headers = headersUser
 
     Given path 'finance/finance-data'

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/finance-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/finance-junit.feature
@@ -148,12 +148,7 @@ Feature: mod-finance integration tests
     * call read('classpath:common/eureka/keycloak.feature@configureAccessTokenTime') { 'AccessTokenLifespance' : 3600 }
 
   Scenario: create admin user
-    * def testUser = { tenant: "#(testTenant)", name: '#(testAdmin.name)', password: '#(testAdmin.password)' }
-    * def userPermissions = adminPermissions
-    * call read('classpath:common/eureka/setup-users.feature@getAuthorizationToken')
-    * call read('classpath:common/eureka/setup-users.feature@createTestUser')
-    * call read('classpath:common/eureka/setup-users.feature@specifyUserCredentials')
-    * call read('classpath:common/eureka/setup-users.feature@addUserCapabilities')
+    * def v = call createAdditionalUser { testUser: '#(testAdmin)',  userPermissions: '#(adminPermissions)' }
 
   Scenario: init global data
     * call login testUser

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/cancel-and-delete-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/cancel-and-delete-order.feature
@@ -4,18 +4,17 @@ Feature: Cancel and delete order
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * call variables
-
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
 
     * def fundId = call uuid1
     * def budgetId = call uuid2
@@ -26,11 +25,13 @@ Feature: Cancel and delete order
 
   Scenario: Cancel & Delete Order
     * print '## Prepare finances'
+    * configure headers = headersAdmin
     * def v = call createFund { id: "#(fundId)" }
     * def v = call createBudget { id: "#(budgetId)", fundId: "#(fundId)", allocated: 1000 }
 
 
     * print '## Create an order'
+    * configure headers = headersUser
     * def v = call createOrder { id: "#(orderId)" }
 
 
@@ -65,6 +66,7 @@ Feature: Cancel and delete order
 
 
     * print '## Check the encumbrances were deleted'
+    * configure headers = headersAdmin
     Given path '/finance/transactions'
     And param query = 'encumbrance.sourcePurchaseOrderId==' + orderId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/cancel-item-after-canceling-poline-in-multi-line-orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/cancel-item-after-canceling-poline-in-multi-line-orders.feature
@@ -3,12 +3,15 @@ Feature: Cancel order
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -103,6 +106,7 @@ Feature: Cancel order
     Then status 200
     * def poLine = $
 
+    * configure headers = headersAdmin
     Given path 'holdings-storage/holdings'
     And param query = 'instanceId ==' + poLine.instanceId
     When method GET
@@ -118,11 +122,13 @@ Feature: Cancel order
     * def item = items[0]
     * match item.status.name == 'Order closed'
 
+    * configure headers = headersUser
     Given path 'orders/order-lines/', poLineId2
     When method GET
     Then status 200
     * def poLine2 = $
 
+    * configure headers = headersAdmin
     Given path 'holdings-storage/holdings'
     And param query = 'instanceId ==' + poLine2.instanceId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/cancel-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/cancel-order.feature
@@ -1,21 +1,18 @@
 Feature: Cancel order
 
   Background:
-    * url baseUrl
     * print karate.info.scenarioName
+    * url baseUrl
 
-    * callonce loginAdmin testAdmin
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
-
-    # Define reusable functions
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
-    * def cancelOrder = read('classpath:thunderjet/mod-orders/reusable/cancel-order.feature')
 
   @Positive
   Scenario: Cancel order
@@ -30,6 +27,7 @@ Feature: Cancel order
     * def v = call createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 1000 }
 
     * print '2. Create composite order'
+    * configure headers = headersUser
     * def v = call createOrder { id: '#(orderId)' }
 
     * print '3. Create order lines'
@@ -48,6 +46,7 @@ Feature: Cancel order
     * def v = call cancelOrder { orderId: '#(orderId)' }
 
     * print '6. Check the order lines after cancelling the order'
+    * configure headers = headersAdmin
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET
@@ -62,6 +61,7 @@ Feature: Cancel order
     And match budget.unavailable == 0
 
     * print '7. Check the budget after cancelling the order'
+    * configure headers = headersUser
     Given path 'orders/composite-orders', orderId
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/change-location-when-receiving-piece.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/change-location-when-receiving-piece.feature
@@ -3,11 +3,16 @@
 Feature: Change location when receiving a piece
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -20,6 +25,7 @@ Feature: Change location when receiving a piece
 
   Scenario: Create finances
     # this is needed for instance if a previous test does a rollover which changes the global fund
+    * configure headers = headersAdmin
     * call createFund { 'id': '#(fundId)'}
     * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)'}
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/change-pending-distribution-with-inactive-budget.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/change-pending-distribution-with-inactive-budget.feature
@@ -2,13 +2,16 @@
 Feature: Change pending distribution with inactive budget
 
   Background:
-    * url baseUrl
     * print karate.info.scenarioName
+    * url baseUrl
 
-    * callonce loginAdmin testAdmin
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -22,12 +25,14 @@ Feature: Change pending distribution with inactive budget
     * def poLineId = call uuid
 
     * print '1. Prepare finances, create 2 funds and 2 budgets'
+    * configure headers = headersAdmin
     * def v = call createFund { id: '#(fundId1)' }
     * def v = call createBudget { id: '#(budgetId1)', fundId: '#(fundId1)', allocated: 1000 }
     * def v = call createFund { id: '#(fundId2)' }
     * def v = call createBudget { id: '#(budgetId2)', fundId: '#(fundId2)', allocated: 1000 }
 
     * print '2. Create order and line'
+    * configure headers = headersUser
     * def v = call createOrder { id: '#(orderId)' }
     * def v = call createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', fundId: '#(fundId1)' }
 
@@ -48,6 +53,8 @@ Feature: Change pending distribution with inactive budget
     And request budget
     When method PUT
     Then status 204
+
+    * configure headers = headersUser
 
 
   @Positive

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-encumbrance-status-after-moving-expended-value.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-encumbrance-status-after-moving-expended-value.feature
@@ -1,3 +1,4 @@
+# THIS SHOULD BE IN CROSS-MODULES
 @parallel=false
 # for https://issues.folio.org/browse/MODORDERS-943
 Feature: Check encumbrance status after moving expended value
@@ -15,12 +16,15 @@ Feature: Check encumbrance status after moving expended value
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -104,6 +108,7 @@ Feature: Check encumbrance status after moving expended value
     Then status 204
 
   Scenario: Create an invoice
+    * configure headers = headersAdmin
     * copy invoice = invoiceTemplate
     * set invoice.id = invoiceId
     Given path 'invoice/invoices'
@@ -121,6 +126,7 @@ Feature: Check encumbrance status after moving expended value
     * def encumbranceId2 = poLine.fundDistribution[1].encumbrance
 
     * print "Add an invoice line linked to the po line"
+    * configure headers = headersAdmin
     * copy invoiceLine = invoiceLineTemplate
     * set invoiceLine.id = invoiceLineId
     * set invoiceLine.invoiceId = invoiceId
@@ -137,6 +143,7 @@ Feature: Check encumbrance status after moving expended value
     Then status 201
 
   Scenario: Approve the invoice
+    * configure headers = headersAdmin
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200
@@ -148,6 +155,7 @@ Feature: Check encumbrance status after moving expended value
     Then status 204
 
   Scenario: Pay the invoice
+    * configure headers = headersAdmin
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200
@@ -181,6 +189,7 @@ Feature: Check encumbrance status after moving expended value
     Then status 200
     * def newEncumbranceId = $.fundDistribution[<index>].encumbrance
 
+    * configure headers = headersAdmin
     Given path 'finance/transactions', newEncumbranceId
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-estimated-price-with-composite-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-estimated-price-with-composite-order.feature
@@ -3,12 +3,16 @@ Feature: Check estimated price with composite order
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * call variables
 
 
@@ -29,6 +33,7 @@ Feature: Check estimated price with composite order
     * def v = call createBudget { id: "#(miscHistBudgetId)", fundId: "#(miscHistFundId)", allocated: 1000 }
 
     * print '## Prepare the order'
+    * configure headers = headersUser
     * def po = read('classpath:samples/mod-orders/compositeOrders/po-listed-print-monograph.json')
     # Make sure expected number of PO Lines available
     * assert po.poLines.length == 2
@@ -102,6 +107,7 @@ Feature: Check estimated price with composite order
     * match poLine2.cost.poLineEstimatedPrice == expectedTotalPoLine2
 
     * print '## Check created encumbrances'
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-holding-instance-creation-with-createInventory-options.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-holding-instance-creation-with-createInventory-options.feature
@@ -2,19 +2,25 @@
 Feature: check-holding-instance-creation-with-createInventory-options
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
 
     * callonce variables
     * def fundId = callonce uuid1
     * def budgetId = callonce uuid2
 
     ## Prepare finances
-    * callonce createFund { 'id': '#(fundId)'}
-    * callonce createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)'}
+    * configure headers = headersAdmin
+    * callonce createFund { 'id': '#(fundId)' }
+    * callonce createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)' }
+    * configure headers = headersUser
 
   @Positive
   Scenario: Verify holding NOT being created when createInventory: None
@@ -26,7 +32,6 @@ Feature: check-holding-instance-creation-with-createInventory-options
     * def v = call openOrder { id: #(orderId)}
 
     # Verify instance is not being created
-    * configure headers = headersAdmin
     Given path 'orders/order-lines', poLineId
     When method GET
     Then status 200
@@ -42,7 +47,6 @@ Feature: check-holding-instance-creation-with-createInventory-options
     * def v = call openOrder { id: #(orderId)}
 
     # Verify holding is not being created
-    * configure headers = headersAdmin
     Given path 'orders/order-lines', poLineId
     When method GET
     Then status 200
@@ -51,6 +55,7 @@ Feature: check-holding-instance-creation-with-createInventory-options
     * def instanceId = response.instanceId
 
     Given path 'holdings-storage/holdings'
+    * configure headers = headersAdmin
     And param query = 'instanceId==' + instanceId
     When method GET
     And match $.totalRecords == 0
@@ -65,7 +70,6 @@ Feature: check-holding-instance-creation-with-createInventory-options
     * def v = call openOrder { id: #(orderId)}
 
     # Verify instance, holding, item creation
-    * configure headers = headersAdmin
     Given path 'orders/order-lines', poLineId
     When method GET
     Then status 200
@@ -73,6 +77,7 @@ Feature: check-holding-instance-creation-with-createInventory-options
     * def holdingId = response.locations[0].holdingId
 
     Given path 'holdings-storage/holdings'
+    * configure headers = headersAdmin
     And param query = 'instanceId==' + instanceId
     When method GET
     And match $.totalRecords == 1

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-new-tags-in-central-tag-repository.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-new-tags-in-central-tag-repository.feature
@@ -2,14 +2,17 @@
 Feature: Check new tags created in central tag repository
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-#    * callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def orderId = callonce uuid3
@@ -45,6 +48,7 @@ Feature: Check new tags created in central tag repository
     Then status 201
 
     # ============= check tags in central repository (lowercase, no spaces) ===================
+    * configure headers = headersAdmin
     Given path 'tags'
     And param query = "label==check-central-tag OR label==another_tag"
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-order-lines-number-retrieve-limit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-order-lines-number-retrieve-limit.feature
@@ -2,15 +2,17 @@
 Feature: Check limit number of order lines which can be retrieved in scope of composite order.
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-    #* callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
 
-    # load global variables
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def orderId = callonce uuid1

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-order-re-encumber-work-correctly.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-order-re-encumber-work-correctly.feature
@@ -1,15 +1,19 @@
+# THIS SHOULD BE IN CROSS-MODULES TESTS
 @parallel=false
 Feature: Check re-encumber works correctly
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-    # * callonce dev {tenant: 'testorders12'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fromFiscalYearId = callonce uuid1
@@ -77,7 +81,7 @@ Feature: Check re-encumber works correctly
 
 
   Scenario Outline: prepare finances for fiscal year with <fiscalYearId> for re-encumber
-
+    * configure headers = headersAdmin
     * def fiscalYearId = <fiscalYearId>
     * def code = <code>
 
@@ -101,6 +105,7 @@ Feature: Check re-encumber works correctly
       | toFiscalYearId   | toYear   |
 
   Scenario Outline: prepare finances for ledger with <ledgerId> for re-encumber
+    * configure headers = headersAdmin
     * def ledgerId = <ledgerId>
 
     Given path 'finance/ledgers'
@@ -127,6 +132,7 @@ Feature: Check re-encumber works correctly
       | initialAmountOngoingRolloverLedger | true                |
 
   Scenario Outline: prepare finances for rollover with <rolloverId>
+    * configure headers = headersAdmin
     * def rolloverId = <rolloverId>
     * def ledgerId = <ledgerId>
     * def oneTime = {"orderType": 'One-time', "basedOn": <basedOn>, "increaseBy": <increaseBy>}
@@ -191,7 +197,7 @@ Feature: Check re-encumber works correctly
       | initialAmountEncumberedFund  | initialAmountOngoingRolloverLedger |
 
   Scenario Outline: prepare finances for budget with <fundId> and <fiscalYearId>
-
+    * configure headers = headersAdmin
     * def fundId = <fundId>
     * def fiscalYearId = <fiscalYearId>
 
@@ -231,7 +237,6 @@ Feature: Check re-encumber works correctly
     * def orderId = <orderId>
     * def ongoing = <orderType> == 'Ongoing' ? {"isSubscription": <subscription>} : null
 
-    * configure headers = headersAdmin
     Given path 'orders-storage/purchase-orders'
     And request
     """
@@ -259,7 +264,6 @@ Feature: Check re-encumber works correctly
       | successInitialAmountOrder  | 'Ongoing'  | null         |
 
   Scenario Outline: prepare order lines with orderLineId <poLineId>
-    * configure headers = headersAdmin
     * def orderId = <orderId>
     * def poLineId = <poLineId>
     * def fund1Id = <fund1Id>
@@ -416,7 +420,7 @@ Feature: Check re-encumber works correctly
       | successInitialAmountOrder   | null                   | 204      |
 
   Scenario Outline: check encumbrances and orderLine <poLineId> after re-encumber
-
+    * configure headers = headersAdmin
     * def poLineId = <poLineId>
 
     Given path 'finance/transactions'
@@ -431,6 +435,7 @@ Feature: Check re-encumber works correctly
     * def encumbrance1Id = <encumbrance1Id> == 'newEncumbrance1' ? newEncumbrance1.id : <encumbrance1Id>
     * def encumbrance2Id = <encumbrance2Id> == 'newEncumbrance2' ? newEncumbrance2.id : <encumbrance2Id>
 
+    * configure headers = headersUser
     Given path 'orders/order-lines', poLineId
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-order-total-fields-calculated-correctly.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-order-total-fields-calculated-correctly.feature
@@ -1,15 +1,21 @@
+# THIS SHOULD BE IN CROSS-MODULES TESTS
 Feature: Check that order total fields are calculated correctly
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
 
     * callonce variables
 
     ### Before All ###
+    * configure headers = headersAdmin
     * def previousFiscalYear = callonce uuid1
     * def currentFiscalYear = callonce uuid2
     * def codePrefix = callonce random_string
@@ -41,6 +47,7 @@ Feature: Check that order total fields are calculated correctly
 
 
     ### Before Each ###
+    * configure headers = headersUser
     * def orderId = call uuid
     * def v = call createOrder { id: "#(orderId)" }
 
@@ -52,15 +59,19 @@ Feature: Check that order total fields are calculated correctly
 
     * def v = call openOrder { id: "#(orderId)" }
 
+    * configure headers = headersAdmin
     * def invoiceId = call uuid
     * table invoicesData
       | id        | fiscalYearId      |
       | invoiceId | currentFiscalYear |
     * def v = call createInvoice invoicesData
 
+    * configure headers = headersUser
+
   @Positive
   Scenario: Check total order fields with totalExpended being zero while invoice lines are opened
     # 1. Create Invoice Lines
+    * configure headers = headersAdmin
     * def invoiceLineId1 = call uuid
     * def invoiceLineId2 = call uuid
     * table invoiceLinesData
@@ -70,6 +81,7 @@ Feature: Check that order total fields are calculated correctly
     * def v = call createInvoiceLine invoiceLinesData
 
     # 2. Check that total fields are calculated correctly
+    * configure headers = headersUser
     Given path 'orders/composite-orders', orderId
     When method GET
     Then status 200
@@ -80,6 +92,7 @@ Feature: Check that order total fields are calculated correctly
   @Positive
   Scenario: Check total order fields with totalExpended being zero while invoice lines are approved
     # 1. Create Invoice Lines
+    * configure headers = headersAdmin
     * def invoiceLineId1 = call uuid
     * def invoiceLineId2 = call uuid
     * table invoiceLinesData
@@ -90,6 +103,7 @@ Feature: Check that order total fields are calculated correctly
     * def v = call approveInvoice invoiceLinesData
 
     # 2. Check that total fields are calculated correctly
+    * configure headers = headersUser
     Given path 'orders/composite-orders', orderId
     When method GET
     Then status 200
@@ -100,6 +114,7 @@ Feature: Check that order total fields are calculated correctly
   @Positive
   Scenario: Check order total fields with invoice lines having positive and negative sub-total values
     # 1. Create Invoice Lines
+    * configure headers = headersAdmin
     * def invoiceLineId1 = call uuid
     * def invoiceLineId2 = call uuid
     * table invoiceLinesData
@@ -111,6 +126,7 @@ Feature: Check that order total fields are calculated correctly
     * def v = call payInvoice invoiceLinesData
 
     # 2. Check that total fields are calculated correctly
+    * configure headers = headersUser
     Given path 'orders/composite-orders', orderId
     When method GET
     Then status 200
@@ -121,6 +137,7 @@ Feature: Check that order total fields are calculated correctly
   @Positive
   Scenario: Check order total fields with invoice lines having only positive sub-total values
     # 1. Create Invoice Line
+    * configure headers = headersAdmin
     * def invoiceLineId1 = call uuid
     * table invoiceLinesData
       | invoiceLineId  | invoiceId | poLineId | fundId | total |
@@ -130,6 +147,7 @@ Feature: Check that order total fields are calculated correctly
     * def v = call payInvoice invoiceLinesData
 
     # 2. Check that total fields are calculated correctly
+    * configure headers = headersUser
     Given path 'orders/composite-orders', orderId
     When method GET
     Then status 200
@@ -140,6 +158,7 @@ Feature: Check that order total fields are calculated correctly
   @Positive
   Scenario: Check order total fields with invoice lines having only negative sub-total values
     # 1. Create Invoice Line
+    * configure headers = headersAdmin
     * def invoiceLineId1 = call uuid
     * table invoiceLinesData
       | invoiceLineId  | invoiceId | poLineId | fundId | total |
@@ -149,6 +168,7 @@ Feature: Check that order total fields are calculated correctly
     * def v = call payInvoice invoiceLinesData
 
     # 2. Check that total fields are calculated correctly
+    * configure headers = headersUser
     Given path 'orders/composite-orders', orderId
     When method GET
     Then status 200
@@ -173,6 +193,7 @@ Feature: Check that order total fields are calculated correctly
     * def v = call openOrder { id: "#(orderId2)" }
 
     # 1. Create Invoice Lines
+    * configure headers = headersAdmin
     * def invoiceLineId1 = call uuid
     * def invoiceLineId2 = call uuid
     * def invoiceLineId3 = call uuid
@@ -188,6 +209,7 @@ Feature: Check that order total fields are calculated correctly
     * def v = call payInvoice invoiceLinesData
 
     # 2. Check that total fields are calculated correctly
+    * configure headers = headersUser
     Given path 'orders/composite-orders', orderId
     When method GET
     Then status 200
@@ -198,6 +220,7 @@ Feature: Check that order total fields are calculated correctly
   @Positive
   Scenario: Check order total fields with invoices having different fiscal year
     # 1. Create Invoice with previous fiscal year
+    * configure headers = headersAdmin
     * def invoiceId2 = call uuid
     * table invoicesData
       | id         | fiscalYearId       |
@@ -215,6 +238,7 @@ Feature: Check that order total fields are calculated correctly
 
     # 3. Check that total fields are calculated correctly
     Given path 'orders/composite-orders', orderId
+    * configure headers = headersUser
     When method GET
     Then status 200
     And match response.totalEncumbered == 100
@@ -250,6 +274,7 @@ Feature: Check that order total fields are calculated correctly
     * def v = call openOrder { id: "#(orderId2)" }
 
     # 2. Create Invoice with previous fiscal year and Invoice Lines for previous and current fiscal years
+    * configure headers = headersAdmin
     * def invoiceId2 = call uuid
     * table invoicesData
       | id         | fiscalYearId       |
@@ -271,6 +296,7 @@ Feature: Check that order total fields are calculated correctly
     * def v = call payInvoice invoiceLinesData
 
     # 3. Check that total fields are calculated correctly with only current fiscal year and no encumbrances
+    * configure headers = headersUser
     Given path 'orders/composite-orders', orderId2
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-re-encumber-property.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/check-re-encumber-property.feature
@@ -2,14 +2,17 @@
 Feature: Check needReEncumber flag populated correctly
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-    # * callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fiscalYearId = karate.get('fiscalYearId', globalFiscalYearId)
@@ -31,7 +34,7 @@ Feature: Check needReEncumber flag populated correctly
     * def budgetId = <budgetId>
 
     * configure headers = headersAdmin
-    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerId)'}
+    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerId)' }
     * call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 9999 }
 
     Examples:
@@ -121,6 +124,7 @@ Feature: Check needReEncumber flag populated correctly
     When method DELETE
     Then status 204
 
+    * configure headers = headersUser
     Given path 'orders/composite-orders' , orderId
     And header Accept = 'application/json'
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/check_total_encumbered_expended_calculated_correctly.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/check_total_encumbered_expended_calculated_correctly.feature
@@ -1,15 +1,19 @@
+# THIS SHOULD BE IN CROSS-MODULES TESTS
 @parallel=false
 Feature: Check that totalEncumbered and totalExpended calculated correctly
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-    #* callonce dev {tenant: 'testorders32'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def previousFiscalYear = callonce uuid1
@@ -40,6 +44,7 @@ Feature: Check that totalEncumbered and totalExpended calculated correctly
     * def fromYear = parseInt(toYear) -1
 
   Scenario Outline: prepare fiscal year for <year>
+    * configure headers = headersAdmin
     * def fiscalYearId = <fiscalYearId>
     * def year = <year>
 
@@ -63,6 +68,7 @@ Feature: Check that totalEncumbered and totalExpended calculated correctly
       | currentFiscalYear  | toYear   |
 
   Scenario: prepare ledger
+    * configure headers = headersAdmin
 
     Given path 'finance/ledgers'
     And request
@@ -80,6 +86,7 @@ Feature: Check that totalEncumbered and totalExpended calculated correctly
     Then status 201
 
   Scenario Outline: prepare fund with fundId
+    * configure headers = headersAdmin
     * def fundId = <fundId>
 
     Given path 'finance-storage/funds'
@@ -105,6 +112,7 @@ Feature: Check that totalEncumbered and totalExpended calculated correctly
 
 
   Scenario Outline: Create a budgets for fiscal year <fiscalYearId> and fund <fundId>
+    * configure headers = headersAdmin
     * def fiscalYearId = <fiscalYearId>
     * def fundId = <fundId>
 
@@ -168,6 +176,7 @@ Feature: Check that totalEncumbered and totalExpended calculated correctly
 
 
   Scenario Outline: Create encumbrances for order <orderId>
+    * configure headers = headersAdmin
     * def transactionId = <transactionId>
     * def orderId = <orderId>
     * def orderLineId = <orderLineId>
@@ -213,6 +222,7 @@ Feature: Check that totalEncumbered and totalExpended calculated correctly
 
 
   Scenario Outline: create pending payments for <encumbranceId>
+    * configure headers = headersAdmin
     * def encumbranceId = <encumbranceId>
     * def fundId = <fundId>
     * def fiscalYearId = <fiscalYearId>
@@ -249,6 +259,7 @@ Feature: Check that totalEncumbered and totalExpended calculated correctly
 
 
   Scenario Outline: create payments, credits for <encumbranceId>
+    * configure headers = headersAdmin
     * def encumbranceId = <encumbranceId>
     * def fundId = <fundId>
     * def fiscalYearId = <fiscalYearId>

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/close-order-and-release-encumbrances.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/close-order-and-release-encumbrances.feature
@@ -2,14 +2,17 @@
 Feature: Close order and release encumbrances
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-#    * callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fundId = callonce uuid1
@@ -24,14 +27,15 @@ Feature: Close order and release encumbrances
     * def budgetId = <budgetId>
 
     * configure headers = headersAdmin
-    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)'}
-    * call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 10000}
+    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)' }
+    * call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 10000 }
 
     Examples:
       | fundId | budgetId |
       | fundId | budgetId |
 
   Scenario: check budget after create
+    * configure headers = headersAdmin
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET
@@ -96,6 +100,7 @@ Feature: Close order and release encumbrances
     Then status 204
 
   Scenario: check budget after open order
+    * configure headers = headersAdmin
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET
@@ -125,6 +130,7 @@ Feature: Close order and release encumbrances
     Then status 204
 
   Scenario: check budget after close order
+    * configure headers = headersAdmin
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/close-order-including-lines.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/close-order-including-lines.feature
@@ -4,10 +4,14 @@ Feature: Close order including lines
   Background:
     * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -15,10 +19,6 @@ Feature: Close order including lines
     * def budgetId = callonce uuid2
     * def orderId = callonce uuid3
     * def poLineId = callonce uuid4
-
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
 
 
   Scenario: Prepare finances
@@ -61,6 +61,7 @@ Feature: Close order including lines
 
 
   Scenario: Check the encumbrance after closing the order
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/close-order-when-fully-paid-and-received.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/close-order-when-fully-paid-and-received.feature
@@ -1,11 +1,17 @@
 Feature: Verify once poline fully paid and received order should be closed
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * configure retry = { count: 4, interval: 1000 }
 
     * callonce variables

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/create-five-pieces.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/create-five-pieces.feature
@@ -3,11 +3,17 @@
 Feature: Create fives pieces for an open order
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fundId = callonce uuid1
@@ -66,6 +72,7 @@ Feature: Create fives pieces for an open order
     * call createPiece { pieceId: "#(pieceId5)", poLineId: "#(poLineId5)", titleId: "#(titleId5)" }
 
   Scenario: Check budget
+    * configure headers = headersAdmin
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/create-open-composite-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/create-open-composite-order.feature
@@ -3,12 +3,16 @@
 
     Background:
       * print karate.info.scenarioName
-
       * url baseUrl
-      * callonce loginAdmin testAdmin
+
+      * callonce login testAdmin
       * def okapitokenAdmin = okapitoken
-      * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-      * configure headers = headersAdmin
+      * callonce login testUser
+      * def okapitokenUser = okapitoken
+      * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+      * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+      * configure headers = headersUser
+
       * call variables
 
 
@@ -29,6 +33,7 @@
       * def v = call createBudget { id: "#(miscHistBudgetId)", fundId: "#(miscHistFundId)", allocated: 1000 }
 
       * print '## Prepare the order'
+      * configure headers = headersUser
       * def po = read('classpath:samples/mod-orders/compositeOrders/po-listed-print-monograph.json')
       * def line1 = po.poLines[0]
       * def line2 = po.poLines[1]
@@ -102,6 +107,7 @@
       * match each $.poLines[*].paymentStatus == 'Awaiting Payment'
 
       * print '## Check created instances'
+      * configure headers = headersAdmin
       Given path 'inventory/instances'
       And param query = 'title==("' + line1.titleOrPackage + '" OR "' + line2.titleOrPackage + '")'
       When method GET
@@ -110,7 +116,6 @@
       * def instances = response.instances
 
       * print '## Check created holdings'
-      * configure headers = headersAdmin
       Given path 'holdings-storage/holdings'
       And param query = 'instanceId==("' + instances[0].id + '" OR "' + instances[1].id + '")'
       When method GET
@@ -130,6 +135,7 @@
       * def itemIds = $.items[*].id
 
       * print '## Check created pieces'
+      * configure headers = headersUser
       Given path 'orders/pieces'
       And param query = 'poLineId==("' + newLines[0].id + '" OR "' + newLines[1].id + '")'
       And param limit = 100
@@ -143,6 +149,7 @@
       * match $.pieces[*].format == '#[14]'
 
       * print '## Check created encumbrances'
+      * configure headers = headersAdmin
       Given path 'finance/transactions'
       And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId
       When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/create-order-that-has-not-enough-money.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/create-order-that-has-not-enough-money.feature
@@ -3,14 +3,17 @@ Feature: Create order that has not enough money
 # This will test opening an order when the budget doesn't have enough available money, and when it does.
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-    #* callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fundId = callonce uuid1
@@ -45,6 +48,7 @@ Feature: Create order that has not enough money
     Then status 201
 
   Scenario: Check budget after create
+    * configure headers = headersAdmin
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET
@@ -110,6 +114,7 @@ Feature: Create order that has not enough money
     And match response.errors[0].code == 'fundCannotBePaid'
 
   Scenario: Check budget after open order failed
+    * configure headers = headersAdmin
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET
@@ -156,6 +161,7 @@ Feature: Create order that has not enough money
     Then status 204
 
   Scenario: Check budget after opening order
+    * configure headers = headersAdmin
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/delete-fund-distribution.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/delete-fund-distribution.feature
@@ -3,12 +3,17 @@
 Feature: Delete fund distribution and check encumbrances are removed
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
 
-    * callonce loginAdmin testAdmin
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * configure readTimeout = 60000
 
     * callonce variables
@@ -21,8 +26,8 @@ Feature: Delete fund distribution and check encumbrances are removed
 
   Scenario: Create a fund and budget
     * configure headers = headersAdmin
-    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerId)'}
-    * callonce createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 1000}
+    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerId)' }
+    * callonce createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 1000 }
 
 
   Scenario: Create composite order

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/delete-opened-order-and-lines.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/delete-opened-order-and-lines.feature
@@ -2,14 +2,17 @@
 Feature: Delete opened order and lines
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-    #* callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def orderId = callonce uuid1
@@ -89,7 +92,7 @@ Feature: Delete opened order and lines
 
 
   Scenario: Delete order line after order is opened
-
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'encumbrance.sourcePurchaseOrderId==' + orderId
     When method GET
@@ -112,10 +115,12 @@ Feature: Delete opened order and lines
     * def unavailableBefore2 = response.budgets[0].unavailable
     * def encumbered2 = response.budgets[0].encumbered
 
+    * configure headers = headersUser
     Given  path 'orders/order-lines/', orderLineId
     When method DELETE
     Then status 204
 
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'encumbrance.sourcePurchaseOrderId==' + orderId
     When method GET
@@ -145,10 +150,12 @@ Feature: Delete opened order and lines
     * match response.budgets[0].encumbered == encumbered2 - 60
 
 
+    * configure headers = headersUser
     Given  path 'orders/composite-orders/', orderId
     When method DELETE
     Then status 204
 
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'encumbrance.sourcePurchaseOrderId==' + orderId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/encumbrance-released-when-order-closes.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/encumbrance-released-when-order-closes.feature
@@ -4,12 +4,15 @@ Feature: Encumbrance released when order closes
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -94,6 +97,7 @@ Feature: Encumbrance released when order closes
 
 
   Scenario: Check the encumbrance was released
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId + ' and encumbrance.status==Released'
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/encumbrance-tags-inheritance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/encumbrance-tags-inheritance.feature
@@ -2,15 +2,17 @@
 Feature: Verify once order is opened or poline is updated, encumbrance inherit poline's tags
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-#    * callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
 
-    # load global variables
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def orderId = callonce uuid1
@@ -59,6 +61,7 @@ Feature: Verify once order is opened or poline is updated, encumbrance inherit p
     Then status 204
 
   Scenario: Verify created encumbrance
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'transactionType==Encumbrance and encumbrance.sourcePoLineId==' + poLineId
     When method get
@@ -95,6 +98,7 @@ Feature: Verify once order is opened or poline is updated, encumbrance inherit p
     Then status 204
 
   Scenario: Verify updated encumbrances
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'transactionType==Encumbrance and encumbrance.sourcePoLineId==' + poLineId
     When method get

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/encumbrance-update-after-expense-class-change.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/encumbrance-update-after-expense-class-change.feature
@@ -4,12 +4,15 @@ Feature: Encumbrance update after expense class change
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -67,6 +70,7 @@ Feature: Encumbrance update after expense class change
 
 
   Scenario: Check the encumbrance expense class
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId
     When method GET
@@ -94,6 +98,7 @@ Feature: Encumbrance update after expense class change
 
 
   Scenario: Check the encumbrance expense class again
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId
     When method GET
@@ -128,6 +133,7 @@ Feature: Encumbrance update after expense class change
 
     * def fundDistribution = $.fundDistribution
 
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId
     When method GET
@@ -161,6 +167,7 @@ Feature: Encumbrance update after expense class change
 
     * def fundDistribution = $.fundDistribution
 
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId
     When method GET
@@ -198,6 +205,7 @@ Feature: Encumbrance update after expense class change
 
     * def fundDistribution = $.fundDistribution
 
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/expense-class-handling-for-order-and-lines.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/expense-class-handling-for-order-and-lines.feature
@@ -2,14 +2,17 @@
 Feature: Handling of expense classes for order and order lines
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-#    * callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fundIdForActiveExpenseClass = callonce uuid1
@@ -31,8 +34,8 @@ Feature: Handling of expense classes for order and order lines
     * def budgetId = <budgetId>
     * configure headers = headersAdmin
 
-    * call createFund { 'id': '#(fundId)'}
-    * call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 99999999}
+    * call createFund { 'id': '#(fundId)' }
+    * call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 99999999 }
 
     Examples:
       | fundId                        | budgetId                         |

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/find-holdings-by-location-and-instance-for-mixed-pol.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/find-holdings-by-location-and-instance-for-mixed-pol.feature
@@ -3,12 +3,16 @@
 Feature: find-holdings-by-location-and-instance-for-mixed-pol
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-#    * callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -73,14 +77,13 @@ Feature: find-holdings-by-location-and-instance-for-mixed-pol
     * def holdingId = response.locations[0].holdingId
     * print 'Check items'
 
-    Given path 'holdings-storage/holdings'
     * configure headers = headersAdmin
+    Given path 'holdings-storage/holdings'
     And param query = 'instanceId==' + instanceId
     When method GET
     And match $.totalRecords == 1
 
     Given path 'inventory/items-by-holdings-id'
-    * configure headers = headersAdmin
     And param query = 'holdingsRecordId==' + holdingId
     When method GET
     And match $.totalRecords == 2
@@ -141,14 +144,13 @@ Feature: find-holdings-by-location-and-instance-for-mixed-pol
     * def holdingId = response.locations[0].holdingId
     * print 'Check items'
 
-    Given path 'holdings-storage/holdings'
     * configure headers = headersAdmin
+    Given path 'holdings-storage/holdings'
     And param query = 'instanceId==' + instanceId
     When method GET
     And match $.totalRecords == 1
 
     Given path 'inventory/items-by-holdings-id'
-    * configure headers = headersAdmin
     And param query = 'holdingsRecordId==' + holdingId
     When method GET
     And match $.totalRecords == 4

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/fund-codes-in-open-order-error.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/fund-codes-in-open-order-error.feature
@@ -3,11 +3,16 @@
 Feature: Fund codes in open order error
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/increase-poline-quantity-for-open-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/increase-poline-quantity-for-open-order.feature
@@ -2,13 +2,13 @@
 Feature: Verify updating poLine location restricted after open order
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-    #* callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     # load global variables
     * callonce variables
@@ -17,6 +17,7 @@ Feature: Verify updating poLine location restricted after open order
     * def poLineId = callonce uuid2
     * def locationId = callonce uuid3
     * def holdingIdForUpdate = callonce uuid4
+
   Scenario: Create composite order
     Given path 'orders/composite-orders'
     And request
@@ -55,8 +56,6 @@ Feature: Verify updating poLine location restricted after open order
     Then status 204
 
   Scenario: Verify that pieces has been created for poLine
-    * configure headers = headersAdmin
-
     Given path 'orders-storage/pieces'
     And param query = 'poLineId==' + poLineId
     When method GET
@@ -93,8 +92,6 @@ Feature: Verify updating poLine location restricted after open order
     And match $.errors contains deep {code: 'locationCannotBeModifiedAfterOpen'}
 
   Scenario: Verify that pieces has not been increase for poLine
-    * configure headers = headersAdmin
-
     Given path 'orders-storage/pieces'
     And param query = 'poLineId==' + poLineId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/item-and-holding-operations-for-order-flows.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/item-and-holding-operations-for-order-flows.feature
@@ -3,12 +3,16 @@
 Feature: check Items and holding process.
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    #* callonce dev {tenant: 'testorders1'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * configure retry = { count: 10, interval: 10000 }
 
@@ -25,8 +29,8 @@ Feature: check Items and holding process.
   Scenario: Create finances
     # this is needed for instance if a previous test does a rollover which changes the global fund
     * configure headers = headersAdmin
-    * call createFund { 'id': '#(fundId)'}
-    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)'}
+    * call createFund { 'id': '#(fundId)' }
+    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)' }
 
   Scenario: Create an order
     Given path 'orders/composite-orders'
@@ -79,6 +83,7 @@ Feature: check Items and holding process.
     * def holdingId = response.locations[0].holdingId
 
     * print 'Check items'
+    * configure headers = headersAdmin
     Given path 'inventory/items'
     * configure headers = headersAdmin
     And param query = 'purchaseOrderLineIdentifier==' + poLineId
@@ -115,6 +120,7 @@ Feature: check Items and holding process.
     * def holdingId = response.locations[0].holdingId
 
     * print 'Check items'
+    * configure headers = headersAdmin
     Given path 'inventory/items'
     * configure headers = headersAdmin
     And param query = 'purchaseOrderLineIdentifier==' + poLineId
@@ -149,6 +155,7 @@ Feature: check Items and holding process.
     * def holdingId = response.locations[0].holdingId
 
     * print 'Check items'
+    * configure headers = headersAdmin
     Given path 'inventory/items'
     * configure headers = headersAdmin
     And param query = 'purchaseOrderLineIdentifier==' + poLineId
@@ -185,6 +192,7 @@ Feature: check Items and holding process.
     * def holdingId = response.locations[0].holdingId
 
     * print 'Check items'
+    * configure headers = headersAdmin
     Given path 'inventory/items'
     * configure headers = headersAdmin
     And param query = 'purchaseOrderLineIdentifier==' + poLineId

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/moving_encumbered_value_to_different_budget.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/moving_encumbered_value_to_different_budget.feature
@@ -1,16 +1,19 @@
+# THIS SHOULD BE IN MOD-INVOICE OR CROSS-MODULES
 @parallel=false
 # for https://issues.folio.org/browse/MODORDERS-800
 Feature: Moving encumbered value from budget 1 to budget 2
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-#    * callonce dev {tenant: 'testorders1'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -81,6 +84,7 @@ Feature: Moving encumbered value from budget 1 to budget 2
     Then status 204
 
   Scenario: Create an invoice
+    * configure headers = headersAdmin
     * copy invoice = invoiceTemplate
     * set invoice.id = invoiceId
     Given path 'invoice/invoices'
@@ -97,6 +101,7 @@ Feature: Moving encumbered value from budget 1 to budget 2
     * def encumbranceId = poLine.fundDistribution[0].encumbrance
 
     * print "Add an invoice line linked to the po line"
+    * configure headers = headersAdmin
     * copy invoiceLine = invoiceLineTemplate
     * set invoiceLine.id = invoiceLineId
     * set invoiceLine.invoiceId = invoiceId
@@ -112,6 +117,7 @@ Feature: Moving encumbered value from budget 1 to budget 2
     Then status 201
 
   Scenario: Approve the invoice
+    * configure headers = headersAdmin
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200
@@ -123,6 +129,7 @@ Feature: Moving encumbered value from budget 1 to budget 2
     Then status 204
 
   Scenario: Check the budget after invoice approve
+    * configure headers = headersAdmin
     Given path 'finance/budgets', budgetId1
     When method GET
     Then status 200
@@ -134,6 +141,7 @@ Feature: Moving encumbered value from budget 1 to budget 2
     And match $.encumbered == 0
 
   Scenario: Cancel the invoice
+    * configure headers = headersAdmin
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200
@@ -145,6 +153,7 @@ Feature: Moving encumbered value from budget 1 to budget 2
     Then status 204
 
   Scenario: Check the budget after invoice cancel
+    * configure headers = headersAdmin
     Given path 'finance/budgets', budgetId1
     When method GET
     Then status 200
@@ -170,6 +179,7 @@ Feature: Moving encumbered value from budget 1 to budget 2
     Then status 204
 
   Scenario: Check the previous budget
+    * configure headers = headersAdmin
     Given path 'finance/budgets', budgetId1
     When method GET
     Then status 200
@@ -181,6 +191,7 @@ Feature: Moving encumbered value from budget 1 to budget 2
     And match $.encumbered == 0
 
   Scenario: Check the current budget
+    * configure headers = headersAdmin
     Given path 'finance/budgets', budgetId2
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-and-unopen-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-and-unopen-order.feature
@@ -2,19 +2,18 @@
 Feature: Open and unopen order
 
   Background:
-    * url baseUrl
     * print karate.info.scenarioName
-    * callonce loginAdmin testAdmin
+    * url baseUrl
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
-
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
-    * def unopenOrder = read('classpath:thunderjet/mod-orders/reusable/unopen-order.feature')
 
   @Positive
   Scenario: Open and unopen one-time order
@@ -25,10 +24,11 @@ Feature: Open and unopen order
 
     * print '1. Create a fund and budget'
     * configure headers = headersAdmin
-    * def v = call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerId)'}
-    * def v = call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 1000, 'statusExpenseClasses': [{'expenseClassId': '#(globalPrnExpenseClassId)','status': 'Active' }]}
+    * def v = call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerId)' }
+    * def v = call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 1000, 'statusExpenseClasses': [{'expenseClassId': '#(globalPrnExpenseClassId)','status': 'Active' }] }
 
     * print '2. Create a composite one-time order'
+    * configure headers = headersUser
     * def v = call createOrder { id: '#(orderId)',vendor: '#(globalVendorId)', orderType: 'One-Time' }
 
     * print '3. Create an order line'
@@ -67,6 +67,7 @@ Feature: Open and unopen order
     * def v = call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 1000, 'statusExpenseClasses': [{'expenseClassId': '#(globalPrnExpenseClassId)','status': 'Active' }]}
 
     * print '2. Create a composite ongoing order'
+    * configure headers = headersUser
     * def v = call createOrder { id: '#(orderId)',vendor: '#(globalVendorId)', orderType: 'Ongoing', "ongoing": {"interval" : 123, "isSubscription" : true, "renewalDate" : "2022-05-08T00:00:00.000+00:00"}}
 
     * print '3. Create an order line'

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-approve-and-pay-order-with-50-lines.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-approve-and-pay-order-with-50-lines.feature
@@ -1,3 +1,4 @@
+# THIS SHOULD BE IN MOD-INVOICE
 @parallel=false
 # for https://folio-org.atlassian.net/browse/MODORDERS-1021
 Feature: Approve and pay order with 50 lines
@@ -11,19 +12,17 @@ Feature: Approve and pay order with 50 lines
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
-
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
-    * def createInvoiceLine = read('classpath:thunderjet/mod-invoice/reusable/create-invoice-line.feature')
 
     * def fundId = callonce uuid1
     * def budgetId = callonce uuid2
@@ -32,9 +31,7 @@ Feature: Approve and pay order with 50 lines
     * def poLineUuid = 'f91b86d6-e2e5-4d0c-bffd-7beb1d56ce'
     * def invoiceLineUuid = '0c2a0074-43e3-4dcf-b3a8-978124ea20'
 
-    * def orderLineTemplate = read('classpath:samples/mod-orders/orderLines/minimal-order-line.json')
     * def invoiceTemplate = read('classpath:samples/mod-invoice/invoices/global/invoice.json')
-    * def invoiceLineTemplate = read('classpath:samples/mod-invoice/invoices/global/invoice-line-percentage.json')
 
     * configure readTimeout = 60000
 
@@ -68,6 +65,7 @@ Feature: Approve and pay order with 50 lines
 
 
   Scenario: Create an invoice
+    * configure headers = headersAdmin
     * copy invoice = invoiceTemplate
     * set invoice.id = invoiceId
     Given path 'invoice/invoices'
@@ -77,6 +75,7 @@ Feature: Approve and pay order with 50 lines
 
 
   Scenario: Create 50 invoiceLines for 50 poLines
+    * configure headers = headersAdmin
     * def lineParameters = []
     * def createParameterArray =
       """
@@ -99,6 +98,7 @@ Feature: Approve and pay order with 50 lines
 
 
   Scenario: Approve the invoice
+    * configure headers = headersAdmin
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200
@@ -111,6 +111,7 @@ Feature: Approve and pay order with 50 lines
 
 
   Scenario: Pay the invoice
+    * configure headers = headersAdmin
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200
@@ -123,6 +124,7 @@ Feature: Approve and pay order with 50 lines
 
 
   Scenario: Verify payed invoice
+    * configure headers = headersAdmin
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200
@@ -130,6 +132,7 @@ Feature: Approve and pay order with 50 lines
 
 
   Scenario Outline: Check that payments created with 10$ amount of money
+    * configure headers = headersAdmin
     * def invoiceLineId = <invoiceLineId>
     * def amount = <amount>
     Given path 'finance/transactions'

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-ongoing-order-if-interval-or-renewaldate-notset.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-ongoing-order-if-interval-or-renewaldate-notset.feature
@@ -2,14 +2,17 @@
 Feature: Should Open ongoing order if interval or renewal date is not set
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-#    * callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fundId = callonce uuid1
@@ -27,7 +30,7 @@ Feature: Should Open ongoing order if interval or renewal date is not set
     * def fundId = <fundId>
     * def budgetId = <budgetId>
 
-    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)'}
+    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)' }
     * call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 10000 }
 
     Examples:
@@ -35,6 +38,7 @@ Feature: Should Open ongoing order if interval or renewal date is not set
       | fundId | budgetId |
 
   Scenario: check budget after create
+    * configure headers = headersAdmin
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-ongoing-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-ongoing-order.feature
@@ -2,14 +2,17 @@
 Feature: Open ongoing order
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-#    * callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fundId = callonce uuid1
@@ -23,7 +26,7 @@ Feature: Open ongoing order
     * def budgetId = <budgetId>
     * configure headers = headersAdmin
 
-    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)'}
+    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)' }
     * call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 10000 }
 
     Examples:
@@ -31,6 +34,7 @@ Feature: Open ongoing order
       | fundId | budgetId |
 
   Scenario: check budget after create
+    * configure headers = headersAdmin
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-failure-side-effects.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-failure-side-effects.feature
@@ -3,11 +3,16 @@
 Feature: Open order failure side effects
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -71,6 +76,7 @@ Feature: Open order failure side effects
     Then status 422
 
     # We are checking that inventory records were not created during the failed open order operation
+    * configure headers = headersAdmin
     * print 'Check instances'
     Given path 'inventory/instances'
     And param query = 'title==' + titleOrPackage
@@ -78,6 +84,7 @@ Feature: Open order failure side effects
     And match $.totalRecords == 0
 
     * print 'Check pieces'
+    * configure headers = headersUser
     Given path 'orders/pieces'
     And param query = 'poLineId==' + poLineId
     When method GET
@@ -85,6 +92,7 @@ Feature: Open order failure side effects
     And match $.totalRecords == 0
 
     * print 'Check items'
+    * configure headers = headersAdmin
     Given path 'inventory/items'
     And param query = 'purchaseOrderLineIdentifier==' + poLineId
     When method GET
@@ -93,7 +101,7 @@ Feature: Open order failure side effects
 
   Scenario: Create a budget with insufficient allocation
     * configure headers = headersAdmin
-    * call createBudget { 'id': '#(budgetId)', 'allocated': 5, 'fundId': '#(fundId)'}
+    * call createBudget { 'id': '#(budgetId)', 'allocated': 5, 'fundId': '#(fundId)' }
 
 
   Scenario: Try to open the order again
@@ -111,12 +119,14 @@ Feature: Open order failure side effects
     Then status 422
 
     * print 'Check instances'
+    * configure headers = headersAdmin
     Given path 'inventory/instances'
     And param query = 'title==' + titleOrPackage
     When method GET
     And match $.totalRecords == 0
 
     * print 'Check pieces'
+    * configure headers = headersUser
     Given path 'orders/pieces'
     And param query = 'poLineId==' + poLineId
     When method GET
@@ -124,6 +134,7 @@ Feature: Open order failure side effects
     And match $.totalRecords == 0
 
     * print 'Check items'
+    * configure headers = headersAdmin
     Given path 'inventory/items'
     And param query = 'purchaseOrderLineIdentifier==' + poLineId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-instance-link.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-instance-link.feature
@@ -3,13 +3,16 @@
 Feature: Check opening an order links to the right instance based on the identifier type and value but only if instance matching is not disabled
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-    #* callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -34,12 +37,13 @@ Feature: Check opening an order links to the right instance based on the identif
     # this is needed for instance if a previous test does a rollover which changes the global fund
     * print "Create finances"
     * configure headers = headersAdmin
-    * call createFund { 'id': '#(fundId)'}
-    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)'}
+    * call createFund { 'id': '#(fundId)' }
+    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)' }
 
 
   Scenario: Create instances
     * print "Create instances"
+    * configure headers = headersAdmin
     Given path 'inventory/instances'
     And request
     """

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-success-with-expenditure-restrictions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-success-with-expenditure-restrictions.feature
@@ -7,10 +7,14 @@ Feature: Open order success with expenditure restrictions
   Background:
     * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-different-po-line-currency.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-different-po-line-currency.feature
@@ -2,14 +2,17 @@
 Feature: Open order with different po line currency
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-#    * callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fundId = callonce uuid1
@@ -24,8 +27,8 @@ Feature: Open order with different po line currency
     * def budgetId = <budgetId>
 
     * configure headers = headersAdmin
-    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)'}
-    * call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 9999}
+    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)' }
+    * call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 9999 }
 
     Examples:
       | fundId | budgetId |
@@ -84,6 +87,7 @@ Feature: Open order with different po line currency
 
   Scenario: get encumbrances
 
+    * configure headers = headersAdmin
     Given path '/finance/exchange-rate'
     And param from = 'EUR'
     And param to = 'USD'

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-locations-from-different-tenants.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-locations-from-different-tenants.feature
@@ -3,13 +3,16 @@
 Feature: Open ongoing order
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-#    * callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     # load global variables
     * callonce variables
@@ -41,7 +44,7 @@ Feature: Open ongoing order
     Then status 201
 
 
-  Scenario Outline: Create order lines for <orderLineId> and <fundId>
+  Scenario: Create order lines for <orderLineId> and <fundId>
     * def orderId = <orderId>
     * def poLineId = <orderLineId>
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-manual-exchange-rate.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-manual-exchange-rate.feature
@@ -2,14 +2,17 @@
 Feature: Open order with manual exchange rate
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-#    * callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fundId = callonce uuid1
@@ -25,8 +28,8 @@ Feature: Open order with manual exchange rate
     * def fundId = <fundId>
     * def budgetId = <budgetId>
 
-    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)'}
-    * call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 9999}
+    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)' }
+    * call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 9999 }
 
     Examples:
       | fundId | budgetId |
@@ -86,6 +89,7 @@ Feature: Open order with manual exchange rate
     Then status 204
 
   Scenario Outline: get encumbrances transaction
+    * configure headers = headersAdmin
     * def poLineId = <orderLineId>
 
     Given path 'finance/transactions'

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-resolution-statuses.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-resolution-statuses.feature
@@ -4,10 +4,14 @@ Feature: Close order if order line has resolution statuses that should make it a
   Background:
     * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -24,6 +28,7 @@ Feature: Close order if order line has resolution statuses that should make it a
     * def v = call createBudget { id: #(budgetId), fundId: #(fundId), allocated: 100 }
 
     # 2. Create an order
+    * configure headers = headersUser
     * def v = call createOrder { id: #(orderId) }
 
     # 3. Create an order line
@@ -39,6 +44,7 @@ Feature: Close order if order line has resolution statuses that should make it a
     And match $.workflowStatus == 'Closed'
 
     # 6. Check the encumbrance after closing the order
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-restricted-locations.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-restricted-locations.feature
@@ -3,14 +3,17 @@
 Feature: Open ongoing order
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-#    * callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fundId = callonce uuid1
@@ -32,6 +35,7 @@ Feature: Open ongoing order
       | fundId | budgetId |
 
   Scenario: check budget after create
+    * configure headers = headersAdmin
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-the-same-fund-distributions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-with-the-same-fund-distributions.feature
@@ -2,14 +2,17 @@
 Feature: Should open order with polines having the same fund distributions
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-#    * callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fundId = callonce uuid1
@@ -24,8 +27,8 @@ Feature: Should open order with polines having the same fund distributions
   Scenario: prepare finances for fund with
     * configure headers = headersAdmin
 
-    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)'}
-    * call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 9999}
+    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)' }
+    * call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 9999 }
 
     # prepare expense class
     Given path '/finance-storage/budget-expense-classes'
@@ -41,6 +44,7 @@ Feature: Should open order with polines having the same fund distributions
     Then status 201
 
     # Open order with polines having the same fund distributions
+    * configure headers = headersUser
     Given path 'orders/composite-orders'
     And request
     """

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-without-holdings.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-without-holdings.feature
@@ -2,11 +2,16 @@
 Feature: Open order without creating holdings
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -24,7 +29,7 @@ Feature: Open order without creating holdings
     * print 'Create a fund and a budget'
     * configure headers = headersAdmin
     * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerId)' }
-    * call createBudget { 'id': '#(budgetId)', 'allocated': 10, 'fundId': '#(fundId)'}
+    * call createBudget { 'id': '#(budgetId)', 'allocated': 10, 'fundId': '#(fundId)' }
 
     * print 'Create a new location'
     Given path 'locations'
@@ -48,6 +53,7 @@ Feature: Open order without creating holdings
     Then status 201
 
     * print 'Create an order'
+    * configure headers = headersUser
     Given path 'orders/composite-orders'
     And request
     """

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-orders-with-poLines.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-orders-with-poLines.feature
@@ -2,12 +2,15 @@
 Feature: Open Orders with PoLines
 
   Background:
-    * url baseUrl
     * print karate.info.scenarioName
-    * callonce loginAdmin testAdmin
+    * url baseUrl
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
 
     * callonce variables
 
@@ -17,6 +20,7 @@ Feature: Open Orders with PoLines
     * configure headers = headersAdmin
     * def v = callonce createFund { id: '#(fundId)' }
     * def v = callonce createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 1000 }
+    * configure headers = headersUser
 
   @Positive
   Scenario: Open Orders with PoLines

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/order-event.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/order-event.feature
@@ -4,22 +4,26 @@ Feature: mod audit order events
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
     * def orderId = callonce uuid
 
     * configure retry = { count: 10, interval: 5000 }
 
   Scenario: Create Order event
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
     * callonce createOrder { id: #(orderId) }
 
   Scenario: Check event saved in audit
+    * configure headers = headersAdmin
     Given path 'audit-data/acquisition/order/', orderId
     And retry until response.totalItems == 1
     When method GET
@@ -41,6 +45,7 @@ Feature: mod audit order events
     Then status 204
 
   Scenario: Check 2 events saved in audit
+    * configure headers = headersAdmin
     Given path 'audit-data/acquisition/order/' + orderId
     And retry until response.totalItems == 2
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/order-line-event.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/order-line-event.feature
@@ -4,12 +4,16 @@ Feature: mod audit order_line events
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
     * def orderId = callonce uuid
     * def poLineId1 = callonce uuid
@@ -19,13 +23,12 @@ Feature: mod audit order_line events
     * configure retry = { count: 10, interval: 5000 }
 
   Scenario: Create Order and OrderLines
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-audit-order-line.feature')
     * callonce createOrder { id: #(orderId) }
     * callonce createOrderLine { id: #(poLineId1), orderId: #(orderId), fundId: #(fundId) }
 
 
   Scenario: Check event saved in audit
+    * configure headers = headersAdmin
     Given path 'audit-data/acquisition/order-line/', poLineId1
     And retry until response.totalItems == 1
     When method GET
@@ -47,6 +50,7 @@ Feature: mod audit order_line events
     Then status 204
 
   Scenario: Check 2 events saved in audit
+    * configure headers = headersAdmin
     Given path 'audit-data/acquisition/order-line/', poLineId1
     And retry until response.totalItems == 2
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/parallel-create-piece.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/parallel-create-piece.feature
@@ -5,11 +5,17 @@ Feature: Create pieces for an open order in parallel
   Background:
     # This part is called once before scenarios are executed. It's important that all scenarios start at the same time,
     # so all scripts must be called with callonce.
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fundId = callonce uuid1
@@ -33,8 +39,9 @@ Feature: Create pieces for an open order in parallel
     * def createPiece = read('../reusable/create-piece.feature')
 
     * configure headers = headersAdmin
-    * callonce createFund { 'id': '#(fundId)'}
-    * callonce createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)'}
+    * callonce createFund { 'id': '#(fundId)' }
+    * callonce createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)' }
+    * configure headers = headersUser
     * callonce createOrder { id: "#(orderId)" }
     * callonce createOrderLine { id: "#(poLineId1)", orderId: "#(orderId)", fundId: "#(fundId)" }
     * callonce createOrderLine { id: "#(poLineId2)", orderId: "#(orderId)", fundId: "#(fundId)" }
@@ -58,6 +65,7 @@ Feature: Create pieces for an open order in parallel
     # but errors are not reported with this method, so we have to use an additional feature file
     * call read('parallel-create-piece-2.feature')
 
+    * configure headers = headersAdmin
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/parallel-update-order-lines-different-orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/parallel-update-order-lines-different-orders.feature
@@ -3,11 +3,17 @@
 Feature: Update order lines for different open orders in parallel (using the same fund), and check budget
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fundId = callonce uuid1
@@ -21,15 +27,11 @@ Feature: Update order lines for different open orders in parallel (using the sam
     * def poLineId3 = callonce uuid9
     * def poLineId4 = callonce uuid10
 
-    * def createOrder = read('../reusable/create-order.feature')
-    * def createOrderLine = read('../reusable/create-order-line.feature')
-    * def openOrder = read('../reusable/open-order.feature')
-    * def getOrderLine = read('../reusable/get-order-line.feature')
-
     * configure headers = headersAdmin
     * callonce createFund { id: '#(fundId)' }
     * callonce createBudget { id: '#(budgetId)', allocated: 1000, fundId: '#(fundId)' }
 
+    * configure headers = headersUser
     * callonce createOrder { id: '#(orderId1)' }
     * callonce createOrder { id: '#(orderId2)' }
     * callonce createOrder { id: '#(orderId3)' }
@@ -97,6 +99,7 @@ Feature: Update order lines for different open orders in parallel (using the sam
     # So we have to wait for the updates in a parallel thread before checking the budget.
     * call pause 2000
 
+    * configure headers = headersAdmin
     Given path '/finance/budgets'
     And param query = 'fundId==' + fundId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/parallel-update-order-lines-same-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/parallel-update-order-lines-same-order.feature
@@ -5,11 +5,17 @@ Feature: Update order lines for an open order in parallel
   Background:
     # This part is called once before scenarios are executed. It's important that all scenarios start at the same time,
     # so all scripts must be called with callonce.
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fundId = callonce uuid1
@@ -21,14 +27,11 @@ Feature: Update order lines for an open order in parallel
     * def poLineId4 = callonce uuid7
     * def poLineId5 = callonce uuid8
 
-    * def createOrder = read('../reusable/create-order.feature')
-    * def createOrderLine = read('../reusable/create-order-line.feature')
-    * def openOrder = read('../reusable/open-order.feature')
-
     * configure headers = headersAdmin
+    * callonce createFund { 'id': '#(fundId)' }
+    * callonce createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)' }
 
-    * callonce createFund { 'id': '#(fundId)'}
-    * callonce createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)'}
+    * configure headers = headersUser
     * callonce createOrder { id: "#(orderId)" }
     * callonce createOrderLine { id: "#(poLineId1)", orderId: "#(orderId)", fundId: "#(fundId)" }
     * callonce createOrderLine { id: "#(poLineId2)", orderId: "#(orderId)", fundId: "#(fundId)" }

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/pe-mix-update-piece.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/pe-mix-update-piece.feature
@@ -3,17 +3,17 @@ Feature: P/E mix update piece
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
-
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
 
 
   Scenario: Update piece for default P/E mix
@@ -28,6 +28,7 @@ Feature: P/E mix update piece
     * call createBudget { id: '#(budgetId)', allocated: 1000, fundId: '#(fundId)', status: 'Active' }
 
     * print "Create an order"
+    * configure headers = headersUser
     * def v = call createOrder { id: '#(orderId)' }
 
     * print "Create an order line with a P/E mix"

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/piece-audit-history.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/piece-audit-history.feature
@@ -3,19 +3,17 @@ Feature: Piece audit history
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-#    * callonce dev {tenant: 'testorders1'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
-
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-audit-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
 
     * def fundId = callonce uuid1
     * def budgetId = callonce uuid2
@@ -78,6 +76,7 @@ Feature: Piece audit history
     And match $.totalRecords == 1
     * def pieceId = $.pieces[0].id
 
+    * configure headers = headersAdmin
     Given path 'audit-data/acquisition/piece', pieceId
     When method GET
     Then status 200
@@ -96,6 +95,7 @@ Feature: Piece audit history
     And match $.totalRecords == 1
     * def pieceId = $.pieces[0].id
 
+    * configure headers = headersAdmin
     Given path 'audit-data/acquisition/piece', pieceId, 'status-change-history'
     When method GET
     Then status 200
@@ -145,6 +145,7 @@ Feature: Piece audit history
     And match $.totalRecords == 1
     * def pieceId = $.pieces[0].id
 
+    * configure headers = headersAdmin
     Given path 'audit-data/acquisition/piece', pieceId
     When method GET
     Then status 200
@@ -163,6 +164,7 @@ Feature: Piece audit history
     And match $.totalRecords == 1
     * def pieceId = $.pieces[0].id
 
+    * configure headers = headersAdmin
     Given path 'audit-data/acquisition/piece', pieceId, 'status-change-history'
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/piece-batch-job.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/piece-batch-job.feature
@@ -3,20 +3,21 @@ Feature: Piece batch job testing
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-#    * callonce dev {tenant: 'testorders1'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * configure retry = { count: 10, interval: 5000 }
 
     * callonce variables
 
     * def orderLineTemplate = read('classpath:samples/mod-orders/orderLines/minimal-order-line.json')
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
 
     * def fundId = callonce uuid1
     * def budgetId = callonce uuid2
@@ -37,7 +38,7 @@ Feature: Piece batch job testing
 
   Scenario: Create finances
     * configure headers = headersAdmin
-    * call createFund { 'id': '#(fundId)'}
+    * call createFund { 'id': '#(fundId)' }
     * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)', 'status': 'Active' }
 
   Scenario Outline: Create 6 orders
@@ -163,6 +164,7 @@ Feature: Piece batch job testing
     And match $.totalRecords == 1
     * def pieceId = $.pieces[0].id
 
+    * configure headers = headersAdmin
     Given path 'audit-data/acquisition/piece', pieceId, 'status-change-history'
     And retry until response.totalItems == <eventQuantity>
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/piece-deletion-restriction.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/piece-deletion-restriction.feature
@@ -1,11 +1,15 @@
 Feature: Piece deletion restrictions from order and order line
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
 
     * callonce variables
     * def last_piece_error_masage = "The piece cannot be deleted because it is the last piece for the poLine with Receiving Workflow 'Synchronized order and receipt quantity' and cost quantity '1'"
@@ -16,6 +20,7 @@ Feature: Piece deletion restrictions from order and order line
     * configure headers = headersAdmin
     * call createFund { 'id': '#(fundId)' }
     * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)' }
+    * configure headers = headersUser
 
   Scenario: Avoid deletion of piece when poLine cost quantity '1' and ReceivingWorkflow 'Syncronized'
     increase piece quantity and delete successfully

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/piece-operations-for-order-flows-mixed-order-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/piece-operations-for-order-flows-mixed-order-line.feature
@@ -37,12 +37,16 @@ Feature: Test operations affecting pieces with different po line options
   # - Check items after deleting the order line
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce dev {tenant: 'testorders1'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -69,8 +73,9 @@ Feature: Test operations affecting pieces with different po line options
     * print 'Create finances'
     # this is needed for instance if a previous test does a rollover which changes the global fund
     * configure headers = headersAdmin
-    * call createFund { 'id': '#(fundId)'}
-    * call createBudget { 'id': '#(budgetId)', 'allocated': 1000, 'fundId': '#(fundId)'}
+    * call createFund { 'id': '#(fundId)' }
+    * call createBudget { 'id': '#(budgetId)', 'allocated': 1000, 'fundId': '#(fundId)' }
+    * configure headers = headersUser
 
     # When an instance is connected to the po line
     * if (<instance> || locations == 'holdingLocation') karate.log('Create an instance (for cases with a connected instance or a holding location)')
@@ -169,6 +174,7 @@ Feature: Test operations affecting pieces with different po line options
     * if (<isPackage>) karate.call('../reusable/create-title.feature', { titleId: packageTitleId, poLineId })
 
     * print 'Check titles'
+    * configure headers = headersUser
     Given path 'orders/titles'
     And param query = 'poLineId==' + poLineId
     When method GET
@@ -302,6 +308,7 @@ Feature: Test operations affecting pieces with different po line options
     And assert response.locations.length == 0 || response.locations[0].holdingId == holdingId
 
     * print 'Check items after unopen'
+    * configure headers = headersAdmin
     Given path 'inventory/items'
     And param query = 'purchaseOrderLineIdentifier==' + poLineId
     When method GET
@@ -310,6 +317,7 @@ Feature: Test operations affecting pieces with different po line options
 
 
     * print 'Reopen the order'
+    * configure headers = headersUser
     Given path 'orders/composite-orders', orderId
     When method GET
     Then status 200
@@ -359,6 +367,7 @@ Feature: Test operations affecting pieces with different po line options
     And assert physicalItem == null || physicalItem.status.name == 'On order'
 
     * print 'Check titles after reopen'
+    * configure headers = headersUser
     Given path 'orders/titles'
     And param query = 'poLineId==' + poLineId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/piece-operations-for-order-flows-phys-order-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/piece-operations-for-order-flows-phys-order-line.feature
@@ -37,12 +37,16 @@ Feature: Test operations affecting pieces for physical po line with different op
   # - Check items after deleting the order line
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce dev {tenant: 'testorders1'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -69,8 +73,8 @@ Feature: Test operations affecting pieces for physical po line with different op
     * print 'Create finances'
     # this is needed for instance if a previous test does a rollover which changes the global fund
     * configure headers = headersAdmin
-    * call createFund { 'id': '#(fundId)'}
-    * call createBudget { 'id': '#(budgetId)', 'allocated': 1000, 'fundId': '#(fundId)'}
+    * call createFund { 'id': '#(fundId)' }
+    * call createBudget { 'id': '#(budgetId)', 'allocated': 1000, 'fundId': '#(fundId)' }
 
     # When an instance is connected to the po line
     * if (<instance> || locations == 'holdingLocation') karate.log('Create an instance (for cases with a connected instance or a holding location)')
@@ -305,6 +309,7 @@ Feature: Test operations affecting pieces for physical po line with different op
     And assert response.locations.length == 0 || response.locations[0].holdingId == holdingId
 
     * print 'Check items after unopen'
+    * configure headers = headersAdmin
     Given path 'inventory/items'
     And param query = 'purchaseOrderLineIdentifier==' + poLineId
     When method GET
@@ -313,6 +318,7 @@ Feature: Test operations affecting pieces for physical po line with different op
 
 
     * print 'Reopen the order'
+    * configure headers = headersUser
     Given path 'orders/composite-orders', orderId
     When method GET
     Then status 200
@@ -362,6 +368,7 @@ Feature: Test operations affecting pieces for physical po line with different op
     And assert physicalItem == null || physicalItem.status.name == 'On order'
 
     * print 'Check titles after reopen'
+    * configure headers = headersUser
     Given path 'orders/titles'
     And param query = 'poLineId==' + poLineId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/piece-status-transitions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/piece-status-transitions.feature
@@ -3,19 +3,19 @@ Feature: Piece status transitions
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-#    * callonce dev {tenant: 'testorders1'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
     * def orderLineTemplate = read('classpath:samples/mod-orders/orderLines/minimal-order-line.json')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
 
     * def fundId = callonce uuid1
     * def budgetId = callonce uuid2
@@ -104,6 +104,7 @@ Feature: Piece status transitions
     And match $.totalRecords == 1
     * def pieceId = $.pieces[0].id
 
+    * configure headers = headersAdmin
     Given path 'audit-data/acquisition/piece', pieceId, 'status-change-history'
     When method GET
     Then status 200
@@ -223,6 +224,7 @@ Feature: Piece status transitions
     And match $.totalRecords == 1
     * def pieceId = $.pieces[0].id
 
+    * configure headers = headersAdmin
     Given path 'audit-data/acquisition/piece', pieceId, 'status-change-history'
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/poline-claiming-interval-checks.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/poline-claiming-interval-checks.feature
@@ -3,18 +3,19 @@ Feature: Claiming Active/Claiming interval checks
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-#    * callonce dev {tenant: 'testorders1'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
     * def orderLineTemplate = read('classpath:samples/mod-orders/orderLines/minimal-order-line.json')
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
 
     * def fundId = callonce uuid1
     * def budgetId = callonce uuid2
@@ -24,7 +25,7 @@ Feature: Claiming Active/Claiming interval checks
 
   Scenario: Create finances
     * configure headers = headersAdmin
-    * call createFund { 'id': '#(fundId)'}
+    * call createFund { 'id': '#(fundId)' }
     * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)', 'status': 'Active' }
 
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/poline_change_instance_connection.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/poline_change_instance_connection.feature
@@ -3,12 +3,16 @@
 Feature: PoLine change instance connection
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-#    * callonce dev {tenant: 'testorders2'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -30,10 +34,11 @@ Feature: PoLine change instance connection
     # this is needed for instance if a previous test does a rollover which changes the global fund
     * print "Create finances"
     * configure headers = headersAdmin
-    * call createFund { 'id': '#(fundId)'}
-    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)'}
+    * call createFund { 'id': '#(fundId)' }
+    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)' }
 
   Scenario: Create instances
+    * configure headers = headersAdmin
     * print "Create instances"
     Given path 'inventory/instances'
     And request

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/productIds-field-error-when-attempting-to-update-unmodified-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/productIds-field-error-when-attempting-to-update-unmodified-order.feature
@@ -4,13 +4,16 @@
 Feature: Get and put a composite order
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-     # uncomment below line for development
-#    * callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -54,7 +57,6 @@ Feature: Get and put a composite order
 
 
   Scenario: Re-add the product ids with order storage
-    * configure headers = headersAdmin
     Given path 'orders-storage/po-lines', poLineId
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/receive-20-pieces.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/receive-20-pieces.feature
@@ -4,18 +4,18 @@ Feature: Receive 20 pieces
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
-    * def createPiece = read('classpath:thunderjet/mod-orders/reusable/create-piece.feature')
     * def receivePiece = read('classpath:thunderjet/mod-orders/reusable/receive-piece.feature')
 
     * def fundId = callonce uuid1

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/receive-piece-against-non-package-pol.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/receive-piece-against-non-package-pol.feature
@@ -3,12 +3,16 @@
 Feature: Receive piece against non-package POL
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    #* callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -23,8 +27,8 @@ Feature: Receive piece against non-package POL
   Scenario: Create finances
     # this is needed for instance if a previous test does a rollover which changes the global fund
     * configure headers = headersAdmin
-    * call createFund { 'id': '#(fundId)'}
-    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)'}
+    * call createFund { 'id': '#(fundId)' }
+    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)' }
 
 
   Scenario: Create an order

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/receive-piece-against-package-pol.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/receive-piece-against-package-pol.feature
@@ -3,12 +3,16 @@
 Feature: Receive piece against package POL
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    #* callonce dev {tenant: 'testorders'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -26,8 +30,8 @@ Feature: Receive piece against package POL
   Scenario: Create finances
     # this is needed for instance if a previous test does a rollover which changes the global fund
     * configure headers = headersAdmin
-    * call createFund { 'id': '#(fundId)'}
-    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)'}
+    * call createFund { 'id': '#(fundId)' }
+    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)' }
 
 
   Scenario: Create an order
@@ -110,7 +114,6 @@ Feature: Receive piece against package POL
 
   Scenario: Create piece 1 for title 1
     * print "Create piece 1 for title 1"
-    * configure headers = headersAdmin
 
     Given path 'orders/pieces'
     And request
@@ -162,8 +165,8 @@ Feature: Receive piece against package POL
 
 
     * print 'Check items after checkin first piece with createItem flag'
-    Given path 'inventory/items'
     * configure headers = headersAdmin
+    Given path 'inventory/items'
     And param query = 'purchaseOrderLineIdentifier==' + poLineId
     When method GET
     And match $.totalRecords == 1
@@ -174,6 +177,7 @@ Feature: Receive piece against package POL
     And match itemForPiece1.discoverySuppress == true
     
     # Check piece 1 receivingStatus
+    * configure headers = headersUser
     Given path 'orders/pieces', pieceId1
     When method GET
     Then status 200
@@ -205,7 +209,6 @@ Feature: Receive piece against package POL
     * print "Create piece 2 for title 2"
 
     Given path 'orders/pieces'
-    And headers headersAdmin
     And request
     """
     {
@@ -224,7 +227,6 @@ Feature: Receive piece against package POL
     * print "Create piece 3 for title 2"
 
     Given path 'orders/pieces'
-    And headers headersAdmin
     And request
     """
     {

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/reopen-order-creates-encumbrances.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/reopen-order-creates-encumbrances.feature
@@ -4,10 +4,14 @@ Feature: Reopen an order creates encumbrances
   Background:
     * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -16,11 +20,7 @@ Feature: Reopen an order creates encumbrances
     * def orderId = callonce uuid3
     * def poLineId = callonce uuid4
 
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
     * def closeOrderRemoveLines = read('classpath:thunderjet/mod-orders/reusable/close-order-remove-lines.feature')
-    * def getOrderLine = read('../reusable/get-order-line.feature')
 
 
   Scenario: Prepare finances
@@ -46,6 +46,7 @@ Feature: Reopen an order creates encumbrances
 
 
   Scenario: Check the encumbrance after closing the order
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId
     When method GET
@@ -58,7 +59,6 @@ Feature: Reopen an order creates encumbrances
 
 
   Scenario: Remove the encumbrance link in the order line and delete the encumbrance
-    * configure headers = headersAdmin
     Given path 'orders-storage/po-lines', poLineId
     When method GET
     Then status 200
@@ -72,6 +72,7 @@ Feature: Reopen an order creates encumbrances
     When method PUT
     Then status 204
 
+    * configure headers = headersAdmin
     Given path 'finance/transactions/batch-all-or-nothing'
     And request
     """
@@ -88,6 +89,7 @@ Feature: Reopen an order creates encumbrances
 
 
   Scenario: Check that the encumbrance was created and that the encumbrance link was added to the order line
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId
     When method GET
@@ -98,5 +100,6 @@ Feature: Reopen an order creates encumbrances
     And assert transaction.encumbrance.initialAmountEncumbered == 1.0
     And assert transaction.encumbrance.status == 'Unreleased'
 
+    * configure headers = headersUser
     * call getOrderLine { poLineId: #(poLineId) }
     And match poLine.fundDistribution[0].encumbrance == transaction.id

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/reopen-order-with-50-lines.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/reopen-order-with-50-lines.feature
@@ -4,18 +4,18 @@ Feature: Reopen order with 50 lines
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
     * def closeOrderRemoveLines = read('classpath:thunderjet/mod-orders/reusable/close-order-remove-lines.feature')
 
     * def fundId = callonce uuid1
@@ -56,6 +56,7 @@ Feature: Reopen order with 50 lines
     * def v = call closeOrderRemoveLines { orderId: #(orderId) }
 
   Scenario: Check the encumbrances were all released
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId + ' and encumbrance.status==Released'
     When method GET
@@ -67,6 +68,7 @@ Feature: Reopen order with 50 lines
     * def v = call openOrder { orderId: "#(orderId)" }
 
   Scenario: Check the encumbrances were all unreleased
+    * configure headers = headersAdmin
     Given path 'finance/transactions'
     And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId + ' and encumbrance.status==Released'
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/retrieve-titles-with-honor-of-acq-units.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/retrieve-titles-with-honor-of-acq-units.feature
@@ -3,11 +3,16 @@
 Feature: Retrieve titles with honor of acquisition units
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -20,14 +25,13 @@ Feature: Retrieve titles with honor of acquisition units
 
   Scenario: Create a fund and budget
     * configure headers = headersAdmin
-    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerId)'}
-    * callonce createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 1000, 'statusExpenseClasses': [{'expenseClassId': '#(globalPrnExpenseClassId)','status': 'Active'}]}
+    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerId)' }
+    * callonce createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 1000, 'statusExpenseClasses': [{'expenseClassId': '#(globalPrnExpenseClassId)','status': 'Active'}] }
 
 
   Scenario: Create acq unit
     * configure headers = headersAdmin
     Given path 'acquisitions-units/units'
-    And headers headersAdmin
     And request
     """
     {
@@ -44,15 +48,14 @@ Feature: Retrieve titles with honor of acquisition units
 
   Scenario: Create acq unit membership
     * configure headers = headersAdmin
-    * def result = call read('classpath:common/eureka/users.feature') {user: '#(testAdmin)'}
-    * def userIdForMembership = result.userId
+    * def res = callonce getUserIdByUsername { user: '#(testUser)' }
+    * def userId = res.userId
     Given path 'acquisitions-units/memberships'
-    And headers headersAdmin
     And request
     """
       {
         "id": '#(acqUnitMembershipId)',
-        "userId": "#(userIdForMembership)",
+        "userId": "#(userId)",
         "acquisitionsUnitId": "#(acqUnitId)"
       }
     """

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/routing-list-print-template.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/routing-list-print-template.feature
@@ -2,11 +2,16 @@
   Feature: Should check processing of printing routing list functionlity
 
     Background:
+      * print karate.info.scenarioName
       * url baseUrl
-      * callonce loginAdmin testAdmin
+
+      * callonce login testAdmin
       * def okapitokenAdmin = okapitoken
-      * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-      * configure headers = headersAdmin
+      * callonce login testUser
+      * def okapitokenUser = okapitoken
+      * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+      * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+      * configure headers = headersUser
 
       * callonce variables
       * def routingListId = "a1d13648-347b-4ac9-8c2f-5bc47248b87e"
@@ -71,7 +76,6 @@
 
 
       * print "Create two users with different addressType are related to routingLists"
-      * configure headers = headersAdmin
       * set user1.personal.addresses[0].addressTypeId = officeAddressTypeId
       * set user1.personal.addresses[0].addressLine1 = officeAddressLine1V1
       * set user1.personal.addresses[1].addressTypeId = homeAddressTypeId
@@ -114,6 +118,7 @@
 
 
       * print "Create composite order to use in routing list"
+      * configure headers = headersUser
       Given path 'orders/composite-orders'
       And request
         """
@@ -142,7 +147,6 @@
 
 
       * print "POST setting with addressTypId"
-      * configure headers = headersAdmin
       Given path 'orders-storage/settings'
       And request
         """
@@ -179,7 +183,6 @@
       * set routingList.userIds[0] = user1.id
       * set routingList.userIds[1] = user2.id
       * set routingList.userIds[2] = user3.id
-      * configure headers = headersAdmin
 
       Given path 'orders-storage/routing-lists'
       And request routingList

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/routing-lists-api.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/routing-lists-api.feature
@@ -2,11 +2,13 @@
 Feature: Test routing list API
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -20,9 +22,6 @@ Feature: Test routing list API
     * def rListSample = read('classpath:samples/mod-orders/routingLists/a1d13648-347b-4ac9-8c2f-5bc47248b87e.json')
     * set rListSample.id = rListId;
     * set rListSample.poLineId = poLineId;
-
-    * def createOrder = read('../reusable/create-order.feature')
-    * def createOrderLine = read('../reusable/create-order-line.feature')
 
     * callonce createOrder { id: #(orderId) }
     * callonce createOrderLine { id: #(poLineId), orderId: #(orderId) }

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/should-decrease-quantity-when-delete-piece-with-no-location.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/should-decrease-quantity-when-delete-piece-with-no-location.feature
@@ -1,11 +1,14 @@
 Feature: Should decrease quantity when delete piece with no location
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def orderIdForPhysicalQuantity = callonce uuid1

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/three-fund-distributions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/three-fund-distributions.feature
@@ -3,11 +3,16 @@
 Feature: Three fund distributions
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/title-instance-creation.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/title-instance-creation.feature
@@ -2,11 +2,16 @@
 Feature: Test instance creation with new title
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -14,9 +19,6 @@ Feature: Test instance creation with new title
     * def poLineId = callonce uuid2
     * def fundId = callonce uuid3
     * def titleId = callonce uuid4
-
-    * def createOrder = read('../reusable/create-order.feature')
-    * def createOrderLine = read('../reusable/create-order-line.feature')
 
     * callonce createOrder { id: #(orderId) }
     * callonce createOrderLine { id: #(poLineId), orderId: #(orderId), isPackage: true }
@@ -39,6 +41,7 @@ Feature: Test instance creation with new title
     * def instId = response.instanceId
 
     # Check instance creation
+    * configure headers = headersAdmin
     Given path '/instance-storage/instances', instId
     When method GET
     Then status 200
@@ -46,6 +49,7 @@ Feature: Test instance creation with new title
     And match response.title == "New Title 1"
 
     # Check title by poLineId contains same instance
+    * configure headers = headersUser
     Given path '/orders/titles'
     And param query = 'poLineId==' + poLineId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/unlink-title.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/unlink-title.feature
@@ -4,14 +4,14 @@ Feature: unlink title from package. DELETE Title
     * print karate.info.scenarioName
     * url baseUrl
 
-    * call loginAdmin testAdmin
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * call loginRegularUser dummyUser
+    * callonce login testUser
     * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
     * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
-    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)' }
+
     * configure retry = { count: 10, interval: 5000 }
-    * configure headers = headersAdmin
 
     * callonce variables
     * def fundId = callonce uuid
@@ -19,6 +19,7 @@ Feature: unlink title from package. DELETE Title
 
     ### Before All ###
     # 1. Prepare finance data
+    * configure headers = headersAdmin
     * def v = callonce createFund { id: '#(fundId)' }
     * def v = callonce createBudget { id: '#(budgetId)', allocated: 100, fundId: '#(fundId)', status: 'Active' }
 
@@ -62,12 +63,14 @@ Feature: unlink title from package. DELETE Title
       * def instanceTitle1 = "Instance 1" + instanceId1
 
       # 1. Create instances using table and createInstance method
+      * configure headers = headersAdmin
       * table instances
         | id          | title       | instanceTypeId       |
         | instanceId1 | instanceId1 | globalInstanceTypeId |
       * def v = call createInstance instances
 
       # 2. Prepare acquisitions data
+      * configure headers = headersUser
       * def v = call createOrder { id: '#(orderId)' }
       * def v = call createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', fundId: '#(fundId)', isPackage: true, claimingActive: true, claimingInterval: 1 }
       * def v = call openOrder { orderId: '#(orderId)' }
@@ -91,12 +94,14 @@ Feature: unlink title from package. DELETE Title
     * def instanceTitle1 = "Instance 1" + instanceId1
 
     # 1. Create instances using table and createInstance method
+    * configure headers = headersAdmin
     * table instances
       | id          | title       | instanceTypeId       |
       | instanceId1 | instanceId1 | globalInstanceTypeId |
     * def v = call createInstance instances
 
     # 2. Prepare data
+    * configure headers = headersUser
     * def v = call createOrder { id: '#(orderId)' }
     * def v = call createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', fundId: '#(fundId)', isPackage: true, claimingActive: true, claimingInterval: 1 }
     * def v = call openOrder { orderId: '#(orderId)' }
@@ -132,9 +137,9 @@ Feature: unlink title from package. DELETE Title
     When method GET
     Then status 200
     And match $.holdingsRecordId == holdingId
-    * configure headers = headersUser
 
     # 5. Verify existing holding confirmation error
+    * configure headers = headersUser
     Given path 'orders/titles', titleId
     When method DELETE
     Then status 400
@@ -156,12 +161,14 @@ Feature: unlink title from package. DELETE Title
     * def instanceTitle2 = "Instance 2" + instanceId2
 
     # 1. Create instances using table and createInstance method
+    * configure headers = headersAdmin
     * table instances
       | id          | title       | instanceTypeId       |
       | instanceId1 | instanceId1 | globalInstanceTypeId |
     * def v = call createInstance instances
 
     # 2. Prepare data
+    * configure headers = headersUser
     * def v = call createOrder { id: '#(orderId)' }
     * def v = call createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', fundId: '#(fundId)', isPackage: true, claimingActive: true, claimingInterval: 1 }
     * def v = call openOrder { orderId: '#(orderId)' }
@@ -195,14 +202,13 @@ Feature: unlink title from package. DELETE Title
     * def holdingId = $.holdingsRecords[0].id
 
     Given path 'inventory/items', pieceItemId
-    * configure headers = headersAdmin
     When method GET
     Then status 200
     And match $.holdingsRecordId == holdingId
-    * configure headers = headersUser
 
 
     # 5. Unlink title (Delete title)
+    * configure headers = headersUser
     Given path 'orders/titles', titleId
     And param deleteHoldings = false
     When method DELETE
@@ -219,11 +225,10 @@ Feature: unlink title from package. DELETE Title
     * def holdingId = $.holdingsRecords[0].id
 
     Given path 'inventory/items', pieceItemId
-    * configure headers = headersAdmin
     When method GET
     Then status 404
-    * configure headers = headersUser
 
+    * configure headers = headersUser
     Given path 'orders/pieces', pieceId1
     When method GET
     Then status 404
@@ -245,12 +250,14 @@ Feature: unlink title from package. DELETE Title
     * def instanceTitle1 = "Instance 1" + instanceId1
 
     # 1. Create instances using table and createInstance method
+    * configure headers = headersAdmin
     * table instances
       | id          | title       | instanceTypeId       |
       | instanceId1 | instanceId1 | globalInstanceTypeId |
     * def v = call createInstance instances
 
     # 2. Prepare data
+    * configure headers = headersUser
     * def v = call createOrder { id: '#(orderId)' }
     * def v = call createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', fundId: '#(fundId)', isPackage: true, claimingActive: true, claimingInterval: 1 }
     * def v = call openOrder { orderId: '#(orderId)' }
@@ -287,10 +294,10 @@ Feature: unlink title from package. DELETE Title
     When method GET
     Then status 200
     And match $.holdingsRecordId == holdingId
-    * configure headers = headersUser
 
 
     # 5. Unlink title (Delete title)
+    * configure headers = headersUser
     Given path 'orders/titles', titleId
     And param deleteHoldings = true
     When method DELETE
@@ -308,8 +315,8 @@ Feature: unlink title from package. DELETE Title
     Given path 'inventory/items', pieceItemId
     When method GET
     Then status 404
-    * configure headers = headersUser
 
+    * configure headers = headersUser
     Given path 'orders/pieces', pieceId1
     When method GET
     Then status 404
@@ -332,6 +339,7 @@ Feature: unlink title from package. DELETE Title
     * def instanceTitle2 = "Instance 2" + instanceId2
 
     # 1. Create instances using table and createInstance method
+    * configure headers = headersAdmin
     * table instances
       | id          | title       | instanceTypeId       |
       | instanceId1 | instanceId1 | globalInstanceTypeId |
@@ -339,6 +347,7 @@ Feature: unlink title from package. DELETE Title
     * def v = call createInstance instances
 
     # 2. Prepare data for first order
+    * configure headers = headersUser
     * def v = call createOrder { id: '#(orderId)' }
     * def v = call createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', fundId: '#(fundId)', isPackage: true, claimingActive: true, claimingInterval: 1 }
     * def v = call openOrder { orderId: '#(orderId)' }
@@ -369,10 +378,10 @@ Feature: unlink title from package. DELETE Title
     Then status 200
     And match $.totalRecords == 1
     * def holdingId1 = $.holdingsRecords[0].id
-    * configure headers = headersUser
 
 
     # 5. Prepare acquisitions data for second order
+    * configure headers = headersUser
     * def v = call createOrder { id: '#(orderId2)' }
     * def v = call createOrderLine { id: '#(poLineId2)', orderId: '#(orderId2)', fundId: '#(fundId)', isPackage: true, claimingActive: true, claimingInterval: 1 }
     * def v = call openOrder { orderId: '#(orderId2)' }
@@ -397,11 +406,11 @@ Feature: unlink title from package. DELETE Title
 
 
     # 7. Move to first holding to make holding to used by two poLines
+    * configure headers = headersAdmin
     * def v = call moveItem { holdingId: '#(holdingId1)', itemId: '#(pieceItemId2)' }
 
 
     # 8. Check holding and item existence
-    * configure headers = headersAdmin
     Given path 'inventory/items', pieceItemId1
     When method GET
     Then status 200
@@ -411,10 +420,10 @@ Feature: unlink title from package. DELETE Title
     When method GET
     Then status 200
     And match $.holdingsRecordId == holdingId1
-    * configure headers = headersUser
 
 
     # 9. Delete Title and holdings
+    * configure headers = headersUser
     Given path 'orders/titles', titleId
     And param deleteHoldings = true
     When method DELETE
@@ -436,9 +445,9 @@ Feature: unlink title from package. DELETE Title
     Given path 'inventory/items', pieceItemId2
     When method GET
     Then status 200
-    * configure headers = headersUser
 
     # 10.4 Verify that piece belong to poLineId1 and unlinking title is deleted
+    * configure headers = headersUser
     Given path 'orders/pieces', pieceId1
     When method GET
     Then status 404

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/unopen-order-with-different-fund.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/unopen-order-with-different-fund.feature
@@ -4,10 +4,14 @@ Feature: Unopen order and change fund distribution
   Background:
     * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -23,6 +27,7 @@ Feature: Unopen order and change fund distribution
       * def v = call createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 1000, statusExpenseClasses: '#(statusExpenseClasses)' }
 
       # 2. Create order and order line
+      * configure headers = headersUser
       * def orderId = call uuid
       * def poLineId = call uuid
 
@@ -71,6 +76,7 @@ Feature: Unopen order and change fund distribution
       * def v = call createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 1000, statusExpenseClasses: '#(statusExpenseClasses)' }
 
       # 2. Create order and order line
+      * configure headers = headersUser
       * def orderId = call uuid
       * def poLineId = call uuid
       * def v = call createOrder { id: '#(orderId)', vendor: '#(globalVendorId)', orderType: 'One-Time' }
@@ -127,6 +133,7 @@ Feature: Unopen order and change fund distribution
     * def v = call createBudget budgetTable
 
     # 2. Create order and 15 order line with 3 fund distributions
+    * configure headers = headersUser
     * def orderId = call uuid
     * def v = call createOrder { id: '#(orderId)', vendor: '#(globalVendorId)', orderType: 'One-Time' }
 
@@ -157,16 +164,21 @@ Feature: Unopen order and change fund distribution
     # 3. Open and unopen the order and check encumbrance transactions status
     * def v = call openOrder { orderId: '#(orderId)' }
     * def expectedEncumbranceStatus = { _orderId: '#(orderId)', _encumbranceStatus: 'Unreleased', _orderStatus: 'Open' }
+    * configure headers = headersAdmin
     * def v = call verifyEncumbranceStatus expectedEncumbranceStatus
 
     # 4. Unopen the order and check encumbrance transactions status
+    * configure headers = headersUser
     * def v = call unopenOrder { orderId: '#(orderId)' }
     * def expectedEncumbranceStatus = { _orderId: '#(orderId)', _encumbranceStatus: 'Pending', _orderStatus: 'Pending' }
+    * configure headers = headersAdmin
     * def v = call verifyEncumbranceStatus expectedEncumbranceStatus
 
     # 5. Reopen the order and check encumbrance transactions status
+    * configure headers = headersUser
     * def v = call openOrder { orderId: '#(orderId)' }
     * def expectedEncumbranceStatus = { _orderId: '#(orderId)', _encumbranceStatus: 'Unreleased', _orderStatus: 'Open' }
+    * configure headers = headersAdmin
     * def v = call verifyEncumbranceStatus expectedEncumbranceStatus
 
 
@@ -212,6 +224,7 @@ Feature: Unopen order and change fund distribution
     * def v = call createBudget budgetsTable
 
     # 2. Create order and one order line with 25 fund distributions
+    * configure headers = headersUser
     * def orderId = call uuid
     * def v = call createOrder { id: '#(orderId)', vendor: '#(globalVendorId)', orderType: 'One-Time' }
 
@@ -237,14 +250,19 @@ Feature: Unopen order and change fund distribution
     # 3. Open and unopen the order and check encumbrance transactions status
     * def v = call openOrder { orderId: '#(orderId)' }
     * def expectedEncumbranceStatus = { _orderId: '#(orderId)', _encumbranceStatus: 'Unreleased', _orderStatus: 'Open' }
+    * configure headers = headersAdmin
     * def v = call verifyEncumbranceStatus expectedEncumbranceStatus
 
     # 4. Unopen the order and check encumbrance transactions status
+    * configure headers = headersUser
     * def v = call unopenOrder { orderId: '#(orderId)' }
     * def expectedEncumbranceStatus = { _orderId: '#(orderId)', _encumbranceStatus: 'Pending', _orderStatus: 'Pending' }
+    * configure headers = headersAdmin
     * def v = call verifyEncumbranceStatus expectedEncumbranceStatus
 
     # 5. Reopen the order and check encumbrance transactions status
+    * configure headers = headersUser
     * def v = call openOrder { orderId: '#(orderId)' }
     * def expectedEncumbranceStatus = { _orderId: '#(orderId)', _encumbranceStatus: 'Unreleased', _orderStatus: 'Open' }
+    * configure headers = headersAdmin
     * def v = call verifyEncumbranceStatus expectedEncumbranceStatus

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/unreceive-piece-and-check-order-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/unreceive-piece-and-check-order-line.feature
@@ -2,19 +2,19 @@
 Feature: Unreceive a piece and check the order line
 
   Background:
-    * url baseUrl
     * print karate.info.scenarioName
-    * callonce loginAdmin testAdmin
+    * url baseUrl
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
-    * def createPiece = read('classpath:thunderjet/mod-orders/reusable/create-piece.feature')
     * def unreceivePiece = read('classpath:thunderjet/mod-orders/reusable/unreceive-piece.feature')
 
     * configure retry = { count: 10, interval: 5000 }
@@ -36,6 +36,7 @@ Feature: Unreceive a piece and check the order line
     * def v = call createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 100 }
 
     * print '2. Create an order'
+    * configure headers = headersUser
     * def v = callonce createOrder { id: '#(orderId)' }
 
     * print '3. Create a package order line'

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/update-purchase-order-with-order-lines.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/update-purchase-order-with-order-lines.feature
@@ -2,11 +2,16 @@
 Feature: Update purchase order with order lines
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -25,6 +30,7 @@ Feature: Update purchase order with order lines
     * def v = call createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 1000 }
 
     ### 2. Create orders and order lines
+    * configure headers = headersUser
     * def ongoingObj = { "interval": 123, "isSubscription": true, "renewalDate": "2022-05-08T00:00:00.000+00:00" }
     * table orders
       | id       | orderId  | orderType  | ongoing    |

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/update-purchase-order-workflow-status.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/update-purchase-order-workflow-status.feature
@@ -2,11 +2,16 @@
 Feature: Update purchase order workflow status
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -25,6 +30,7 @@ Feature: Update purchase order workflow status
     * def v = call createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 1000 }
 
     ### 2. Create orders and order lines
+    * configure headers = headersUser
     * def ongoingObj = { "interval": 123, "isSubscription": true, "renewalDate": "2022-05-08T00:00:00.000+00:00" }
     * table orders
       | id       | orderId  | orderType  | ongoing    |

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/update_fields_in_item.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/update_fields_in_item.feature
@@ -2,20 +2,19 @@
 Feature: Should update copy number, enumeration and chronology in item after updating in piece
 
   Background:
-    * url baseUrl
     * print karate.info.scenarioName
+    * url baseUrl
 
-    # * callonce dev {tenant: 'testorders1'}
-    * callonce loginAdmin testAdmin
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
     * def orderLineTemplate = read('classpath:samples/mod-orders/orderLines/minimal-order-line.json')
 
   @Positive
@@ -31,6 +30,7 @@ Feature: Should update copy number, enumeration and chronology in item after upd
     * def v = call createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 1000 }
 
     * print '2. Create an order'
+    * configure headers = headersUser
     * def v = call createOrder { id: '#(orderId)', vendor: '#(globalVendorId)', orderType: 'One-Time' }
 
     * print '3. Create a po line'
@@ -73,7 +73,8 @@ Feature: Should update copy number, enumeration and chronology in item after upd
     Then status 200
 
     * def piece = $.pieces[0]
-    
+
+    * configure headers = headersAdmin
     Given path '/inventory/items/', piece.itemId
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/update_fund_in_poline_when_invoice_approved.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/update_fund_in_poline_when_invoice_approved.feature
@@ -1,16 +1,19 @@
+# THIS SHOULD BE IN MOD-INVOICE
 @parallel=false
 # for https://issues.folio.org/browse/MODORDERS-803
 Feature: Should fail updating fund in poLine when related invoice is approved
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-#    * callonce dev {tenant: 'testorders1'}
-    * callonce loginAdmin testAdmin
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -81,6 +84,7 @@ Feature: Should fail updating fund in poLine when related invoice is approved
     Then status 204
 
   Scenario: Create an invoice
+    * configure headers = headersAdmin
     * copy invoice = invoiceTemplate
     * set invoice.id = invoiceId
     Given path 'invoice/invoices'
@@ -97,6 +101,7 @@ Feature: Should fail updating fund in poLine when related invoice is approved
     * def encumbranceId = poLine.fundDistribution[0].encumbrance
 
     * print "Add an invoice line linked to the po line"
+    * configure headers = headersAdmin
     * copy invoiceLine = invoiceLineTemplate
     * set invoiceLine.id = invoiceLineId
     * set invoiceLine.invoiceId = invoiceId
@@ -112,6 +117,7 @@ Feature: Should fail updating fund in poLine when related invoice is approved
     Then status 201
 
   Scenario: Approve the invoice
+    * configure headers = headersAdmin
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200
@@ -123,6 +129,7 @@ Feature: Should fail updating fund in poLine when related invoice is approved
     Then status 204
 
   Scenario: Check the budget
+    * configure headers = headersAdmin
     Given path 'finance/budgets', budgetId1
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/validate-fund-distribution-for-zero-price.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/validate-fund-distribution-for-zero-price.feature
@@ -2,17 +2,19 @@
 Feature: Validate fund distribution for zero price
 
   Background:
-    * url baseUrl
     * print karate.info.scenarioName
-    * callonce loginAdmin testAdmin
+    * url baseUrl
+
+    * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)'  }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
     * def orderLineTemplate = read('classpath:samples/mod-orders/orderLines/minimal-order-line.json')
 
   @Positive
@@ -33,6 +35,7 @@ Feature: Validate fund distribution for zero price
     * def v = call createBudget { id: '#(budgetId2)', fundId: '#(fundId2)', allocated: 1000 }
 
     * print '2. Create an order'
+    * configure headers = headersUser
     * def v = call createOrder { id: '#(orderId)' }
 
     * print '3. Create an order line with a fund distribution using amounts'

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders-junit.feature
@@ -1,3 +1,4 @@
+@parallel=false
 Feature: mod-orders integration tests
 
   Background:
@@ -30,140 +31,10 @@ Feature: mod-orders integration tests
 
     * table userPermissions
       | name                                                          |
-      | 'acquisition.invoice.events.get'                              |
-      | 'acquisition.invoice-line.events.get'                         |
-      | 'acquisition.order-line.events.get'                           |
-      | 'acquisition.order.events.get'                                |
-      | 'acquisition.piece.events.history.get'                        |
-      | 'acquisition.piece.events.get'                                |
-      | 'addresstypes.item.post'                                      |
-      | 'acquisitions-units.memberships.item.delete'                  |
-      | 'acquisitions-units.memberships.item.post'                    |
-      | 'acquisitions-units.units.item.post'                          |
-      | 'acquisitions-units.units.item.put'                           |
-      | 'acquisitions-units-storage.memberships.collection.get'       |
-      | 'acquisitions-units-storage.memberships.item.delete'          |
-      | 'acquisitions-units-storage.memberships.item.get'             |
-      | 'acquisitions-units-storage.memberships.item.post'            |
-      | 'acquisitions-units-storage.memberships.item.put'             |
-      | 'acquisitions-units-storage.units.item.post'                  |
-      | 'circulation.rules.put'                                       |
-      | 'circulation.requests.item.get'                               |
-      | 'circulation.requests.item.move.post'                         |
-      | 'circulation.requests.item.post'                              |
-      | 'circulation-storage.loan-policies.collection.get'            |
-      | 'circulation-storage.loan-policies.item.post'                 |
-      | 'circulation-storage.patron-notice-policies.collection.get'   |
-      | 'circulation-storage.patron-notice-policies.item.post'        |
-      | 'circulation-storage.request-policies.collection.get'         |
-      | 'circulation-storage.request-policies.item.post'              |
-      | 'configuration.entries.collection.get'                        |
-      | 'configuration.entries.item.delete'                           |
-      | 'configuration.entries.item.post'                             |
-      | 'configuration.entries.item.put'                              |
-      | 'finance.budgets-expense-classes-totals.collection.get'       |
-      | 'finance.budgets.collection.get'                              |
-      | 'finance.budgets.item.delete'                                 |
-      | 'finance.budgets.item.get'                                    |
-      | 'finance.budgets.item.post'                                   |
-      | 'finance.budgets.item.put'                                    |
-      | 'finance.exchange-rate.item.get'                              |
-      | 'finance.expense-classes.item.post'                           |
-      | 'finance.fiscal-years.item.delete'                            |
-      | 'finance.fiscal-years.item.get'                               |
-      | 'finance.fiscal-years.item.post'                              |
-      | 'finance.fiscal-years.item.put'                               |
-      | 'finance.fund-types.item.post'                                |
-      | 'finance.funds.budget.item.get'                               |
-      | 'finance.funds.collection.get'                                |
-      | 'finance.funds.item.get'                                      |
-      | 'finance.funds.item.put'                                      |
-      | 'finance.group-fiscal-year-summaries.collection.get'          |
-      | 'finance.group-fund-fiscal-years.item.post'                   |
-      | 'finance.groups-expense-classes-totals.collection.get'        |
-      | 'finance.ledger-rollovers-budgets.collection.get'             |
-      | 'finance.ledger-rollovers-budgets.item.get'                   |
-      | 'finance.ledger-rollovers-errors.collection.get'              |
-      | 'finance.ledger-rollovers-logs.collection.get'                |
-      | 'finance.ledger-rollovers-logs.item.get'                      |
-      | 'finance.ledger-rollovers-progress.collection.get'            |
-      | 'finance.ledger-rollovers-progress.item.put'                  |
-      | 'finance.ledger-rollovers.item.post'                          |
-      | 'finance.ledgers.collection.get'                              |
-      | 'finance.ledgers.current-fiscal-year.item.get'                |
-      | 'finance.ledgers.item.delete'                                 |
-      | 'finance.ledgers.item.get'                                    |
-      | 'finance.ledgers.item.post'                                   |
-      | 'finance.release-encumbrance.item.post'                       |
-      | 'finance.transactions.batch.execute'                          |
-      | 'finance.transactions.collection.get'                         |
-      | 'finance.transactions.item.get'                               |
-      | 'finance-storage.budget-expense-classes.collection.get'       |
-      | 'finance-storage.budget-expense-classes.item.post'            |
-      | 'finance-storage.budgets.item.get'                            |
-      | 'finance-storage.budgets.item.post'                           |
-      | 'finance-storage.funds.item.delete'                           |
-      | 'finance-storage.funds.item.post'                             |
-      | 'finance-storage.group-fund-fiscal-years.collection.get'      |
-      | 'finance-storage.group-fund-fiscal-years.item.post'           |
-      | 'finance-storage.ledger-rollovers-errors.collection.get'      |
-      | 'finance-storage.ledger-rollovers-errors.item.delete'         |
-      | 'finance-storage.ledger-rollovers-errors.item.post'           |
-      | 'finance-storage.ledger-rollovers.item.delete'                |
-      | 'finance-storage.ledger-rollovers.item.post'                  |
-      | 'finance-storage.ledgers.item.post'                           |
-      | 'finance-storage.transactions.batch.execute'                  |
-      | 'finance-storage.transactions.collection.get'                 |
-      | 'inventory-storage.contributor-name-types.item.post'          |
-      | 'inventory-storage.electronic-access-relationships.item.post' |
-      | 'inventory-storage.holdings.collection.get'                   |
-      | 'inventory-storage.holdings.item.get'                         |
-      | 'inventory-storage.holdings.item.post'                        |
-      | 'inventory-storage.holdings.retrieve.collection.post'         |
-      | 'inventory-storage.holdings-sources.item.post'                |
-      | 'inventory-storage.identifier-types.item.post'                |
-      | 'inventory-storage.instance-statuses.item.post'               |
-      | 'inventory-storage.instance-types.item.post'                  |
-      | 'inventory-storage.instances.item.get'                        |
-      | 'inventory-storage.items.item.get'                            |
-      | 'inventory-storage.loan-types.item.post'                      |
-      | 'inventory-storage.location-units.campuses.item.post'         |
-      | 'inventory-storage.location-units.institutions.item.post'     |
-      | 'inventory-storage.location-units.libraries.item.post'        |
-      | 'inventory-storage.locations.item.post'                       |
-      | 'inventory-storage.material-types.item.post'                  |
-      | 'inventory-storage.service-points.item.post'                  |
-      | 'inventory.instances.collection.get'                          |
-      | 'inventory.instances.item.post'                               |
-      | 'inventory.instances.item.put'                                |
-      | 'inventory.items.collection.get'                              |
-      | 'inventory.items.move.item.post'                              |
-      | 'inventory.items-by-holdings-id.collection.get'               |
-      | 'inventory.tenant-items.collection.get'                       |
-      | 'inventory.holdings.move.item.post'                           |
-      | 'invoice.invoice-lines.collection.get'                        |
-      | 'invoice.invoice-lines.item.delete'                           |
-      | 'invoice.invoice-lines.item.get'                              |
-      | 'invoice.invoice-lines.item.post'                             |
-      | 'invoice.invoice-lines.item.put'                              |
-      | 'invoice.invoices.collection.get'                             |
-      | 'invoice.invoices.documents.item.post'                        |
-      | 'invoice.invoices.fiscal-years.collection.get'                |
-      | 'invoice.invoices.item.delete'                                |
-      | 'invoice.invoices.item.get'                                   |
-      | 'invoice.invoices.item.post'                                  |
-      | 'invoice.invoices.item.put'                                   |
-      | 'invoice.item.approve.execute'                                |
-      | 'invoice.item.cancel.execute'                                 |
-      | 'invoice.item.pay.execute'                                    |
-      | 'invoices.acquisitions-units-assignments.assign'              |
-      | 'invoices.acquisitions-units-assignments.manage'              |
-      | 'lost-item-fees-policies.collection.get'                      |
-      | 'lost-item-fees-policies.item.post'                           |
       | 'orders.acquisition-method.item.post'                         |
-      | 'orders.acquisition-units.bypass.execute'                     |
       | 'orders.acquisitions-units-assignments.assign'                |
       | 'orders.acquisitions-units-assignments.manage'                |
+      | 'orders.acquisition-units.bypass.execute'                     |
       | 'orders.bind-pieces.collection.post'                          |
       | 'orders.bind-pieces.item.delete'                              |
       | 'orders.check-in.collection.post'                             |
@@ -187,18 +58,14 @@ Feature: mod-orders integration tests
       | 'orders.po-lines.item.get'                                    |
       | 'orders.po-lines.item.post'                                   |
       | 'orders.po-lines.item.put'                                    |
-      | 'orders.re-encumber.item.post'                                |
       | 'orders.receiving.collection.post'                            |
+      | 'orders.re-encumber.item.post'                                |
       | 'orders.routing-lists.collection.get'                         |
       | 'orders.routing-lists.item.delete'                            |
       | 'orders.routing-lists.item.get'                               |
       | 'orders.routing-lists.item.post'                              |
       | 'orders.routing-lists.item.put'                               |
       | 'orders.routing-lists-template.item.get'                      |
-      | 'orders.titles.collection.get'                                |
-      | 'orders.titles.item.get'                                      |
-      | 'orders.titles.item.post'                                     |
-      | 'orders.titles.item.put'                                      |
       | 'orders-storage.claiming.process.execute'                     |
       | 'orders-storage.pieces.collection.get'                        |
       | 'orders-storage.po-lines.item.get'                            |
@@ -207,6 +74,145 @@ Feature: mod-orders integration tests
       | 'orders-storage.purchase-orders.item.post'                    |
       | 'orders-storage.routing-lists.item.post'                      |
       | 'orders-storage.settings.item.post'                           |
+      | 'orders.titles.collection.get'                                |
+      | 'orders.titles.item.delete'                                   |
+      | 'orders.titles.item.get'                                      |
+      | 'orders.titles.item.post'                                     |
+      | 'orders.titles.item.put'                                      |
+
+    * table adminPermissions
+      | name                                                          |
+      | 'acquisition.invoice.events.get'                              |
+      | 'acquisition.invoice-line.events.get'                         |
+      | 'acquisition.order.events.get'                                |
+      | 'acquisition.order-line.events.get'                           |
+      | 'acquisition.piece.events.get'                                |
+      | 'acquisition.piece.events.history.get'                        |
+      | 'acquisitions-units.memberships.item.delete'                  |
+      | 'acquisitions-units.memberships.item.post'                    |
+      | 'acquisitions-units-storage.memberships.collection.get'       |
+      | 'acquisitions-units-storage.memberships.item.delete'          |
+      | 'acquisitions-units-storage.memberships.item.get'             |
+      | 'acquisitions-units-storage.memberships.item.post'            |
+      | 'acquisitions-units-storage.memberships.item.put'             |
+      | 'acquisitions-units-storage.units.item.post'                  |
+      | 'acquisitions-units.units.item.post'                          |
+      | 'acquisitions-units.units.item.put'                           |
+      | 'addresstypes.item.post'                                      |
+      | 'circulation.requests.item.get'                               |
+      | 'circulation.requests.item.move.post'                         |
+      | 'circulation.requests.item.post'                              |
+      | 'circulation.rules.put'                                       |
+      | 'circulation-storage.loan-policies.collection.get'            |
+      | 'circulation-storage.loan-policies.item.post'                 |
+      | 'circulation-storage.patron-notice-policies.collection.get'   |
+      | 'circulation-storage.patron-notice-policies.item.post'        |
+      | 'circulation-storage.request-policies.collection.get'         |
+      | 'circulation-storage.request-policies.item.post'              |
+      | 'configuration.entries.collection.get'                        |
+      | 'configuration.entries.item.delete'                           |
+      | 'configuration.entries.item.post'                             |
+      | 'configuration.entries.item.put'                              |
+      | 'finance.budgets.collection.get'                              |
+      | 'finance.budgets-expense-classes-totals.collection.get'       |
+      | 'finance.budgets.item.delete'                                 |
+      | 'finance.budgets.item.get'                                    |
+      | 'finance.budgets.item.post'                                   |
+      | 'finance.budgets.item.put'                                    |
+      | 'finance.exchange-rate.item.get'                              |
+      | 'finance.expense-classes.item.post'                           |
+      | 'finance.fiscal-years.item.delete'                            |
+      | 'finance.fiscal-years.item.get'                               |
+      | 'finance.fiscal-years.item.post'                              |
+      | 'finance.fiscal-years.item.put'                               |
+      | 'finance.funds.budget.item.get'                               |
+      | 'finance.funds.collection.get'                                |
+      | 'finance.funds.item.get'                                      |
+      | 'finance.funds.item.put'                                      |
+      | 'finance.fund-types.item.post'                                |
+      | 'finance.group-fiscal-year-summaries.collection.get'          |
+      | 'finance.group-fund-fiscal-years.item.post'                   |
+      | 'finance.groups-expense-classes-totals.collection.get'        |
+      | 'finance.ledger-rollovers-budgets.collection.get'             |
+      | 'finance.ledger-rollovers-budgets.item.get'                   |
+      | 'finance.ledger-rollovers-errors.collection.get'              |
+      | 'finance.ledger-rollovers.item.post'                          |
+      | 'finance.ledger-rollovers-logs.collection.get'                |
+      | 'finance.ledger-rollovers-logs.item.get'                      |
+      | 'finance.ledger-rollovers-progress.collection.get'            |
+      | 'finance.ledger-rollovers-progress.item.put'                  |
+      | 'finance.ledgers.collection.get'                              |
+      | 'finance.ledgers.current-fiscal-year.item.get'                |
+      | 'finance.ledgers.item.delete'                                 |
+      | 'finance.ledgers.item.get'                                    |
+      | 'finance.ledgers.item.post'                                   |
+      | 'finance.release-encumbrance.item.post'                       |
+      | 'finance-storage.budget-expense-classes.collection.get'       |
+      | 'finance-storage.budget-expense-classes.item.post'            |
+      | 'finance-storage.budgets.item.get'                            |
+      | 'finance-storage.budgets.item.post'                           |
+      | 'finance-storage.funds.item.delete'                           |
+      | 'finance-storage.funds.item.post'                             |
+      | 'finance-storage.group-fund-fiscal-years.collection.get'      |
+      | 'finance-storage.group-fund-fiscal-years.item.post'           |
+      | 'finance-storage.ledger-rollovers-errors.collection.get'      |
+      | 'finance-storage.ledger-rollovers-errors.item.delete'         |
+      | 'finance-storage.ledger-rollovers-errors.item.post'           |
+      | 'finance-storage.ledger-rollovers.item.delete'                |
+      | 'finance-storage.ledger-rollovers.item.post'                  |
+      | 'finance-storage.ledgers.item.post'                           |
+      | 'finance-storage.transactions.batch.execute'                  |
+      | 'finance-storage.transactions.collection.get'                 |
+      | 'finance.transactions.batch.execute'                          |
+      | 'finance.transactions.collection.get'                         |
+      | 'finance.transactions.item.get'                               |
+      | 'inventory.holdings.move.item.post'                           |
+      | 'inventory.instances.collection.get'                          |
+      | 'inventory.instances.item.post'                               |
+      | 'inventory.instances.item.put'                                |
+      | 'inventory.items-by-holdings-id.collection.get'               |
+      | 'inventory.items.collection.get'                              |
+      | 'inventory.items.item.get'                                    |
+      | 'inventory.items.move.item.post'                              |
+      | 'inventory-storage.contributor-name-types.item.post'          |
+      | 'inventory-storage.electronic-access-relationships.item.post' |
+      | 'inventory-storage.holdings.collection.get'                   |
+      | 'inventory-storage.holdings.item.get'                         |
+      | 'inventory-storage.holdings.item.post'                        |
+      | 'inventory-storage.holdings.retrieve.collection.post'         |
+      | 'inventory-storage.holdings-sources.item.post'                |
+      | 'inventory-storage.identifier-types.item.post'                |
+      | 'inventory-storage.instances.item.get'                        |
+      | 'inventory-storage.instance-statuses.item.post'               |
+      | 'inventory-storage.instance-types.item.post'                  |
+      | 'inventory-storage.items.item.get'                            |
+      | 'inventory-storage.loan-types.item.post'                      |
+      | 'inventory-storage.locations.item.post'                       |
+      | 'inventory-storage.location-units.campuses.item.post'         |
+      | 'inventory-storage.location-units.institutions.item.post'     |
+      | 'inventory-storage.location-units.libraries.item.post'        |
+      | 'inventory-storage.material-types.item.post'                  |
+      | 'inventory-storage.service-points.item.post'                  |
+      | 'inventory.tenant-items.collection.get'                       |
+      | 'invoice.invoice-lines.collection.get'                        |
+      | 'invoice.invoice-lines.item.delete'                           |
+      | 'invoice.invoice-lines.item.get'                              |
+      | 'invoice.invoice-lines.item.post'                             |
+      | 'invoice.invoice-lines.item.put'                              |
+      | 'invoice.invoices.collection.get'                             |
+      | 'invoice.invoices.documents.item.post'                        |
+      | 'invoice.invoices.fiscal-years.collection.get'                |
+      | 'invoice.invoices.item.delete'                                |
+      | 'invoice.invoices.item.get'                                   |
+      | 'invoice.invoices.item.post'                                  |
+      | 'invoice.invoices.item.put'                                   |
+      | 'invoice.item.approve.execute'                                |
+      | 'invoice.item.cancel.execute'                                 |
+      | 'invoice.item.pay.execute'                                    |
+      | 'invoices.acquisitions-units-assignments.assign'              |
+      | 'invoices.acquisitions-units-assignments.manage'              |
+      | 'lost-item-fees-policies.collection.get'                      |
+      | 'lost-item-fees-policies.item.post'                           |
       | 'organizations.organizations.item.get'                        |
       | 'organizations.organizations.item.post'                       |
       | 'organizations.organizations.item.put'                        |
@@ -216,219 +222,22 @@ Feature: mod-orders integration tests
       | 'tags.collection.get'                                         |
       | 'templates.item.post'                                         |
       | 'titles.acquisitions-units-assignments.assign'                |
+      | 'titles.acquisitions-units-assignments.manage'                |
+      | 'usergroups.item.post'                                        |
       | 'users.collection.get'                                        |
       | 'users.item.post'                                             |
-      | 'usergroups.item.post'                                        |
-      | 'inventory.items.item.get'                                    |
-      | 'titles.acquisitions-units-assignments.manage'                |
 
   Scenario: create tenant and users for testing
-    * def testUser = testAdmin
-    Given call read('classpath:common/eureka/setup-users.feature')
+    * call read('classpath:common/eureka/setup-users.feature')
+
+  Scenario: create admin user and extra test user
+    * def v = call createAdditionalUser { testUser: '#(testAdmin)',  userPermissions: '#(adminPermissions)' }
 
   Scenario: init global data
     * call login testAdmin
-
     * callonce read('classpath:global/inventory.feature')
     * callonce read('classpath:global/configuration.feature')
     * callonce read('classpath:global/finances.feature')
     * callonce read('classpath:global/organizations.feature')
+    * call login testUser
     * callonce read('classpath:global/orders.feature')
-
-  Scenario: dummyUser creation
-    * table userPermissions
-      | name                                                          |
-      | 'acquisition.invoice.events.get'                              |
-      | 'acquisition.invoice-line.events.get'                         |
-      | 'acquisition.order-line.events.get'                           |
-      | 'acquisition.order.events.get'                                |
-      | 'acquisition.piece.events.history.get'                        |
-      | 'acquisition.piece.events.get'                                |
-      | 'addresstypes.item.post'                                      |
-      | 'acquisitions-units.memberships.item.delete'                  |
-      | 'acquisitions-units.memberships.item.post'                    |
-      | 'acquisitions-units.units.item.post'                          |
-      | 'acquisitions-units.units.item.put'                           |
-      | 'acquisitions-units-storage.memberships.collection.get'       |
-      | 'acquisitions-units-storage.memberships.item.delete'          |
-      | 'acquisitions-units-storage.memberships.item.get'             |
-      | 'acquisitions-units-storage.memberships.item.post'            |
-      | 'acquisitions-units-storage.memberships.item.put'             |
-      | 'acquisitions-units-storage.units.item.post'                  |
-      | 'circulation.rules.put'                                       |
-      | 'circulation.requests.item.get'                               |
-      | 'circulation.requests.item.move.post'                         |
-      | 'circulation.requests.item.post'                              |
-      | 'circulation-storage.loan-policies.collection.get'            |
-      | 'circulation-storage.loan-policies.item.post'                 |
-      | 'circulation-storage.patron-notice-policies.collection.get'   |
-      | 'circulation-storage.patron-notice-policies.item.post'        |
-      | 'circulation-storage.request-policies.collection.get'         |
-      | 'circulation-storage.request-policies.item.post'              |
-      | 'configuration.entries.collection.get'                        |
-      | 'configuration.entries.item.delete'                           |
-      | 'configuration.entries.item.post'                             |
-      | 'configuration.entries.item.put'                              |
-      | 'finance.budgets-expense-classes-totals.collection.get'       |
-      | 'finance.budgets.collection.get'                              |
-      | 'finance.budgets.item.delete'                                 |
-      | 'finance.budgets.item.get'                                    |
-      | 'finance.budgets.item.post'                                   |
-      | 'finance.budgets.item.put'                                    |
-      | 'finance.exchange-rate.item.get'                              |
-      | 'finance.expense-classes.item.post'                           |
-      | 'finance.fiscal-years.item.delete'                            |
-      | 'finance.fiscal-years.item.get'                               |
-      | 'finance.fiscal-years.item.post'                              |
-      | 'finance.fiscal-years.item.put'                               |
-      | 'finance.fund-types.item.post'                                |
-      | 'finance.funds.budget.item.get'                               |
-      | 'finance.funds.collection.get'                                |
-      | 'finance.funds.item.get'                                      |
-      | 'finance.funds.item.put'                                      |
-      | 'finance.group-fiscal-year-summaries.collection.get'          |
-      | 'finance.group-fund-fiscal-years.item.post'                   |
-      | 'finance.groups-expense-classes-totals.collection.get'        |
-      | 'finance.ledger-rollovers-budgets.collection.get'             |
-      | 'finance.ledger-rollovers-budgets.item.get'                   |
-      | 'finance.ledger-rollovers-errors.collection.get'              |
-      | 'finance.ledger-rollovers-logs.collection.get'                |
-      | 'finance.ledger-rollovers-logs.item.get'                      |
-      | 'finance.ledger-rollovers-progress.collection.get'            |
-      | 'finance.ledger-rollovers-progress.item.put'                  |
-      | 'finance.ledger-rollovers.item.post'                          |
-      | 'finance.ledgers.collection.get'                              |
-      | 'finance.ledgers.current-fiscal-year.item.get'                |
-      | 'finance.ledgers.item.delete'                                 |
-      | 'finance.ledgers.item.get'                                    |
-      | 'finance.ledgers.item.post'                                   |
-      | 'finance.release-encumbrance.item.post'                       |
-      | 'finance.transactions.batch.execute'                          |
-      | 'finance.transactions.collection.get'                         |
-      | 'finance.transactions.item.get'                               |
-      | 'finance-storage.budget-expense-classes.collection.get'       |
-      | 'finance-storage.budget-expense-classes.item.post'            |
-      | 'finance-storage.budgets.item.get'                            |
-      | 'finance-storage.budgets.item.post'                           |
-      | 'finance-storage.funds.item.delete'                           |
-      | 'finance-storage.funds.item.post'                             |
-      | 'finance-storage.group-fund-fiscal-years.collection.get'      |
-      | 'finance-storage.group-fund-fiscal-years.item.post'           |
-      | 'finance-storage.ledger-rollovers-errors.collection.get'      |
-      | 'finance-storage.ledger-rollovers-errors.item.delete'         |
-      | 'finance-storage.ledger-rollovers-errors.item.post'           |
-      | 'finance-storage.ledger-rollovers.item.delete'                |
-      | 'finance-storage.ledger-rollovers.item.post'                  |
-      | 'finance-storage.ledgers.item.post'                           |
-      | 'finance-storage.transactions.batch.execute'                  |
-      | 'finance-storage.transactions.collection.get'                 |
-      | 'inventory-storage.contributor-name-types.item.post'          |
-      | 'inventory-storage.electronic-access-relationships.item.post' |
-      | 'inventory-storage.holdings.collection.get'                   |
-      | 'inventory-storage.holdings.item.get'                         |
-      | 'inventory-storage.holdings.item.post'                        |
-      | 'inventory-storage.holdings.retrieve.collection.post'         |
-      | 'inventory-storage.holdings-sources.item.post'                |
-      | 'inventory-storage.identifier-types.item.post'                |
-      | 'inventory-storage.instance-statuses.item.post'               |
-      | 'inventory-storage.instance-types.item.post'                  |
-      | 'inventory-storage.instances.item.get'                        |
-      | 'inventory-storage.items.item.get'                            |
-      | 'inventory-storage.loan-types.item.post'                      |
-      | 'inventory-storage.location-units.campuses.item.post'         |
-      | 'inventory-storage.location-units.institutions.item.post'     |
-      | 'inventory-storage.location-units.libraries.item.post'        |
-      | 'inventory-storage.locations.item.post'                       |
-      | 'inventory-storage.material-types.item.post'                  |
-      | 'inventory-storage.service-points.item.post'                  |
-      | 'inventory.instances.collection.get'                          |
-      | 'inventory.instances.item.post'                               |
-      | 'inventory.instances.item.put'                                |
-      | 'inventory.items.collection.get'                              |
-      | 'inventory.items.move.item.post'                              |
-      | 'inventory.items-by-holdings-id.collection.get'               |
-      | 'inventory.tenant-items.collection.get'                       |
-      | 'inventory.holdings.move.item.post'                           |
-      | 'invoice.invoice-lines.collection.get'                        |
-      | 'invoice.invoice-lines.item.delete'                           |
-      | 'invoice.invoice-lines.item.get'                              |
-      | 'invoice.invoice-lines.item.post'                             |
-      | 'invoice.invoice-lines.item.put'                              |
-      | 'invoice.invoices.collection.get'                             |
-      | 'invoice.invoices.documents.item.post'                        |
-      | 'invoice.invoices.fiscal-years.collection.get'                |
-      | 'invoice.invoices.item.delete'                                |
-      | 'invoice.invoices.item.get'                                   |
-      | 'invoice.invoices.item.post'                                  |
-      | 'invoice.invoices.item.put'                                   |
-      | 'invoice.item.approve.execute'                                |
-      | 'invoice.item.cancel.execute'                                 |
-      | 'invoice.item.pay.execute'                                    |
-      | 'invoices.acquisitions-units-assignments.assign'              |
-      | 'invoices.acquisitions-units-assignments.manage'              |
-      | 'lost-item-fees-policies.collection.get'                      |
-      | 'lost-item-fees-policies.item.post'                           |
-      | 'orders.acquisition-method.item.post'                         |
-      | 'orders.acquisition-units.bypass.execute'                     |
-      | 'orders.acquisitions-units-assignments.assign'                |
-      | 'orders.acquisitions-units-assignments.manage'                |
-      | 'orders.bind-pieces.collection.post'                          |
-      | 'orders.bind-pieces.item.delete'                              |
-      | 'orders.check-in.collection.post'                             |
-      | 'orders.collection.get'                                       |
-      | 'orders.item.approve'                                         |
-      | 'orders.item.delete'                                          |
-      | 'orders.item.get'                                             |
-      | 'orders.item.post'                                            |
-      | 'orders.item.put'                                             |
-      | 'orders.item.reopen'                                          |
-      | 'orders.item.unopen'                                          |
-      | 'orders.pieces.collection.get'                                |
-      | 'orders.pieces.collection.post'                               |
-      | 'orders.pieces.collection.put'                                |
-      | 'orders.pieces.item.delete'                                   |
-      | 'orders.pieces.item.get'                                      |
-      | 'orders.pieces.item.post'                                     |
-      | 'orders.pieces.item.put'                                      |
-      | 'orders.po-lines.collection.get'                              |
-      | 'orders.po-lines.item.delete'                                 |
-      | 'orders.po-lines.item.get'                                    |
-      | 'orders.po-lines.item.post'                                   |
-      | 'orders.po-lines.item.put'                                    |
-      | 'orders.re-encumber.item.post'                                |
-      | 'orders.receiving.collection.post'                            |
-      | 'orders.routing-lists.collection.get'                         |
-      | 'orders.routing-lists.item.delete'                            |
-      | 'orders.routing-lists.item.get'                               |
-      | 'orders.routing-lists.item.post'                              |
-      | 'orders.routing-lists.item.put'                               |
-      | 'orders.routing-lists-template.item.get'                      |
-      | 'orders.titles.collection.get'                                |
-      | 'orders.titles.item.get'                                      |
-      | 'orders.titles.item.post'                                     |
-      | 'orders.titles.item.put'                                      |
-      | 'orders-storage.claiming.process.execute'                     |
-      | 'orders-storage.pieces.collection.get'                        |
-      | 'orders-storage.po-lines.item.get'                            |
-      | 'orders-storage.po-lines.item.post'                           |
-      | 'orders-storage.po-lines.item.put'                            |
-      | 'orders-storage.purchase-orders.item.post'                    |
-      | 'orders-storage.routing-lists.item.post'                      |
-      | 'orders-storage.settings.item.post'                           |
-      | 'organizations.organizations.item.get'                        |
-      | 'organizations.organizations.item.post'                       |
-      | 'organizations.organizations.item.put'                        |
-      | 'organizations-storage.organizations.item.post'               |
-      | 'overdue-fines-policies.collection.get'                       |
-      | 'overdue-fines-policies.item.post'                            |
-      | 'tags.collection.get'                                         |
-      | 'templates.item.post'                                         |
-      | 'users.collection.get'                                        |
-      | 'users.item.post'                                             |
-      | 'usergroups.item.post'                                        |
-      | 'inventory.items.item.get'                                    |
-
-    * call read('classpath:common/eureka/setup-users.feature@getAuthorizationToken')
-    * call read('classpath:common/eureka/setup-users.feature@createTestUser') {testUser: '#(dummyUser)'}
-    * call read('classpath:common/eureka/setup-users.feature@specifyUserCredentials') {testUser: '#(dummyUser)'}
-    * call read('classpath:common/eureka/setup-users.feature@addUserCapabilities') {userPermissions: '#(userPermissions)'}

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/acq-unit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/acq-unit.feature
@@ -36,8 +36,8 @@ Feature: Reusable components for acquisition units
 
   @AssignUserToAcqUnit
   Scenario: Assign user to acquisition unit
-    * def result = call read('classpath:common/eureka/users.feature') { user: '#(testAdmin)' }
-    * def userId = karate.get('userId', result.userId)
+    * def res = callonce getUserIdByUsername { user: '#(testAdmin)' }
+    * def userId = res.userId
     * def acqUnitId = karate.get('acqUnitId', randomAcqUnitId)
     Given path 'acquisitions-units-storage/memberships'
     And headers headersAdmin
@@ -56,8 +56,8 @@ Feature: Reusable components for acquisition units
   Scenario: Delete user from acquisition unit
     * configure headers = headersAdminTextPlain
 
-    * def result = call read('classpath:common/eureka/users.feature') { user: '#(testAdmin)' }
-    * def userId = karate.get('userId', result.userId)
+    * def res = callonce getUserIdByUsername { user: '#(testAdmin)' }
+    * def userId = res.userId
     * def acqUnitId = karate.get('acqUnitId', randomAcqUnitId)
 
     Given path 'acquisitions-units-storage/memberships'

--- a/common/src/main/resources/common/eureka/create-additional-user.feature
+++ b/common/src/main/resources/common/eureka/create-additional-user.feature
@@ -1,0 +1,11 @@
+Feature: Create additional user
+  # Parameters: testUser - attributes: tenant, name, password; userPermissions
+
+Background:
+  * url baseUrl
+
+Scenario: searchApplication
+  * call read('classpath:common/eureka/setup-users.feature@getAuthorizationToken')
+  * call read('classpath:common/eureka/setup-users.feature@createTestUser')
+  * call read('classpath:common/eureka/setup-users.feature@specifyUserCredentials')
+  * call read('classpath:common/eureka/setup-users.feature@addUserCapabilities')


### PR DESCRIPTION
## Purpose
[MODORDERS-1272](https://folio-org.atlassian.net/browse/MODORDERS-1272) - Run ACQ Karate tests on Eureka platform

## Approach
- Updated tests to use a test user and an admin user with different permissions. The test user has all permissions for mod-orders, the admin user has all the other permissions.
- Modified `independent-acquisitions-unit-for-ordering-and-receiving.feature`  to create and use a new user, `testUser2`, which has some specific permissions (previously it was using the admin user to edit orders, but the new users do not allow that)
- Introduced 2 new functions, `createAdditionalUser` and `getUserIdByUsername`. Updated mod-finance tests to use `getUserIdByUsername` too.

### TODOS and Open Questions
- TODO: move some tests to mod-invoice or cross-modules.
- TODO: convert the remaining tests
