### PR TITLE
Refactor karate-config.js to use system properties for configuration values

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,25 @@ This first builds the common and testrail-integration submodules and sets maven 
 
 To run only specific runner (Java) class test use `-DfailIfNoTests=false` and `-Dtest=<TestName>`.
 
+## Configuring Tests Using System Properties
+
+You can configure various aspects of the tests using system properties. This is especially useful for providing credentials and environment-specific settings without modifying the code.
+
+```
+mvn test -DargLine="-Dkarate.env=snapshot -DbaseUrl=https://custom-okapi-url:9130 -Dadmin.tenant=mytenant -Dadmin.name=custom_admin -Dadmin.password=secret_password -DprototypeTenant=mytenant"
+```
+
+The following system properties are supported:
+- `baseUrl`: URL of the Okapi instance (e.g., http://localhost:9130)
+- `admin.tenant`: Admin tenant ID (e.g., diku)
+- `admin.name`: Admin username (e.g., diku_admin)
+- `admin.password`: Admin password
+- `prototypeTenant`: Default tenant for the test (e.g., diku)
+- `edgeUrl`: URL for edge services (for modules that use edge services)
+- `apikey`: API key for edge services (for modules that use edge services)
+
+If any of these properties are not specified, they will use default values defined in each module's karate-config.js file.
+
 ## Running tests for a specific module in a specific environment
 
 ```

--- a/acquisitions/src/main/resources/karate-config.js
+++ b/acquisitions/src/main/resources/karate-config.js
@@ -8,16 +8,21 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'] || 'testtenant';
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    edgeUrl: 'http://localhost:8000',
-    ftpUrl: 'ftp://ftp.ci.folio.org',
-    ftpPort:  21,
-    ftpUser: 'folio',
-    ftpPassword: 'Ffx29%pu',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
-    consortiaSystemUserName: 'consortia-system-user',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    edgeUrl: karate.properties['edgeUrl'] || 'http://localhost:8000',
+    ftpUrl: karate.properties['ftpUrl'] || 'ftp://ftp.ci.folio.org',
+    ftpPort: karate.properties['ftpPort'] || 21,
+    ftpUser: karate.properties['ftpUser'] || 'folio',
+    ftpPassword: karate.properties['ftpPassword'] || 'Ffx29%pu',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
+    consortiaSystemUserName: karate.properties['consortiaSystemUserName'] || 'consortia-system-user',
 
     testTenant: testTenant,
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/data-import-large-scale-tests/src/main/resources/karate-config.js
+++ b/data-import-large-scale-tests/src/main/resources/karate-config.js
@@ -29,11 +29,16 @@ function fn() {
     return [year,month,day,hour,minute,seconds].join('');
   })()
 
+  // Get config values from system properties with defaults if not provided
   var config = {
     tenantParams: {loadReferenceData: true},
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant,
     testAdmin: {tenant: testTenant, name: testAdminUsername, password: testAdminPassword},

--- a/data-import/src/main/resources/karate-config.js
+++ b/data-import/src/main/resources/karate-config.js
@@ -29,11 +29,16 @@ function fn() {
     return [year,month,day,hour,minute,seconds].join('');
   })()
 
+  // Get config values from system properties with defaults if not provided
   var config = {
     tenantParams: {loadReferenceData: true},
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant,
     testAdmin: {tenant: testTenant, name: testAdminUsername, password: testAdminPassword},

--- a/edge-caiasoft/src/main/resources/karate-config.js
+++ b/edge-caiasoft/src/main/resources/karate-config.js
@@ -8,10 +8,17 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    edgeUrl: karate.properties['edgeUrl'],
+    apikey: karate.properties['apikey'] || 'eyJzIjoiY2FpYVNvZnRDbGllbnQiLCJ0IjoiZGlrdSIsInUiOiJjYWlhU29mdENsaWVudCJ9',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/edge-dcb/src/main/resources/karate-config.js
+++ b/edge-dcb/src/main/resources/karate-config.js
@@ -8,12 +8,18 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    edgeUrl: 'http://localhost:1212',
-    centralServerUrl: 'https://folio-dev-volaris-mock-server.ci.folio.org',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    edgeUrl: karate.properties['edgeUrl'] || 'http://localhost:1212',
+    centralServerUrl: karate.properties['centralServerUrl'] || 'https://folio-dev-volaris-mock-server.ci.folio.org',
+    apikey: karate.properties['apikey'] || 'eyJzIjoiWDhoYmM1THJDeSIsInQiOiJ0ZXN0ZWRnZWRjYiIsInUiOiJkY2JDbGllbnQifQ==',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     tenantParams: {loadReferenceData: true},
     testTenant: testTenant ? testTenant : 'testtenant',

--- a/edge-dematic/src/main/resources/karate-config.js
+++ b/edge-dematic/src/main/resources/karate-config.js
@@ -8,10 +8,17 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    edgeUrl: karate.properties['edgeUrl'],
+    apikey: karate.properties['apikey'] || 'eyJzIjoic3RhZ2luZ0RpcmVjdG9yIiwidCI6ImRpa3UiLCJ1Ijoic3RhZ2luZ0RpcmVjdG9yIn0',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/edge-fqm/src/main/resources/karate-config.js
+++ b/edge-fqm/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/edge-inn-reach/src/main/resources/karate-config.js
+++ b/edge-inn-reach/src/main/resources/karate-config.js
@@ -8,12 +8,17 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    edgeUrl: 'http://localhost:9703',
-    centralServerUrl: 'https://folio-dev-volaris-mockserver.ci.folio.org',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    edgeUrl: karate.properties['edgeUrl'] || 'http://localhost:9703',
+    centralServerUrl: karate.properties['centralServerUrl'] || 'https://folio-dev-volaris-mockserver.ci.folio.org',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     tenantParams: {loadReferenceData: true},
     testTenant: testTenant ? testTenant : 'testtenant',

--- a/edge-oai-pmh/src/main/resources/karate-config.js
+++ b/edge-oai-pmh/src/main/resources/karate-config.js
@@ -8,10 +8,17 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    edgeUrl: karate.properties['edgeUrl'],
+    apikey: karate.properties['apikey'] || 'eyJzIjoiVExodW1JV2JiTCIsInQiOiJ0ZXN0X29haXBtaCIsInUiOiJ0ZXN0LXVzZXIifQ==',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/edge-patron/src/main/resources/karate-config.js
+++ b/edge-patron/src/main/resources/karate-config.js
@@ -10,10 +10,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/edge-rtac/src/main/resources/karate-config.js
+++ b/edge-rtac/src/main/resources/karate-config.js
@@ -10,10 +10,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-audit/src/main/resources/karate-config.js
+++ b/mod-audit/src/main/resources/karate-config.js
@@ -8,10 +8,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'] || 'testtenant';
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant,
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-batch-print/src/main/resources/karate-config.js
+++ b/mod-batch-print/src/main/resources/karate-config.js
@@ -11,10 +11,16 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    edgeUrl: karate.properties['edgeUrl'],
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-bulk-operations/src/main/resources/karate-config.js
+++ b/mod-bulk-operations/src/main/resources/karate-config.js
@@ -8,13 +8,18 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'] || 'testtenant';
 
+  // Get config values from system properties with defaults if not provided
   var config = {
     tenantParams: {
         loadReferenceData : true
     },
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant,
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-calendar/src/main/resources/karate-config.js
+++ b/mod-calendar/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-circulation-storage/src/main/resources/karate-config.js
+++ b/mod-circulation-storage/src/main/resources/karate-config.js
@@ -15,10 +15,15 @@ function fn() {
   var testUserUsername = karate.properties['testUserUsername'] || 'test-user';
   var testUserPassword = karate.properties['testUserPassword'] || 'test';
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: testAdminUsername, password: testAdminPassword},

--- a/mod-circulation/src/main/resources/karate-config.js
+++ b/mod-circulation/src/main/resources/karate-config.js
@@ -15,10 +15,15 @@ function fn() {
   var testUserUsername = karate.properties['testUserUsername'] || 'test-user';
   var testUserPassword = karate.properties['testUserPassword'] || 'test';
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant,
     testAdmin: {tenant: testTenant, name: testAdminUsername, password: testAdminPassword},

--- a/mod-consortia/src/main/resources/karate-config.js
+++ b/mod-consortia/src/main/resources/karate-config.js
@@ -5,12 +5,17 @@ function fn() {
 
     var env = karate.env;
 
+    // Get config values from system properties with defaults if not provided
     var config = {
-        baseUrl: 'http://localhost:9130',
-        edgeUrl: 'http://localhost:8000',
-        admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-        prototypeTenant: 'diku',
-        consortiaSystemUserName: 'consortia-system-user',
+        baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+        edgeUrl: karate.properties['edgeUrl'] || 'http://localhost:8000',
+        admin: {
+            tenant: karate.properties['admin.tenant'] || 'diku',
+            name: karate.properties['admin.name'] || 'diku_admin',
+            password: karate.properties['admin.password'] || 'admin'
+        },
+        prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
+        consortiaSystemUserName: karate.properties['consortiaSystemUserName'] || 'consortia-system-user',
 
         // define global features
         login: karate.read('classpath:common/login.feature'),

--- a/mod-copycat/src/main/resources/karate-config.js
+++ b/mod-copycat/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     tenantParams: {loadReferenceData : true},
     testTenant: testTenant ? testTenant : 'testtenant',

--- a/mod-data-export/src/test/resources/karate-config.js
+++ b/mod-data-export/src/test/resources/karate-config.js
@@ -6,13 +6,18 @@ function fn() {
   var env = karate.env;
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
     tenantParams: {
       loadReferenceData : true
     },
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-dcb/src/main/resources/karate-config.js
+++ b/mod-dcb/src/main/resources/karate-config.js
@@ -12,12 +12,17 @@ function fn() {
   var testUserUsername = karate.properties['testUserUsername'] || 'test-user';
   var testUserPassword = karate.properties['testUserPassword'] || 'test';
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    edgeUrl: 'http://localhost:9703',
-    centralServerUrl: 'https://folio-dev-volaris-mock-server.ci.folio.org',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    edgeUrl: karate.properties['edgeUrl'] || 'http://localhost:9703',
+    centralServerUrl: karate.properties['centralServerUrl'] || 'https://folio-dev-volaris-mock-server.ci.folio.org',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant,
     testAdmin: {tenant: testTenant, name: testAdminUsername, password: testAdminPassword},

--- a/mod-di-converter-storage/src/main/resources/karate-config.js
+++ b/mod-di-converter-storage/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function configuration() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-email/src/main/resources/karate-config.js
+++ b/mod-email/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-entities-links/src/main/resources/karate-config.js
+++ b/mod-entities-links/src/main/resources/karate-config.js
@@ -11,11 +11,16 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
     featuresPath: 'classpath:spitfire/mod-entities-links/features/',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-event-config/src/main/resources/karate-config.js
+++ b/mod-event-config/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-feesfines/src/main/resources/karate-config.js
+++ b/mod-feesfines/src/main/resources/karate-config.js
@@ -15,10 +15,15 @@ function fn() {
   var testUserUsername = karate.properties['testUserUsername'] || 'test-user';
   var testUserPassword = karate.properties['testUserPassword'] || 'test';
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: testAdminUsername, password: testAdminPassword},

--- a/mod-fqm-manager/src/main/resources/karate-config.js
+++ b/mod-fqm-manager/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'] || 'testtenant';
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant,
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-inn-reach/src/main/resources/karate-config.js
+++ b/mod-inn-reach/src/main/resources/karate-config.js
@@ -8,12 +8,17 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant']|| 'testtenant';
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    edgeUrl: 'http://localhost:8000',
-    centralServerUrl: 'https://folio-dev-volaris-2nd-mockserver.ci.folio.org',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    edgeUrl: karate.properties['edgeUrl'] || 'http://localhost:8000',
+    centralServerUrl: karate.properties['centralServerUrl'] || 'https://folio-dev-volaris-2nd-mockserver.ci.folio.org',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     tenantParams: {loadReferenceData: true},
     testTenant: testTenant ? testTenant : 'testtenant',

--- a/mod-inventory/src/main/resources/karate-config.js
+++ b/mod-inventory/src/main/resources/karate-config.js
@@ -26,10 +26,15 @@ function fn() {
   // define consortiumId
   var consortiumId = karate.properties['consortiumId'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     tenantParams: {loadReferenceData : true},
     testTenant: testTenant ? testTenant : 'testtenant',

--- a/mod-kb-ebsco-java/src/main/resources/karate-config.js
+++ b/mod-kb-ebsco-java/src/main/resources/karate-config.js
@@ -18,10 +18,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
     kbEbscoCredentialsApiKey: kbEbscoCredentialsApiKey,
     kbEbscoCredentialsUrl: kbEbscoCredentialsUrl,
     kbEbscoCredentialsCustomerId: kbEbscoCredentialsCustomerId,

--- a/mod-ldp/src/main/resources/karate-config.js
+++ b/mod-ldp/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: { tenant: 'diku', name: 'diku_admin', password: 'admin' },
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testTenant',
     testAdmin: { tenant: testTenant, name: 'test-admin', password: 'admin' },

--- a/mod-linked-data/src/main/resources/karate-config.js
+++ b/mod-linked-data/src/main/resources/karate-config.js
@@ -11,11 +11,16 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
     tenantParams: {loadReferenceData: true},
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-lists/src/main/resources/karate-config.js
+++ b/mod-lists/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-login-saml/src/main/resources/karate-config.js
+++ b/mod-login-saml/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-notes/src/main/resources/karate-config.js
+++ b/mod-notes/src/main/resources/karate-config.js
@@ -11,11 +11,16 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
     featuresPath: 'classpath:spitfire/mod-notes/features/',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-notify/src/main/resources/karate-config.js
+++ b/mod-notify/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-oai-pmh/src/test/resources/karate-config.js
+++ b/mod-oai-pmh/src/test/resources/karate-config.js
@@ -8,15 +8,20 @@ function fn() {
     // The "testTenant" property could be specified during test runs
     var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},
     testUser: {tenant: testTenant, name: 'test-user', password: 'test'},
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
-    edgeHost:'http://localhost:9701',
-    edgeApiKey: 'eyJzIjoiQlBhb2ZORm5jSzY0NzdEdWJ4RGgiLCJ0IjoiZGlrdSIsInUiOiJkaWt1In0',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
+    edgeHost: karate.properties['edgeHost'] || 'http://localhost:9701',
+    edgeApiKey: karate.properties['edgeApiKey'] || 'eyJzIjoiQlBhb2ZORm5jSzY0NzdEdWJ4RGgiLCJ0IjoiZGlrdSIsInUiOiJkaWt1In0',
     // define global features
     variables: karate.read('classpath:global/variables.feature'),
     destroyData: karate.read('classpath:common/destroy-data.feature'),

--- a/mod-password-validator/src/test/resources/karate-config.js
+++ b/mod-password-validator/src/test/resources/karate-config.js
@@ -6,10 +6,15 @@ function fn() {
   var env = karate.env;
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-patron-blocks/src/main/resources/karate-config.js
+++ b/mod-patron-blocks/src/main/resources/karate-config.js
@@ -15,10 +15,15 @@ function fn() {
   var testUserUsername = karate.properties['testUserUsername'] || 'test-user';
   var testUserPassword = karate.properties['testUserPassword'] || 'test';
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: testAdminUsername, password: testAdminPassword},

--- a/mod-permissions/src/main/resources/karate-config.js
+++ b/mod-permissions/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-quick-marc/src/main/resources/karate-config.js
+++ b/mod-quick-marc/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-reading-room/src/main/resources/karate-config.js
+++ b/mod-reading-room/src/main/resources/karate-config.js
@@ -8,10 +8,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'] || 'testtenant';
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant,
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-search/src/test/resources/karate-config.js
+++ b/mod-search/src/test/resources/karate-config.js
@@ -13,11 +13,16 @@ function fn() {
   // once we run tests again
   var runId = karate.properties['runId'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
     runId: runId ? runId : '',
-    baseUrl: 'https://folio-dev-spitfire-okapi.ci.folio.org',
-    admin: { tenant: 'diku', name: 'diku_admin', password: adminPassword },
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'https://folio-dev-spitfire-okapi.ci.folio.org',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: adminPassword || karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: { tenant: testTenant, name: 'test-admin', password: 'admin' },
     testUser: { tenant: testTenant, name: 'test-user', password: 'test' },

--- a/mod-sender/src/main/resources/karate-config.js
+++ b/mod-sender/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-source-record-manager/src/main/resources/karate-config.js
+++ b/mod-source-record-manager/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function configuration() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-source-record-storage/src/main/resources/karate-config.js
+++ b/mod-source-record-storage/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function configuration() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'testing_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'testing_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-tags/src/test/resources/karate-config.js
+++ b/mod-tags/src/test/resources/karate-config.js
@@ -6,10 +6,15 @@ function fn() {
   var env = karate.env;
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testTenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-template-engine/src/main/resources/karate-config.js
+++ b/mod-template-engine/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-user-import/src/main/resources/karate-config.js
+++ b/mod-user-import/src/main/resources/karate-config.js
@@ -54,10 +54,15 @@ function fn() {
   };
 
   // Define the karate configuration.
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant ? testTenant : 'testtenant',
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-users-bl/src/main/resources/karate-config.js
+++ b/mod-users-bl/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'] || 'testtenant';
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant,
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/mod-users/src/main/resources/karate-config.js
+++ b/mod-users/src/main/resources/karate-config.js
@@ -11,10 +11,15 @@ function fn() {
   // The "testTenant" property could be specified during test runs
   var testTenant = karate.properties['testTenant'] || 'testtenant';
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
-    prototypeTenant: 'diku',
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     testTenant: testTenant,
     testAdmin: {tenant: testTenant, name: 'test-admin', password: 'admin'},

--- a/poc/src/main/resources/karate-config.js
+++ b/poc/src/main/resources/karate-config.js
@@ -9,11 +9,16 @@ function fn() {
   // once we run tests again
   var runId = karate.properties['runId'];
 
+  // Get config values from system properties with defaults if not provided
   var config = {
-    baseUrl: 'http://localhost:9130',
-    admin: {tenant: 'diku', name: 'diku_admin', password: 'admin'},
+    baseUrl: karate.properties['baseUrl'] || 'http://localhost:9130',
+    admin: {
+      tenant: karate.properties['admin.tenant'] || 'diku',
+      name: karate.properties['admin.name'] || 'diku_admin',
+      password: karate.properties['admin.password'] || 'admin'
+    },
     runId: runId ? runId: '',
-    prototypeTenant: 'diku',
+    prototypeTenant: karate.properties['prototypeTenant'] || 'diku',
 
     // define global features
     login: karate.read('classpath:common/login.feature'),


### PR DESCRIPTION
## Purpose
Allow karate tests to be targeted by using special karate properties

## Approach
use karate property values or else use existing defaults.
