### PR TITLE
[MODORDERS-1272] Fixed users and permissions for cross-module tests

### DIFF
--- a/acquisitions/src/main/resources/global/organizations.feature
+++ b/acquisitions/src/main/resources/global/organizations.feature
@@ -2,8 +2,7 @@ Feature: global organizations
 
   Background:
     * url baseUrl
-    * callonce login testAdmin
-    * configure headers = { 'x-okapi-tenant': '#(testTenant)'  }
+    * configure headers = { 'x-okapi-tenant': '#(testTenant)' }
 
   Scenario: create vendor
     Given path 'organizations/organizations'

--- a/acquisitions/src/main/resources/thunderjet/consortia/consortia-orders-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/consortia-orders-junit.feature
@@ -21,6 +21,7 @@ Feature: mod-consortia integration tests
       | 'finance.budgets.item.post'                                 |
       | 'finance.expense-classes.item.post'                         |
       | 'finance.fiscal-years.item.post'                            |
+      | 'finance.funds.item.post'                                   |
       | 'finance.ledgers.item.post'                                 |
       | 'finance-storage.funds.item.post'                           |
       | 'inventory-storage.holdings-sources.item.post'              |
@@ -73,6 +74,7 @@ Feature: mod-consortia integration tests
       | 'orders.titles.item.get'                                    |
       | 'orders.titles.item.post'                                   |
       | 'orders-storage.settings.item.post'                         |
+      | 'organizations.organizations.item.post'                     |
       | 'organizations-storage.organizations.item.post'             |
       | 'overdue-fines-policies.collection.get'                     |
       | 'overdue-fines-policies.item.post'                          |
@@ -121,7 +123,7 @@ Feature: mod-consortia integration tests
       | 'mod-permissions'           |
       | 'okapi'                     |
       | 'mod-configuration'         |
-      | 'mod-login-keycloack'       |
+      | 'mod-login-keycloak'        |
       | 'mod-users'                 |
       | 'mod-pubsub'                |
       | 'mod-audit'                 |
@@ -146,7 +148,7 @@ Feature: mod-consortia integration tests
       | 'mod-permissions'           |
       | 'okapi'                     |
       | 'mod-configuration'         |
-      | 'mod-login-keycloack'       |
+      | 'mod-login-keycloak'        |
       | 'mod-users'                 |
       | 'mod-pubsub'                |
       | 'mod-audit'                 |
@@ -301,6 +303,7 @@ Feature: mod-consortia integration tests
       | 'finance.budgets.item.post'                                 |
       | 'finance.expense-classes.item.post'                         |
       | 'finance.fiscal-years.item.post'                            |
+      | 'finance.funds.item.post'                                   |
       | 'finance.ledgers.item.post'                                 |
       | 'inventory-storage.holdings-sources.item.post'              |
       | 'inventory-storage.holdings.collection.get'                 |
@@ -350,6 +353,7 @@ Feature: mod-consortia integration tests
       | 'orders.titles.collection.get'                              |
       | 'orders.titles.item.get'                                    |
       | 'orders.titles.item.post'                                   |
+      | 'organizations.organizations.item.post'                     |
       | 'organizations-storage.organizations.item.post'             |
       | 'overdue-fines-policies.collection.get'                     |
       | 'overdue-fines-policies.item.post'                          |

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules-junit.feature
@@ -1,6 +1,8 @@
-Feature: cross-module integration tests
+@parallel=false
+Feature: Cross-module integration tests
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
     # Order of the modules below is important: mod-pubsub should come before mod-circulation
 
@@ -23,198 +25,106 @@ Feature: cross-module integration tests
       | 'mod-orders'                |
       | 'mod-organizations-storage' |
 
+    # User permissions: non-storage permissions for finance, orders, invoices and organizations
     * table userPermissions
+      | name                                                          |
+      | 'finance.budgets.collection.get'                              |
+      | 'finance.budgets.item.delete'                                 |
+      | 'finance.budgets.item.get'                                    |
+      | 'finance.budgets.item.post'                                   |
+      | 'finance.budgets.item.put'                                    |
+      | 'finance.expense-classes.item.post'                           |
+      | 'finance.fiscal-years.item.get'                               |
+      | 'finance.fiscal-years.item.post'                              |
+      | 'finance.fiscal-years.item.put'                               |
+      | 'finance.funds.item.get'                                      |
+      | 'finance.funds.item.post'                                     |
+      | 'finance.funds.item.put'                                      |
+      | 'finance.fund-types.item.post'                                |
+      | 'finance.ledger-rollovers-errors.collection.get'              |
+      | 'finance.ledger-rollovers.item.post'                          |
+      | 'finance.ledger-rollovers-logs.item.get'                      |
+      | 'finance.ledger-rollovers-progress.collection.get'            |
+      | 'finance.ledgers.item.post'                                   |
+      | 'finance.release-encumbrance.item.post'                       |
+      | 'finance.transactions.batch.execute'                          |
+      | 'finance.transactions.collection.get'                         |
+      | 'finance.transactions.item.get'                               |
+      | 'invoice.invoice-lines.collection.get'                        |
+      | 'invoice.invoice-lines.item.delete'                           |
+      | 'invoice.invoice-lines.item.get'                              |
+      | 'invoice.invoice-lines.item.post'                             |
+      | 'invoice.invoice-lines.item.put'                              |
+      | 'invoice.invoices.item.delete'                                |
+      | 'invoice.invoices.item.get'                                   |
+      | 'invoice.invoices.item.post'                                  |
+      | 'invoice.invoices.item.put'                                   |
+      | 'invoice.item.approve.execute'                                |
+      | 'invoice.item.cancel.execute'                                 |
+      | 'invoice.item.pay.execute'                                    |
+      | 'invoices.acquisitions-units-assignments.assign'              |
+      | 'invoices.acquisitions-units-assignments.manage'              |
+      | 'invoices.fiscal-year.update.execute'                         |
+      | 'orders.acquisitions-units-assignments.assign'                |
+      | 'orders.acquisitions-units-assignments.manage'                |
+      | 'orders.check-in.collection.post'                             |
+      | 'orders.collection.get'                                       |
+      | 'orders.item.approve'                                         |
+      | 'orders.item.get'                                             |
+      | 'orders.item.post'                                            |
+      | 'orders.item.put'                                             |
+      | 'orders.item.reopen'                                          |
+      | 'orders.item.unopen'                                          |
+      | 'orders.pieces.collection.get'                                |
+      | 'orders.pieces.item.delete'                                   |
+      | 'orders.po-lines.collection.get'                              |
+      | 'orders.po-lines.item.delete'                                 |
+      | 'orders.po-lines.item.get'                                    |
+      | 'orders.po-lines.item.post'                                   |
+      | 'orders.po-lines.item.put'                                    |
+      | 'orders.re-encumber.item.post'                                |
+      | 'organizations.organizations.item.post'                       |
+      | 'voucher.vouchers.collection.get'                             |
+
+    # Admin permissions: all the other permissions needed
+    * table adminPermissions
       | name                                                          |
       | 'acquisitions-units.memberships.item.delete'                  |
       | 'acquisitions-units.memberships.item.post'                    |
       | 'acquisitions-units.units.item.post'                          |
-      | 'acquisitions-units-storage.memberships.collection.get'       |
-      | 'acquisitions-units-storage.memberships.item.delete'          |
-      | 'acquisitions-units-storage.memberships.item.get'             |
-      | 'acquisitions-units-storage.memberships.item.post'            |
-      | 'acquisitions-units-storage.memberships.item.put'             |
       | 'configuration.entries.item.post'                             |
-      | 'finance.budgets.collection.get'                              |
-      | 'finance.budgets.item.delete'                                 |
-      | 'finance.budgets.item.get'                                    |
-      | 'finance.budgets.item.post'                                   |
-      | 'finance.budgets.item.put'                                    |
-      | 'finance.expense-classes.item.post'                           |
-      | 'finance.fiscal-years.item.get'                               |
-      | 'finance.fiscal-years.item.post'                              |
-      | 'finance.fiscal-years.item.put'                               |
-      | 'finance.fund-types.item.post'                                |
-      | 'finance.funds.item.get'                                      |
-      | 'finance.funds.item.put'                                      |
-      | 'finance.ledger-rollovers.item.post'                          |
-      | 'finance.ledger-rollovers-errors.collection.get'              |
-      | 'finance.ledger-rollovers-logs.item.get'                      |
-      | 'finance.ledger-rollovers-progress.collection.get'            |
-      | 'finance.ledgers.item.post'                                   |
-      | 'finance.release-encumbrance.item.post'                       |
-      | 'finance.transactions.batch.execute'                          |
-      | 'finance.transactions.collection.get'                         |
-      | 'finance.transactions.item.get'                               |
-      | 'finance-storage.funds.item.post'                             |
-      | 'finance-storage.ledgers.item.post'                           |
-      | 'finance-storage.transactions.batch.execute'                  |
-      | 'finance-storage.transactions.collection.get'                 |
+      | 'inventory.instances.item.post'                               |
       | 'inventory-storage.contributor-name-types.item.post'          |
       | 'inventory-storage.electronic-access-relationships.item.post' |
-      | 'inventory-storage.holdings-sources.item.post'                |
       | 'inventory-storage.holdings.item.post'                        |
+      | 'inventory-storage.holdings-sources.item.post'                |
       | 'inventory-storage.identifier-types.item.post'                |
       | 'inventory-storage.instance-statuses.item.post'               |
       | 'inventory-storage.instance-types.item.post'                  |
       | 'inventory-storage.loan-types.item.post'                      |
+      | 'inventory-storage.locations.item.post'                       |
       | 'inventory-storage.location-units.campuses.item.post'         |
       | 'inventory-storage.location-units.institutions.item.post'     |
       | 'inventory-storage.location-units.libraries.item.post'        |
-      | 'inventory-storage.locations.item.post'                       |
       | 'inventory-storage.material-types.item.post'                  |
       | 'inventory-storage.service-points.item.post'                  |
-      | 'inventory.instances.item.post'                               |
-      | 'invoice.invoice-lines.collection.get'                        |
-      | 'invoice.invoice-lines.item.delete'                           |
-      | 'invoice.invoice-lines.item.get'                              |
-      | 'invoice.invoice-lines.item.post'                             |
-      | 'invoice.invoice-lines.item.put'                              |
-      | 'invoice.invoices.item.delete'                                |
-      | 'invoice.invoices.item.get'                                   |
-      | 'invoice.invoices.item.post'                                  |
-      | 'invoice.invoices.item.put'                                   |
-      | 'invoice.item.approve.execute'                                |
-      | 'invoice.item.cancel.execute'                                 |
-      | 'invoice.item.pay.execute'                                    |
       | 'invoice-storage.invoices.item.get'                           |
       | 'invoice-storage.invoices.item.put'                           |
-      | 'invoices.acquisitions-units-assignments.assign'              |
-      | 'invoices.acquisitions-units-assignments.manage'              |
-      | 'invoices.fiscal-year.update.execute'                         |
-      | 'orders.acquisitions-units-assignments.assign'                |
-      | 'orders.acquisitions-units-assignments.manage'                |
-      | 'orders.check-in.collection.post'                             |
-      | 'orders.collection.get'                                       |
-      | 'orders.item.approve'                                         |
-      | 'orders.item.get'                                             |
-      | 'orders.item.post'                                            |
-      | 'orders.item.put'                                             |
-      | 'orders.item.reopen'                                          |
-      | 'orders.item.unopen'                                          |
-      | 'orders.po-lines.collection.get'                              |
-      | 'orders.po-lines.item.delete'                                 |
-      | 'orders.po-lines.item.get'                                    |
-      | 'orders.po-lines.item.post'                                   |
-      | 'orders.po-lines.item.put'                                    |
-      | 'orders.pieces.collection.get'                                |
-      | 'orders.pieces.item.delete'                                   |
-      | 'orders.re-encumber.item.post'                                |
       | 'orders-storage.order-invoice-relationships.collection.get'   |
       | 'orders-storage.po-lines.item.get'                            |
       | 'orders-storage.po-lines.item.put'                            |
-      | 'organizations-storage.organizations.item.post'               |
-      | 'voucher.vouchers.collection.get'                             |
       | 'users.collection.get'                                        |
 
-  Scenario: create tenant and users for testing
-    * def testUser = testAdmin
-    Given call read('classpath:common/eureka/setup-users.feature')
+  Scenario: Create tenant and test user
+    * call read('classpath:common/eureka/setup-users.feature')
 
-  Scenario: init global data
+  Scenario: Create admin user
+    * def v = call createAdditionalUser { testUser: '#(testAdmin)',  userPermissions: '#(adminPermissions)' }
+
+  Scenario: Init global data
     * call login testAdmin
-
     * callonce read('classpath:global/inventory.feature')
     * callonce read('classpath:global/configuration.feature')
+    * call login testUser
     * callonce read('classpath:global/finances.feature')
     * callonce read('classpath:global/organizations.feature')
-
-  Scenario: dummyUser creation
-    * table userPermissions
-      | name                                                          |
-      | 'acquisitions-units.memberships.item.post'                    |
-      | 'acquisitions-units.units.item.post'                          |
-      | 'acquisitions-units-storage.memberships.collection.get'       |
-      | 'acquisitions-units-storage.memberships.item.delete'          |
-      | 'acquisitions-units-storage.memberships.item.get'             |
-      | 'acquisitions-units-storage.memberships.item.post'            |
-      | 'acquisitions-units-storage.memberships.item.put'             |
-      | 'configuration.entries.item.post'                             |
-      | 'finance.budgets.collection.get'                              |
-      | 'finance.budgets.item.delete'                                 |
-      | 'finance.budgets.item.get'                                    |
-      | 'finance.budgets.item.post'                                   |
-      | 'finance.budgets.item.put'                                    |
-      | 'finance.expense-classes.item.post'                           |
-      | 'finance.fiscal-years.item.get'                               |
-      | 'finance.fiscal-years.item.post'                              |
-      | 'finance.fiscal-years.item.put'                               |
-      | 'finance.fund-types.item.post'                                |
-      | 'finance.funds.item.get'                                      |
-      | 'finance.funds.item.put'                                      |
-      | 'finance.ledger-rollovers.item.post'                          |
-      | 'finance.ledger-rollovers-errors.collection.get'              |
-      | 'finance.ledger-rollovers-logs.item.get'                      |
-      | 'finance.ledger-rollovers-progress.collection.get'            |
-      | 'finance.ledgers.item.post'                                   |
-      | 'finance.release-encumbrance.item.post'                       |
-      | 'finance.transactions.batch.execute'                          |
-      | 'finance.transactions.collection.get'                         |
-      | 'finance.transactions.item.get'                               |
-      | 'inventory-storage.contributor-name-types.item.post'          |
-      | 'inventory-storage.electronic-access-relationships.item.post' |
-      | 'inventory-storage.holdings-sources.item.post'                |
-      | 'inventory-storage.holdings.item.post'                        |
-      | 'inventory-storage.identifier-types.item.post'                |
-      | 'inventory-storage.instance-statuses.item.post'               |
-      | 'inventory-storage.instance-types.item.post'                  |
-      | 'inventory-storage.loan-types.item.post'                      |
-      | 'inventory-storage.location-units.campuses.item.post'         |
-      | 'inventory-storage.location-units.institutions.item.post'     |
-      | 'inventory-storage.location-units.libraries.item.post'        |
-      | 'inventory-storage.locations.item.post'                       |
-      | 'inventory-storage.material-types.item.post'                  |
-      | 'inventory-storage.service-points.item.post'                  |
-      | 'inventory.instances.item.post'                               |
-      | 'invoice.invoice-lines.collection.get'                        |
-      | 'invoice.invoice-lines.item.delete'                           |
-      | 'invoice.invoice-lines.item.get'                              |
-      | 'invoice.invoice-lines.item.post'                             |
-      | 'invoice.invoice-lines.item.put'                              |
-      | 'invoice.invoices.item.delete'                                |
-      | 'invoice.invoices.item.get'                                   |
-      | 'invoice.invoices.item.post'                                  |
-      | 'invoice.invoices.item.put'                                   |
-      | 'invoice.item.approve.execute'                                |
-      | 'invoice.item.cancel.execute'                                 |
-      | 'invoice.item.pay.execute'                                    |
-      | 'invoice-storage.invoices.item.get'                           |
-      | 'invoice-storage.invoices.item.put'                           |
-      | 'invoices.acquisitions-units-assignments.assign'              |
-      | 'invoices.acquisitions-units-assignments.manage'              |
-      | 'invoices.fiscal-year.update.execute'                         |
-      | 'orders.acquisitions-units-assignments.assign'                |
-      | 'orders.acquisitions-units-assignments.manage'                |
-      | 'orders.check-in.collection.post'                             |
-      | 'orders.collection.get'                                       |
-      | 'orders.item.approve'                                         |
-      | 'orders.item.get'                                             |
-      | 'orders.item.post'                                            |
-      | 'orders.item.put'                                             |
-      | 'orders.item.reopen'                                          |
-      | 'orders.item.unopen'                                          |
-      | 'orders.po-lines.collection.get'                              |
-      | 'orders.po-lines.item.delete'                                 |
-      | 'orders.po-lines.item.get'                                    |
-      | 'orders.po-lines.item.post'                                   |
-      | 'orders.po-lines.item.put'                                    |
-      | 'orders.pieces.collection.get'                                |
-      | 'orders.pieces.item.delete'                                   |
-      | 'orders.re-encumber.item.post'                                |
-      | 'organizations-storage.organizations.item.post'               |
-      | 'voucher.vouchers.collection.get'                             |
-      | 'users.collection.get'                                        |
-
-    * call read('classpath:common/eureka/setup-users.feature@getAuthorizationToken')
-    * call read('classpath:common/eureka/setup-users.feature@createTestUser') {testUser: '#(dummyUser)'}
-    * call read('classpath:common/eureka/setup-users.feature@specifyUserCredentials') {testUser: '#(dummyUser)'}
-    * call read('classpath:common/eureka/setup-users.feature@addUserCapabilities') {userPermissions: '#(userPermissions)'}

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/MODFISTO-270-delete-planned-budget-without-transactions.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/MODFISTO-270-delete-planned-budget-without-transactions.feature
@@ -22,20 +22,15 @@ Feature: Planned budgets without transactions should be deleted
     * def poLineId = callonce uuid6
 
   Scenario: Create ledger
-    * print "Create ledger"
     * call createLedger { 'id': '#(ledgerId)' }
 
   Scenario: Create funds and current and planned budget
-    * print "Create funds and current and planned budget"
-
     * call createFund { 'id': '#(currentFundId)'}
     * call createBudget { 'id': '#(currentBudgetId)', 'allocated': 1000, 'fundId': '#(currentFundId)'}
     * print "Create planned budget"
     * call createBudget  {'id': '#(plannedBudgetId)', 'budgetStatus': 'Planned', 'allocated': 1000, 'fundId': '#(currentFundId)', "fiscalYearId":"#(globalPlannedFiscalYearId)"}
 
   Scenario: Create order
-    * print "Create order"
-
     Given path 'orders/composite-orders'
     And request
     """
@@ -49,8 +44,6 @@ Feature: Planned budgets without transactions should be deleted
     Then status 201
 
   Scenario: Create order line
-    * print "Create order line"
-
     Given path 'orders/order-lines'
 
     * def orderLine = read('classpath:samples/mod-orders/orderLines/minimal-order-line.json')
@@ -64,8 +57,6 @@ Feature: Planned budgets without transactions should be deleted
     Then status 201
 
   Scenario: Open order
-    * print "Open order"
-
     Given path 'orders/composite-orders', orderId
     When method GET
     Then status 200
@@ -79,23 +70,17 @@ Feature: Planned budgets without transactions should be deleted
     Then status 204
 
   Scenario: Verify that planned budget without transaction can be deleted
-    * print "Verify that planned budget without transaction can be deleted"
-
     Given path 'finance/budgets', plannedBudgetId
     When method DELETE
     Then status 204
 
 
   Scenario: Verify planned budget was deleted
-    * print "Verify planned budget was deleted"
-
     Given path 'finance/budgets', plannedBudgetId
     When method GET
     Then status 404
 
   Scenario: Verify that current budget with transaction can't be deleted
-    * print "Verify that current budget with transaction can't be deleted"
-
     Given path 'finance/budgets', currentBudgetId
     When method DELETE
     Then status 400

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/MODFISTO-270-delete-planned-budget-without-transactions.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/MODFISTO-270-delete-planned-budget-without-transactions.feature
@@ -1,14 +1,15 @@
 # for https://issues.folio.org/browse/MODFISTO-270
+@parallel=false
 Feature: Planned budgets without transactions should be deleted
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-#    * callonce dev {tenant: 'testcrossmodules'}
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def ledgerId = callonce uuid1
@@ -22,12 +23,11 @@ Feature: Planned budgets without transactions should be deleted
 
   Scenario: Create ledger
     * print "Create ledger"
-    * call createLedger { 'id': '#(ledgerId)'}
+    * call createLedger { 'id': '#(ledgerId)' }
 
   Scenario: Create funds and current and planned budget
     * print "Create funds and current and planned budget"
 
-    * configure headers = headersAdmin
     * call createFund { 'id': '#(currentFundId)'}
     * call createBudget { 'id': '#(currentBudgetId)', 'allocated': 1000, 'fundId': '#(currentFundId)'}
     * print "Create planned budget"

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/approve-invoice-using-different-fiscal-years.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/approve-invoice-using-different-fiscal-years.feature
@@ -5,12 +5,15 @@ Feature: Approve an invoice using different fiscal years
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
+
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
     * def poFyId = callonce uuid1
@@ -43,7 +46,6 @@ Feature: Approve an invoice using different fiscal years
 
 
   Scenario: Create a new fiscal year using the same range as the current one, and the associated ledger
-    * configure headers = headersAdmin
     Given path 'finance/fiscal-years', globalFiscalYearId
     When method GET
     Then status 200
@@ -69,7 +71,6 @@ Feature: Approve an invoice using different fiscal years
 
 
   Scenario: Create funds and budgets
-    * configure headers = headersAdmin
     # funds 1 and 2 use the same fiscal year, fund 3 uses the other one
     * call createFund { id: #(fundId1), code: #(fundId1), ledgerId: #(globalLedgerId) }
     * call createBudget { id: #(budgetId1), fundId: #(fundId1), fiscalYearId: #(globalFiscalYearId), allocated: 1000, status: 'Active' }

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/approve-invoice-with-negative-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/approve-invoice-with-negative-line.feature
@@ -3,11 +3,12 @@
 Feature: Approve an invoice with a negative line
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -26,8 +27,7 @@ Feature: Approve an invoice with a negative line
 
 
   Scenario: Create finances
-    * configure headers = headersAdmin
-    * call createFund { 'id': '#(fundId)'}
+    * call createFund { 'id': '#(fundId)' }
     * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)', 'status': 'Active' }
 
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/approve-or-cancel-invoice-with-polinepaymentstatus-parameter.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/approve-or-cancel-invoice-with-polinepaymentstatus-parameter.feature
@@ -3,16 +3,11 @@
 
     Background:
       * print karate.info.scenarioName
-
       * url baseUrl
-      * callonce login testAdmin
-      * def okapitokenAdmin = okapitoken
-      * callonce login dummyUser
-      * def okapitokenDummy = okapitoken
 
-      * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
-      * def headersDummy = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenDummy)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
-      * configure headers = headersDummy
+      * callonce login testUser
+      * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+      * configure headers = headersUser
 
       * callonce variables
 
@@ -44,14 +39,12 @@
       * def invoiceLineId2 = call uuid
 
       * print "Create finances with a current and a past fiscal year"
-      * configure headers = headersAdmin
       * def v = call createFiscalYear { id: '#(currentFiscalYearId)', code: '#(currentFiscalCode)', periodStart: '#(currentPeriodStart)', periodEnd: '#(currentPeriodEnd)', series: '#(codePrefix)' }
       * def v = call createFiscalYear { id: '#(pastFiscalYearId)', code: '#(pastFiscalCode)', periodStart: '#(pastPeriodStart)', periodEnd: '#(pastPeriodEnd)', series: '#(codePrefix)' }
       * def v = call createLedger { id: '#(ledgerId)', fiscalYearId: '#(pastFiscalYearId)', restrictEncumbrance: false, restrictExpenditures: false }
       * def v = call createFund { id: '#(fundId)', ledgerId: '#(ledgerId)' }
       * def v = call createBudget { id: '#(currentBudgetId)', allocated: 1000, fundId: '#(fundId)', status: 'Active', fiscalYearId: '#(currentFiscalYearId)' }
       * def v = call createBudget { id: '#(pastBudgetId)', allocated: 1000, fundId: '#(fundId)', status: 'Active', fiscalYearId: '#(pastFiscalYearId)' }
-      * configure headers = headersDummy
 
       * print "Create an order and 2 lines"
       * def v = call createOrder { id: '#(orderId)' }
@@ -62,10 +55,8 @@
       * def v = call openOrder { orderId: '#(orderId)' }
 
       * print "Create encumbrances in the past fiscal year"
-      * configure headers = headersAdmin
       * def v = call createTransaction { id: '#(pastEncumbranceId1)', transactionType: 'Encumbrance', fiscalYearId: '#(pastFiscalYearId)', fundId: '#(fundId)', amount: 10.0, orderId: '#(orderId)', poLineId: '#(poLineId1)' }
       * def v = call createTransaction { id: '#(pastEncumbranceId2)', transactionType: 'Encumbrance', fiscalYearId: '#(pastFiscalYearId)', fundId: '#(fundId)', amount: 10.0, orderId: '#(orderId)', poLineId: '#(poLineId2)' }
-      * configure headers = headersUser
 
       * print "Create an invoice in the past fiscal year"
       * def v = call createInvoice { id: '#(invoiceId)', fiscalYearId: '#(pastFiscalYearId)' }

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/cancel-invoice-and-unrelease-2-encumbrances.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/cancel-invoice-and-unrelease-2-encumbrances.feature
@@ -27,7 +27,6 @@ Feature: Cancel invoice and unrelease 2 encumbrances
 
 
   Scenario: Create finances
-    * print "Create finances"
     * call createFund { id: '#(fundId1)', code: '#(fundId1)' }
     * call createBudget { id: '#(budgetId1)', allocated: 1000, fundId: '#(fundId1)', status: 'Active' }
     * call createFund { id: '#(fundId2)', code: '#(fundId2)' }
@@ -35,8 +34,6 @@ Feature: Cancel invoice and unrelease 2 encumbrances
 
 
   Scenario: Create an order
-    * print "Create an order"
-
     Given path 'orders/composite-orders'
     And request
     """
@@ -51,8 +48,6 @@ Feature: Cancel invoice and unrelease 2 encumbrances
 
 
   Scenario: Create an order line with 2 fund distributions
-    * print "Create an order line with 2 fund distributions"
-
     * copy poLine = orderLineTemplate
     * set poLine.id = poLineId
     * set poLine.purchaseOrderId = orderId
@@ -68,8 +63,6 @@ Feature: Cancel invoice and unrelease 2 encumbrances
 
 
   Scenario: Open the order
-    * print "Open the order"
-
     Given path 'orders/composite-orders', orderId
     When method GET
     Then status 200
@@ -84,8 +77,6 @@ Feature: Cancel invoice and unrelease 2 encumbrances
 
 
   Scenario: Create an invoice
-    * print "Create an invoice"
-
     * copy invoice = invoiceTemplate
     * set invoice.id = invoiceId
 
@@ -96,7 +87,6 @@ Feature: Cancel invoice and unrelease 2 encumbrances
 
 
   Scenario: Add an invoice line with the same fund distributions
-    * print "Add an invoice line with the same fund distributions"
     * copy invoiceLine = invoiceLineTemplate
     * set invoiceLine.id = invoiceLineId
     * set invoiceLine.invoiceId = invoiceId
@@ -115,8 +105,6 @@ Feature: Cancel invoice and unrelease 2 encumbrances
 
 
   Scenario: Approve the invoice
-    * print "Approve the invoice"
-
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200
@@ -131,7 +119,6 @@ Feature: Cancel invoice and unrelease 2 encumbrances
 
 
   Scenario: Check invoice line encumbrances have been added when the invoice was approved
-    * print "Check invoice line encumbrances have been added when the invoice was approved"
     Given path 'invoice/invoice-lines', invoiceLineId
     When method GET
     Then status 200
@@ -140,8 +127,6 @@ Feature: Cancel invoice and unrelease 2 encumbrances
 
 
   Scenario: Pay the invoice
-    * print "Pay the invoice"
-
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200
@@ -156,7 +141,6 @@ Feature: Cancel invoice and unrelease 2 encumbrances
 
 
   Scenario: Check encumbrances before cancelling the invoice
-    * print "Check encumbrances before cancelling the invoice"
     Given path '/finance/transactions'
     And param query = 'encumbrance.sourcePurchaseOrderId==' + orderId
     When method GET
@@ -166,7 +150,6 @@ Feature: Cancel invoice and unrelease 2 encumbrances
 
 
   Scenario: Cancel the invoice
-    * print "Cancel the invoice"
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200
@@ -179,7 +162,6 @@ Feature: Cancel invoice and unrelease 2 encumbrances
 
 
   Scenario: Check encumbrances after cancelling the invoice
-    * print "Check encumbrances after cancelling the invoice"
     Given path '/finance/transactions'
     And param query = 'encumbrance.sourcePurchaseOrderId==' + orderId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/cancel-invoice-and-unrelease-2-encumbrances.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/cancel-invoice-and-unrelease-2-encumbrances.feature
@@ -3,11 +3,12 @@
 Feature: Cancel invoice and unrelease 2 encumbrances
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -27,7 +28,6 @@ Feature: Cancel invoice and unrelease 2 encumbrances
 
   Scenario: Create finances
     * print "Create finances"
-    * configure headers = headersAdmin
     * call createFund { id: '#(fundId1)', code: '#(fundId1)' }
     * call createBudget { id: '#(budgetId1)', allocated: 1000, fundId: '#(fundId1)', status: 'Active' }
     * call createFund { id: '#(fundId2)', code: '#(fundId2)' }

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/cancel-invoice-linked-to-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/cancel-invoice-linked-to-order.feature
@@ -2,24 +2,16 @@
 Feature: Cancel an invoice linked to an order
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
     * def orderLineTemplate = read('classpath:samples/mod-orders/orderLines/minimal-order-line.json')
-
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
-    * def createInvoice = read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature')
-    * def createInvoiceLine = read('classpath:thunderjet/mod-invoice/reusable/create-invoice-line.feature')
-    * def approveInvoice = read('classpath:thunderjet/mod-invoice/reusable/approve-invoice.feature')
-    * def payInvoice = read('classpath:thunderjet/mod-invoice/reusable/pay-invoice.feature')
-    * def cancelInvoice = read('classpath:thunderjet/mod-invoice/reusable/cancel-invoice.feature')
 
 
   Scenario: Cancel an approved invoice
@@ -31,7 +23,6 @@ Feature: Cancel an invoice linked to an order
     * def invoiceLineId = call uuid
 
     * print "Create finances"
-    * configure headers = headersAdmin
     * call createFund { 'id': '#(fundId)' }
     * call createBudget { 'id': '#(budgetId)', 'allocated': 1000, 'fundId': '#(fundId)', 'status': 'Active' }
 
@@ -144,7 +135,6 @@ Feature: Cancel an invoice linked to an order
     * def invoiceLineId2 = call uuid
 
     * print "Create finances"
-    * configure headers = headersAdmin
     * call createFund { 'id': '#(fundId)' }
     * call createBudget { 'id': '#(budgetId)', 'allocated': 1000, 'fundId': '#(fundId)', 'status': 'Active' }
 
@@ -286,7 +276,6 @@ Feature: Cancel an invoice linked to an order
     * def invoiceLineId = call uuid
 
     * print "Create finances"
-    * configure headers = headersAdmin
     * call createFund { id: #(fundId) }
     * call createBudget { id: #(budgetId), allocated: 1000, fundId: #(fundId), status: 'Active' }
 
@@ -398,7 +387,6 @@ Feature: Cancel an invoice linked to an order
     * def invoiceLineId = call uuid
 
     * print "Create finances"
-    * configure headers = headersAdmin
     * call createFund { 'id': '#(fundId)' }
     * call createBudget { 'id': '#(budgetId)', 'allocated': 1000, 'fundId': '#(fundId)', 'status': 'Active' }
 
@@ -515,7 +503,6 @@ Feature: Cancel an invoice linked to an order
     * def invoiceLineId = call uuid
 
     * print "Create finances"
-    * configure headers = headersAdmin
     * call createFund { 'id': '#(fundId)' }
     * call createBudget { 'id': '#(budgetId)', 'allocated': 1000, 'fundId': '#(fundId)', 'status': 'Active' }
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/cancel-invoice-with-encumbrance.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/cancel-invoice-with-encumbrance.feature
@@ -2,11 +2,12 @@
 Feature: Cancel an invoice with an Encumbrance
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -31,7 +32,6 @@ Feature: Cancel an invoice with an Encumbrance
     * def invoiceLineId = call uuid
 
     * print "1. Create finances"
-    * configure headers = headersAdmin
     * def v = call createFund { id: "#(fundId)" }
     * def v = call createBudget { id: "#(budgetId)", allocated: 10000, fundId: "#(fundId)", status: "Active" }
 
@@ -97,7 +97,6 @@ Feature: Cancel an invoice with an Encumbrance
     * def invoiceLineId = call uuid
 
     * print "1. Create finances"
-    * configure headers = headersAdmin
     * def v = call createFund { id: "#(fundId)" }
     * def v = call createBudget { id: "#(budgetId)", allocated: 10000, fundId: "#(fundId)", status: "Active" }
 
@@ -164,7 +163,6 @@ Feature: Cancel an invoice with an Encumbrance
     * def invoiceLineId = call uuid
 
     * print "1. Create finances"
-    * configure headers = headersAdmin
     * def v = call createFund { id: "#(fundId)" }
     * def v = call createBudget { id: "#(budgetId)", allocated: 10000, fundId: "#(fundId)", status: "Active" }
 
@@ -221,7 +219,6 @@ Feature: Cancel an invoice with an Encumbrance
     * def invoiceLineId = call uuid
 
     * print "1. Create finances"
-    * configure headers = headersAdmin
     * def v = call createFund { id: "#(fundId)" }
     * def v = call createBudget { id: "#(budgetId)", allocated: 10000, fundId: "#(fundId)", status: "Active" }
 
@@ -278,7 +275,6 @@ Feature: Cancel an invoice with an Encumbrance
     * def invoiceLineId = call uuid
 
     * print "1. Create finances"
-    * configure headers = headersAdmin
     * def v = call createFund { id: "#(fundId)" }
     * def v = call createBudget { id: "#(budgetId)", allocated: 10000, fundId: "#(fundId)", status: "Active" }
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/change-fd-check-initial-amount.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/change-fd-check-initial-amount.feature
@@ -4,21 +4,13 @@ Feature: Change fund distribution and check initial amount encumbered
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
-
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
-    * def createInvoice = read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature')
-    * def createInvoiceLine = read('classpath:thunderjet/mod-invoice/reusable/create-invoice-line.feature')
-    * def approveInvoice = read('classpath:thunderjet/mod-invoice/reusable/approve-invoice.feature')
-    * def payInvoice = read('classpath:thunderjet/mod-invoice/reusable/pay-invoice.feature')
 
     * def fundAId = callonce uuid1
     * def fundBId = callonce uuid2
@@ -35,7 +27,6 @@ Feature: Change fund distribution and check initial amount encumbered
 
 
   Scenario: Prepare finances with 4 funds
-    * configure headers = headersAdmin
     * def v = call createFund { id: #(fundAId) }
     * def v = call createFund { id: #(fundBId) }
     * def v = call createFund { id: #(fundCId) }

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/change-poline-fd-and-pay-invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/change-poline-fd-and-pay-invoice.feature
@@ -25,12 +25,10 @@ Feature: Change poline fund distribution and pay invoice
 
 
   Scenario: Create finances
-    * print "Create finances"
     * call createFund { 'id': '#(fundId)' }
     * call createBudget { 'id': '#(budgetId)', 'allocated': 1000, 'fundId': '#(fundId)', 'status': 'Active' }
 
   Scenario: Create an order
-    * print "Create an order"
     Given path 'orders/composite-orders'
     And request
     """
@@ -44,7 +42,6 @@ Feature: Change poline fund distribution and pay invoice
     Then status 201
 
   Scenario: Create an order line
-    * print "Create an order line"
     * copy poLine = orderLineTemplate
     * set poLine.id = poLineId
     * set poLine.purchaseOrderId = orderId
@@ -57,7 +54,6 @@ Feature: Change poline fund distribution and pay invoice
     Then status 201
 
   Scenario: Open the order
-    * print "Open the order"
     Given path 'orders/composite-orders', orderId
     When method GET
     Then status 200
@@ -69,7 +65,6 @@ Feature: Change poline fund distribution and pay invoice
     Then status 204
 
   Scenario: Create an invoice
-    * print "Create an invoice"
     * copy invoice = invoiceTemplate
     * set invoice.id = invoiceId
     Given path 'invoice/invoices'
@@ -101,7 +96,6 @@ Feature: Change poline fund distribution and pay invoice
     Then status 201
 
   Scenario: Remove the order line fund distribution
-    * print "Remove the order line fund distribution"
     Given path 'orders/order-lines', poLineId
     When method GET
     Then status 200
@@ -113,7 +107,6 @@ Feature: Change poline fund distribution and pay invoice
     Then status 204
 
   Scenario: Add a new order line fund distribution
-    * print "Add a new order line fund distribution"
     Given path 'orders/order-lines', poLineId
     When method GET
     Then status 200
@@ -125,7 +118,6 @@ Feature: Change poline fund distribution and pay invoice
     Then status 204
 
   Scenario: Approve the invoice
-    * print "Approve the invoice"
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200
@@ -137,7 +129,6 @@ Feature: Change poline fund distribution and pay invoice
     Then status 204
 
   Scenario: Pay the invoice
-    * print "Pay the invoice"
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/change-poline-fd-and-pay-invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/change-poline-fd-and-pay-invoice.feature
@@ -3,11 +3,12 @@
 Feature: Change poline fund distribution and pay invoice
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -25,7 +26,6 @@ Feature: Change poline fund distribution and pay invoice
 
   Scenario: Create finances
     * print "Create finances"
-    * configure headers = headersAdmin
     * call createFund { 'id': '#(fundId)' }
     * call createBudget { 'id': '#(budgetId)', 'allocated': 1000, 'fundId': '#(fundId)', 'status': 'Active' }
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-approve-and-pay-invoice-with-invoice-references-same-po-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-approve-and-pay-invoice-with-invoice-references-same-po-line.feature
@@ -54,12 +54,10 @@ Feature: Check approve and pay invoice with more than 15 invoice lines, several 
 
 
   Scenario: Create finances
-    * print "Create finances"
     * call createFund { 'id': '#(fundId)' }
     * call createBudget { 'id': '#(budgetId)', 'allocated': 1000, 'fundId': '#(fundId)', 'status': 'Active' }
 
   Scenario: Create an order
-    * print "Create an order"
     Given path 'orders/composite-orders'
     And request
     """
@@ -73,7 +71,6 @@ Feature: Check approve and pay invoice with more than 15 invoice lines, several 
     Then status 201
 
   Scenario: Create an order line
-    * print "Create an order line"
     * copy poLine = orderLineTemplate
     * set poLine.id = poLineId
     * set poLine.purchaseOrderId = orderId
@@ -86,7 +83,6 @@ Feature: Check approve and pay invoice with more than 15 invoice lines, several 
     Then status 201
 
   Scenario: Open the order
-    * print "Open the order"
     Given path 'orders/composite-orders', orderId
     When method GET
     Then status 200
@@ -98,7 +94,6 @@ Feature: Check approve and pay invoice with more than 15 invoice lines, several 
     Then status 204
 
   Scenario: Create an invoice
-    * print "Create an invoice"
     * copy invoice = invoiceTemplate
     * set invoice.id = invoiceId
     Given path 'invoice/invoices'
@@ -166,7 +161,6 @@ Feature: Check approve and pay invoice with more than 15 invoice lines, several 
 
 
   Scenario: Approve the invoice
-    * print "Approve the invoice"
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200
@@ -178,7 +172,6 @@ Feature: Check approve and pay invoice with more than 15 invoice lines, several 
     Then status 204
 
   Scenario: Pay the invoice
-    * print "Pay the invoice"
     Given path 'invoice/invoices', invoiceId
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-approve-and-pay-invoice-with-invoice-references-same-po-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-approve-and-pay-invoice-with-invoice-references-same-po-line.feature
@@ -3,11 +3,12 @@
 Feature: Check approve and pay invoice with more than 15 invoice lines, several of which reference to same POL
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -54,7 +55,6 @@ Feature: Check approve and pay invoice with more than 15 invoice lines, several 
 
   Scenario: Create finances
     * print "Create finances"
-    * configure headers = headersAdmin
     * call createFund { 'id': '#(fundId)' }
     * call createBudget { 'id': '#(budgetId)', 'allocated': 1000, 'fundId': '#(fundId)', 'status': 'Active' }
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-encumbrances-after-issuing-credit-for-paid-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-encumbrances-after-issuing-credit-for-paid-order.feature
@@ -4,10 +4,11 @@
     Background:
       * print karate.info.scenarioName
       * url baseUrl
-      * callonce login testAdmin
-      * def okapitokenAdmin = okapitoken
-      * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-      * configure headers = headersAdmin
+
+      * callonce login testUser
+      * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+      * configure headers = headersUser
+
       * callonce variables
       * def fundId = callonce uuid1
       * def budgetId = callonce uuid2
@@ -21,8 +22,8 @@
 
     Scenario: Check the encumbrances after issuing credit when the order is fully paid
       # 1. Create a fund and a budget
-      * def v = call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)'}
-      * def v = call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 1000}
+      * def v = call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)' }
+      * def v = call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 1000 }
 
       # 2. Create an order, order line and open the order
       * def v = call createOrder { id: '#(orderId)' }

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-encumbrances-after-order-is-reopened-2.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-encumbrances-after-order-is-reopened-2.feature
@@ -3,20 +3,21 @@
 Feature: Check encumbrances after order is reopened - 2
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fundId = call uuid
     * def budgetId = call uuid
 
     # Create a fund and budget
-    * configure headers = headersAdmin
-    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)'}
-    * call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 1000}
+    * call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)' }
+    * call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 1000 }
 
 
   Scenario: Use Case 1 - Allow encumbrance with expended value to be unreleased

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-encumbrances-after-order-is-reopened.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-encumbrances-after-order-is-reopened.feature
@@ -5,10 +5,10 @@ Feature: Check encumbrances after order is reopened
   Background:
     * print karate.info.scenarioName
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -27,14 +27,8 @@ Feature: Check encumbrances after order is reopened
     * def otherEncumbranceId1 = callonce uuid13
     * def otherEncumbranceId2 = callonce uuid14
 
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def createInvoice = read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
-
 
   Scenario: Create a fund and budget
-    * configure headers = headersAdmin
     * def v = call createFund { id: '#(fundId)', ledgerId: '#(globalLedgerWithRestrictionsId)' }
     * def v = call createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 1000 }
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-encumbrances-after-order-line-exchange-rate-update.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-encumbrances-after-order-line-exchange-rate-update.feature
@@ -4,17 +4,13 @@ Feature: Check encumbrances after order line exchange rate update
   Background:
     * print karate.info.scenarioName
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def createInvoice = read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
 
   @Positive
   Scenario: Check encumbrances after order line exchange rate update to manual rate 2 times
@@ -26,7 +22,6 @@ Feature: Check encumbrances after order line exchange rate update
     * def invoiceLineId = call uuid
 
     ### 1. Create finances
-    * configure headers = headersAdmin
     * def v = call createFund { id: "#(fundId)" }
     * def v = call createBudget { id: "#(budgetId)", allocated: 10000, fundId: "#(fundId)", status: "Active" }
 
@@ -121,7 +116,6 @@ Feature: Check encumbrances after order line exchange rate update
     * def invoiceLineId = call uuid
 
     ### 1. Create finances
-    * configure headers = headersAdmin
     * def v = call createFund { id: "#(fundId)" }
     * def v = call createBudget { id: "#(budgetId)", allocated: 10000, fundId: "#(fundId)", status: "Active" }
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-order-re-encumber-after-preview-rollover.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-order-re-encumber-after-preview-rollover.feature
@@ -11,13 +11,12 @@ Feature: Check order re-encumber after preview rollover
   # 6) retry step 3 and make sure that preview rollover wasn't affected to results of re-encumber
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-    #* callonce dev {tenant: 'test_finance1'}
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -110,24 +109,25 @@ Feature: Check order re-encumber after preview rollover
 
 
   Scenario Outline: prepare fund with <fundId>, <ledgerId> for rollover
-    * configure headers = headersAdmin
     * def fundId = <fundId>
     * def ledgerId = <ledgerId>
     * def fundCode = <fundCode>
     * def fundTypeId = <fundTypeId>
 
-    Given path 'finance-storage/funds'
+    Given path 'finance/funds'
     And request
     """
     {
-      "id": "#(fundId)",
-      "code": "#(codePrefix + fundCode)",
-      "description": "Fund #(codePrefix + fundCode) for rollover API Tests",
-      "externalAccountNo": "#(fundId)",
-      "fundStatus": <status>,
-      "ledgerId": "#(ledgerId)",
-      "name": "Fund #(codePrefix + fundCode) for rollover API Tests",
-      "fundTypeId": "#(fundTypeId)"
+      "fund": {
+        "id": "#(fundId)",
+        "code": "#(codePrefix + fundCode)",
+        "description": "Fund #(codePrefix + fundCode) for rollover API Tests",
+        "externalAccountNo": "#(fundId)",
+        "fundStatus": <status>,
+        "ledgerId": "#(ledgerId)",
+        "name": "Fund #(codePrefix + fundCode) for rollover API Tests",
+        "fundTypeId": "#(fundTypeId)",
+      }
     }
     """
     When method POST
@@ -184,8 +184,6 @@ Feature: Check order re-encumber after preview rollover
 
 
   Scenario Outline: Create open orders with 1 fund distribution
-    * configure headers = headersAdmin
-
     * def orderId = <orderId>
     * def poLineId = <poLineId>
     * def fundId = <fundId>
@@ -238,8 +236,6 @@ Feature: Check order re-encumber after preview rollover
 
 
   Scenario Outline: Open order
-    * configure headers = headersAdmin
-
     * def orderId = <orderId>
     Given path 'orders/composite-orders', orderId
     When method GET

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-payment-status-after-cancelling-paid-invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-payment-status-after-cancelling-paid-invoice.feature
@@ -3,23 +3,13 @@ Feature: Check payment status after cancelling paid invoice
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
-
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
-    * def createInvoice = read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature')
-    * def createInvoiceLine = read('classpath:thunderjet/mod-invoice/reusable/create-invoice-line.feature')
-    * def approveInvoice = read('classpath:thunderjet/mod-invoice/reusable/approve-invoice.feature')
-    * def payInvoice = read('classpath:thunderjet/mod-invoice/reusable/pay-invoice.feature')
-    * def cancelInvoice = read('classpath:thunderjet/mod-invoice/reusable/cancel-invoice.feature')
 
 
   Scenario: Cancel with no other invoice
@@ -31,7 +21,6 @@ Feature: Check payment status after cancelling paid invoice
     * def invoiceLineId = call uuid
 
     * print "Create finances"
-    * configure headers = headersAdmin
     * call createFund { id: '#(fundId)' }
     * call createBudget { id: '#(budgetId)', allocated: 1000, fundId: '#(fundId)', status: 'Active' }
 
@@ -89,7 +78,6 @@ Feature: Check payment status after cancelling paid invoice
     * def invoiceLineId2 = call uuid
 
     * print "Create finances"
-    * configure headers = headersAdmin
     * call createFund { id: '#(fundId)' }
     * call createBudget { id: '#(budgetId)', allocated: 1000, fundId: '#(fundId)', status: 'Active' }
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-paymentstatus-after-reopen.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-paymentstatus-after-reopen.feature
@@ -3,22 +3,15 @@ Feature: Check paymentStatus after reopen
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
     * def closeOrderRemoveLines = read('classpath:thunderjet/mod-orders/reusable/close-order-remove-lines.feature')
-    * def createInvoice = read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature')
-    * def createInvoiceLine = read('classpath:thunderjet/mod-invoice/reusable/create-invoice-line.feature')
-    * def approveInvoice = read('classpath:thunderjet/mod-invoice/reusable/approve-invoice.feature')
 
 
   Scenario: Open order, approve invoice, close order, reopen order, check paymentStatus
@@ -30,7 +23,6 @@ Feature: Check paymentStatus after reopen
     * def invoiceLineId = call uuid
 
     * print "Prepare finances"
-    * configure headers = headersAdmin
     * def v = call createFund { id: '#(fundId)' }
     * def v = call createBudget { id: '#(budgetId)', allocated: 1000, fundId: '#(fundId)', status: 'Active' }
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-po-numbers-updates.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/check-po-numbers-updates.feature
@@ -2,12 +2,12 @@
 Feature: Check poNumbers updates when invoice lines are created and updated
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    #* callonce dev {tenant: 'testcrossmodules1'}
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/chek-po-numbers-updates-when-invoice-line-deleted.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/chek-po-numbers-updates-when-invoice-line-deleted.feature
@@ -2,12 +2,13 @@
 Feature: Invoice poNumbers needs to be updated when an invoice line is deleted
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    #* callonce dev {tenant: 'testcrossmodules2'}
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def poLineTemplate = read('classpath:samples/mod-orders/orderLines/minimal-order-line.json')

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/create-order-and-approve-invoice-were-pol-without-fund-distributions.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/create-order-and-approve-invoice-were-pol-without-fund-distributions.feature
@@ -1,14 +1,14 @@
+@parallel=false
 Feature: Create order and approve invoice were pol without fund distributions
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-    #* callonce dev {tenant: 'testcrossmodules'}
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
-    # load global variables
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fundId1 = callonce uuid1
@@ -21,12 +21,11 @@ Feature: Create order and approve invoice were pol without fund distributions
     * def invoiceLineIdWithTwoFD = callonce uuid16
 
   Scenario Outline: prepare finances for fund with <fundId> and budget with <budgetId>, <statusExpenseClasses>
-    * configure headers = headersAdmin
     * def fundId = <fundId>
     * def budgetId = <budgetId>
 
-    * call createFund { 'id': '#(fundId)'}
-    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)'}
+    * call createFund { 'id': '#(fundId)' }
+    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)' }
 
     Examples:
       | fundId  | budgetId  |

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/create-order-and-invoice-with-odd-penny.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/create-order-and-invoice-with-odd-penny.feature
@@ -1,14 +1,14 @@
+@parallel=false
 Feature: Create orders and invoices with odd penny
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-#    * callonce dev {tenant: 'testcrossmodules'}
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
-    # load global variables
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fundId1 = callonce uuid1
@@ -39,10 +39,9 @@ Feature: Create orders and invoices with odd penny
   Scenario Outline: prepare finances for fund with <fundId> and budget with <budgetId>, <statusExpenseClasses>
     * def fundId = <fundId>
     * def budgetId = <budgetId>
-    * configure headers = headersAdmin
 
-    * call createFund { 'id': '#(fundId)'}
-    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)'}
+    * call createFund { 'id': '#(fundId)' }
+    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)' }
 
     Examples:
       | fundId  | budgetId  |

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/create-order-with-invoice-that-has-enough-money.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/create-order-with-invoice-that-has-enough-money.feature
@@ -1,14 +1,14 @@
+@parallel=false
 Feature: Create order with invoice that has enough money
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-    #* callonce dev {tenant: 'testcrossmodules'}
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
-    # load global variables
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def fundId = callonce uuid1
@@ -28,7 +28,6 @@ Feature: Create order with invoice that has enough money
     * def invoiceLineIdWithExpenseClasses = callonce uuid12
 
   Scenario Outline: prepare finances for fund with <fundId> and budget with <budgetId>, <statusExpenseClasses>
-    * configure headers = headersAdmin
     * def fundId = <fundId>
     * def budgetId = <budgetId>
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/delete-encumbrance.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/delete-encumbrance.feature
@@ -1,13 +1,13 @@
 Feature: Test deleting an encumbrance
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-    #* callonce dev {tenant: 'testcrossmodules'}
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
     * def orderId1 = callonce uuid1
     * def orderId2 = callonce uuid2

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/invoice-encumbrance-update-without-acquisition-unit.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/invoice-encumbrance-update-without-acquisition-unit.feature
@@ -4,20 +4,17 @@ Feature: Invoice encumbrance update without acquisition unit
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
+
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
-
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
-    * def createInvoice = read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature')
-    * def createInvoiceLine = read('classpath:thunderjet/mod-invoice/reusable/create-invoice-line.feature')
 
     * def fundId = callonce uuid1
     * def budgetId = callonce uuid2
@@ -30,7 +27,6 @@ Feature: Invoice encumbrance update without acquisition unit
 
 
   Scenario: Prepare finances
-    * configure headers = headersAdmin
     * def v = call createFund { id: '#(fundId)' }
     * def v = call createBudget { id: '#(budgetId)', allocated: 1000, fundId: '#(fundId)', status: 'Active' }
 
@@ -55,8 +51,8 @@ Feature: Invoice encumbrance update without acquisition unit
 
   Scenario: Create acq unit membership
     * configure headers = headersAdmin
-    * def result = call read('classpath:common/eureka/users.feature') {user: '#(testAdmin)'}
-    * def userIdForMembership = result.userId
+    * def res = callonce getUserIdByUsername { user: '#(testUser)' }
+    * def userIdForMembership = res.userId
     Given path 'acquisitions-units/memberships'
     And request
     """
@@ -121,8 +117,8 @@ Feature: Invoice encumbrance update without acquisition unit
 
   Scenario: Re-add acq unit membership
     * configure headers = headersAdmin
-    * def result = call read('classpath:common/eureka/users.feature') {user: '#(testAdmin)'}
-    * def userIdForMembership = result.userId
+    * def res = callonce getUserIdByUsername { user: '#(testUser)' }
+    * def userIdForMembership = res.userId
     Given path 'acquisitions-units/memberships'
     And request
     """

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/link-invoice-line-to-po-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/link-invoice-line-to-po-line.feature
@@ -2,11 +2,16 @@
 Feature: Link an invoice line to a po line
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
+
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -76,8 +81,8 @@ Feature: Link an invoice line to a po line
     And match $.poLineId == poLineId
 
     # Check an order-invoice relationship was created as well
+    * configure headers = headersAdmin
     Given path 'orders-storage/order-invoice-relns'
-    And headers headersAdmin
     And param query = 'invoiceId==' + invoiceId
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/open-order-after-approving-invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/open-order-after-approving-invoice.feature
@@ -4,21 +4,13 @@ Feature: Open order after approving invoice
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
-
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
-    * def createInvoice = read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature')
-    * def createInvoiceLine = read('classpath:thunderjet/mod-invoice/reusable/create-invoice-line.feature')
-    * def approveInvoice = read('classpath:thunderjet/mod-invoice/reusable/approve-invoice.feature')
-    * def payInvoice = read('classpath:thunderjet/mod-invoice/reusable/pay-invoice.feature')
 
     * def fundId = callonce uuid1
     * def budgetId = callonce uuid2
@@ -29,7 +21,6 @@ Feature: Open order after approving invoice
 
 
   Scenario: Prepare finances
-    * configure headers = headersAdmin
     * def v = call createFund { id: #(fundId) }
     * def v = call createBudget { id: #(budgetId), fundId: #(fundId), allocated: 100 }
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/order-invoice-relation-can-be-changed.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/order-invoice-relation-can-be-changed.feature
@@ -1,14 +1,18 @@
+@parallel=false
 Feature: Test order invoice relation can be changed
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-    #* callonce dev {tenant: 'testcrossmodules'}
+
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def orderIdOne = callonce uuid1
@@ -18,6 +22,7 @@ Feature: Test order invoice relation can be changed
 
     * def invoiceId = callonce uuid6
     * def invoiceLineIdOne = callonce uuid7
+
 
   Scenario Outline: Create orders
     * def orderId = <orderId>

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/order-invoice-relation-can-be-deleted.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/order-invoice-relation-can-be-deleted.feature
@@ -1,14 +1,18 @@
+@parallel=false
 Feature: Test order invoice relation can be deleted
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-    #* callonce dev {tenant: 'testcrossmodules'}
+
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def orderIdOne = callonce uuid1
@@ -38,6 +42,7 @@ Feature: Test order invoice relation can be deleted
       | orderId    |
       | orderIdOne |
       | orderIdTwo |
+
 
   Scenario Outline: Create order lines for <orderLineId>
     * def orderId = <orderId>
@@ -79,6 +84,7 @@ Feature: Test order invoice relation can be deleted
     """
     When method POST
     Then status 201
+
 
   Scenario Outline: Create invoice lines
     * def orderLineId = <orderLineId>
@@ -129,6 +135,7 @@ Feature: Test order invoice relation can be deleted
       | orderId    | invoiceId |
       | orderIdOne | invoiceId |
 
+
   Scenario: Update order line reference in the invoice line
     Given path 'invoice/invoice-lines', invoiceLineIdOne
     When method GET
@@ -140,6 +147,7 @@ Feature: Test order invoice relation can be deleted
     And request invoiceLinePayload
     When method PUT
     Then status 204
+
 
   Scenario Outline: Check that order invoice relation has been changed
     * configure headers = headersAdmin

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/order-invoice-relation-must-be-deleted-if-invoice-deleted.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/order-invoice-relation-must-be-deleted-if-invoice-deleted.feature
@@ -1,14 +1,18 @@
+@parallel=false
 Feature: When invoice is deleted, then order vs invoice relation must be deleted and POL can be deleted
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-    #* callonce dev {tenant: 'testcrossmodules1'}
+
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def orderIdOne = callonce uuid1
@@ -35,6 +39,7 @@ Feature: When invoice is deleted, then order vs invoice relation must be deleted
     Examples:
       | orderId    |
       | orderIdOne |
+
 
   Scenario Outline: Create order lines for <orderLineId>
     * def orderId = <orderId>
@@ -77,6 +82,7 @@ Feature: When invoice is deleted, then order vs invoice relation must be deleted
     When method POST
     Then status 201
 
+
   Scenario Outline: Create invoice lines
     * def orderLineId = <orderLineId>
     * def invoiceLineId = <invoiceLineId>
@@ -110,6 +116,7 @@ Feature: When invoice is deleted, then order vs invoice relation must be deleted
       | orderLineId      | invoiceLineId      |
       | orderLineIdOne   | invoiceLineIdOne   |
 
+
   Scenario Outline: Check that order invoice relation has been changed
 
     * def orderId = <orderId>
@@ -117,8 +124,8 @@ Feature: When invoice is deleted, then order vs invoice relation must be deleted
     * def query = 'purchaseOrderId==' + orderId + ' AND invoiceId==' + invoiceId
     * print query
 
+    * configure headers = headersAdmin
     Given path 'orders-storage/order-invoice-relns'
-    And headers headersAdmin
     And param query = query
     When method GET
     Then status 200
@@ -127,11 +134,13 @@ Feature: When invoice is deleted, then order vs invoice relation must be deleted
       | orderId    | invoiceId | count |
       | orderIdOne | invoiceId | 1     |
 
+
   Scenario: Delete invoice
     Given path 'invoice/invoices', invoiceId
     And request
     When method DELETE
     Then status 204
+
 
   Scenario Outline: Check that order invoice relation has been deleted
     * def orderId = <orderId>
@@ -139,8 +148,8 @@ Feature: When invoice is deleted, then order vs invoice relation must be deleted
     * def query = 'purchaseOrderId==' + orderId + ' AND invoiceId==' + invoiceId
     * print query
 
+    * configure headers = headersAdmin
     Given path 'orders-storage/order-invoice-relns'
-    And headers headersAdmin
     And param query = query
     When method GET
     Then status 200
@@ -148,6 +157,7 @@ Feature: When invoice is deleted, then order vs invoice relation must be deleted
     Examples:
       | orderId    | invoiceId | count |
       | orderIdOne | invoiceId | 0     |
+
 
   Scenario: Delete order lines
     Given path 'orders/order-lines', orderLineIdOne

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/order-invoice-relation.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/order-invoice-relation.feature
@@ -1,14 +1,18 @@
+@parallel=false
 Feature: Test order invoice relation logic
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-#    * callonce dev {tenant: 'testcrossmodules'}
+
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
-    # load global variables
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def orderId = callonce uuid1
@@ -125,8 +129,8 @@ Feature: Test order invoice relation logic
     * def invoiceId = <invoiceId>
     * def query = 'purchaseOrderId==' + orderId + ' AND invoiceId==' + invoiceId
     * print query
+    * configure headers = headersAdmin
     Given path 'orders-storage/order-invoice-relns'
-    And headers headersAdmin
     And param query = query
     When method GET
     Then status 200
@@ -152,8 +156,8 @@ Feature: Test order invoice relation logic
     * def invoiceId = <invoiceId>
     * def query = 'purchaseOrderId==' + orderId + ' AND invoiceId==' + invoiceId
     * print query
+    * configure headers = headersAdmin
     Given path 'orders-storage/order-invoice-relns'
-    And headers headersAdmin
     And param query = query
     When method GET
     Then status 200
@@ -174,8 +178,8 @@ Feature: Test order invoice relation logic
     * def invoiceId = <invoiceId>
     * def query = 'purchaseOrderId==' + orderId + ' AND invoiceId==' + invoiceId
     * print query
+    * configure headers = headersAdmin
     Given path 'orders-storage/order-invoice-relns'
-    And headers headersAdmin
     And param query = query
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/partial-rollover.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/partial-rollover.feature
@@ -4,12 +4,11 @@ Feature: Partial rollover
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
     * def fromYear = callonce getCurrentYear
@@ -26,11 +25,6 @@ Feature: Partial rollover
     * def poLineId2 = callonce uuid10
     * def rolloverId = callonce uuid11
 
-    * def createFiscalYear = read('classpath:thunderjet/mod-finance/reusable/createFiscalYear.feature')
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
-
 
   Scenario: Create fiscal years and associated ledgers
     * def periodStart1 = fromYear + '-01-01T00:00:00Z'
@@ -43,7 +37,6 @@ Feature: Partial rollover
 
 
   Scenario: Create fund and budgets
-    * configure headers = headersAdmin
     * def v = call createFund { id: #(fundId), code: #(fundId), ledgerId: #(ledgerId) }
     * def v = call createBudget { id: #(budgetId1), fundId: #(fundId), fiscalYearId: #(fyId1), allocated: 1000, status: 'Active' }
     * def v = call createBudget { id: #(budgetId2), fundId: #(fundId), fiscalYearId: #(fyId2), allocated: 1000, status: 'Active' }

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/pay-invoice-and-delete-piece.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/pay-invoice-and-delete-piece.feature
@@ -3,12 +3,11 @@ Feature: Pay an invoice and delete a piece
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/pay-invoice-with-new-expense-class.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/pay-invoice-with-new-expense-class.feature
@@ -3,11 +3,12 @@
 Feature: Pay invoice with new expense class
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -24,8 +25,7 @@ Feature: Pay invoice with new expense class
 
 
   Scenario: Create finances
-    * configure headers = headersAdmin
-    * call createFund { 'id': '#(fundId)'}
+    * call createFund { 'id': '#(fundId)' }
     * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)', 'status': 'Active' }
 
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/pay-invoice-without-order-acq-unit-permission.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/pay-invoice-without-order-acq-unit-permission.feature
@@ -4,22 +4,17 @@ Feature: Pay invoice without order acq unit permission
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
+
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
-
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
-    * def createInvoice = read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature')
-    * def createInvoiceLine = read('classpath:thunderjet/mod-invoice/reusable/create-invoice-line.feature')
-    * def approveInvoice = read('classpath:thunderjet/mod-invoice/reusable/approve-invoice.feature')
-    * def payInvoice = read('classpath:thunderjet/mod-invoice/reusable/pay-invoice.feature')
 
     * def fundId = callonce uuid1
     * def budgetId = callonce uuid2
@@ -32,7 +27,6 @@ Feature: Pay invoice without order acq unit permission
 
 
   Scenario: Prepare finances
-    * configure headers = headersAdmin
     * def v = call createFund { id: '#(fundId)' }
     * def v = call createBudget { id: '#(budgetId)', allocated: 1000, fundId: '#(fundId)', status: 'Active' }
 
@@ -57,8 +51,8 @@ Feature: Pay invoice without order acq unit permission
 
   Scenario: Create acq unit membership
     * configure headers = headersAdmin
-    * def result = call read('classpath:common/eureka/users.feature') {user: '#(testAdmin)'}
-    * def userIdForMembership = result.userId
+    * def res = callonce getUserIdByUsername { user: '#(testUser)' }
+    * def userIdForMembership = res.userId
     Given path 'acquisitions-units/memberships'
     And request
     """

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/pending-payment-update-after-encumbrance-deletion.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/pending-payment-update-after-encumbrance-deletion.feature
@@ -5,21 +5,12 @@ Feature: Pending payment update after encumbrance deletion
   Background:
     * print karate.info.scenarioName
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
-
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
-    * def unopenOrder = read('classpath:thunderjet/mod-orders/reusable/unopen-order.feature')
-    * def createInvoice = read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature')
-    * def createInvoiceLine = read('classpath:thunderjet/mod-invoice/reusable/create-invoice-line.feature')
-    * def approveInvoice = read('classpath:thunderjet/mod-invoice/reusable/approve-invoice.feature')
-    * def cancelInvoice = read('classpath:thunderjet/mod-invoice/reusable/cancel-invoice.feature')
 
 
   Scenario: Check update to pending payment after deleting an encumbrance for an open order
@@ -31,7 +22,6 @@ Feature: Pending payment update after encumbrance deletion
     * def invoiceLineId = call uuid
 
     * print "Create finances"
-    * configure headers = headersAdmin
     * call createFund { id: "#(fundId)" }
     * call createBudget { id: "#(budgetId)", allocated: 10000, fundId: "#(fundId)", status: "Active" }
 
@@ -108,7 +98,6 @@ Feature: Pending payment update after encumbrance deletion
     * def invoiceLineId = call uuid
 
     * print "Create finances"
-    * configure headers = headersAdmin
     * call createFund { id: "#(fundId)" }
     * call createBudget { id: "#(budgetId)", allocated: 10000, fundId: "#(fundId)", status: "Active" }
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/remove-fund-distribution-after-rollover-when-re-encumber-false.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/remove-fund-distribution-after-rollover-when-re-encumber-false.feature
@@ -4,21 +4,13 @@ Feature: Remove fund distribution after rollover from open order with re-encumbe
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
-
-    * def createFiscalYear = read('classpath:thunderjet/mod-finance/reusable/createFiscalYear.feature')
-    * def createLedger = read('classpath:thunderjet/mod-finance/reusable/createLedger.feature')
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
-    * def getOrderLine = read('classpath:thunderjet/mod-orders/reusable/get-order-line.feature')
 
     * def fromFiscalYearId = callonce uuid1
     * def toFiscalYearId = callonce uuid2
@@ -35,8 +27,8 @@ Feature: Remove fund distribution after rollover from open order with re-encumbe
 
     * configure retry = { count: 10, interval: 5000 }
 
+
   Scenario Outline: Prepare fiscal year with <fiscalYearId> for rollover
-    * configure headers = headersAdmin
     * def fiscalYearId = <fiscalYearId>
     * def code = <code>
     * def periodStart = code + '-01-01T00:00:00Z'
@@ -51,7 +43,6 @@ Feature: Remove fund distribution after rollover from open order with re-encumbe
 
 
   Scenario: Prepare finances
-    * configure headers = headersAdmin
     * def v = call createLedger { id: #(ledgerId), fiscalYearId: #(fromFiscalYearId) }
     * def v = call createFund { id: #(fundId),  ledgerId: #(ledgerId) }
     * def v = call createBudget { id: #(budgetId), fundId: #(fundId), fiscalYearId: #(fromFiscalYearId), allocated: 100 }
@@ -149,9 +140,7 @@ Feature: Remove fund distribution after rollover from open order with re-encumbe
 
 
   Scenario: Check encumbrance after rollover
-    * configure headers = headersAdmin
-
-    Given path 'finance-storage/transactions'
+    Given path 'finance/transactions'
     And param query = 'fromFundId==' + fundId + ' AND fiscalYearId==' + toFiscalYearId + ' AND encumbrance.sourcePurchaseOrderId==' + orderId
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/rollover-and-pay-invoice-using-past-fiscal-year.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/rollover-and-pay-invoice-using-past-fiscal-year.feature
@@ -2,11 +2,12 @@
 Feature: Rollover and pay invoice using past fiscal year
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
@@ -60,7 +61,6 @@ Feature: Rollover and pay invoice using past fiscal year
     * def v = call createLedger { id: '#(ledgerId)', fiscalYearId: '#(fiscalYearId1)' }
 
     ### 2. Create fund and budgets
-    * configure headers = headersAdmin
     * def v = call createFund { id: '#(fundId)', code: '#(fundId)', ledgerId: '#(ledgerId)' }
     * table budgets
       | id        | fundId | fiscalYearId  | allocated | status   |
@@ -224,7 +224,6 @@ Feature: Rollover and pay invoice using past fiscal year
   @ignore @CheckPendingPaymentsWereCreatedInPastFiscalYear
   Scenario: Check pending payments were created in past fiscal year
     Given path 'finance/transactions'
-    And headers headersAdmin
     And param query = 'sourceInvoiceLineId==' + invoiceLineId + ' And transactionType==Pending payment'
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/rollover-with-no-settings.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/rollover-with-no-settings.feature
@@ -4,14 +4,13 @@ Feature: Rollover with no settings
   Background:
     * print karate.info.scenarioName
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
 
-    * def createFiscalYear = read('classpath:thunderjet/mod-finance/reusable/createFiscalYear.feature')
     * def validateOrderLineEncumbranceLinks = read('classpath:thunderjet/mod-orders/reusable/validate-order-line-encumbrance-links.feature')
 
   @Positive
@@ -50,7 +49,6 @@ Feature: Rollover with no settings
     * def v = call createLedger { id: '#(ledgerId)', fiscalYearId: '#(fiscalYearId1)' }
 
     ### 2. Create fund and budgets
-    * configure headers = headersAdmin
     * def v = call createFund { id: '#(fundId)', code: '#(fundId)', ledgerId: '#(ledgerId)' }
     * def v = call createBudget { id: '#(budgetId1)', fundId: '#(fundId)', fiscalYearId: '#(fiscalYearId1)', allocated: 1000, status: 'Active' }
     * def v = call createBudget { id: '#(budgetId2)', fundId: '#(fundId)', fiscalYearId: '#(fiscalYearId2)', allocated: 1000, status: 'Active' }

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/rollover-with-pending-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/rollover-with-pending-order.feature
@@ -3,12 +3,11 @@
 
     Background:
       * print karate.info.scenarioName
-
       * url baseUrl
-      * callonce login testAdmin
-      * def okapitokenAdmin = okapitoken
-      * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-      * configure headers = headersAdmin
+
+      * callonce login testUser
+      * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+      * configure headers = headersUser
 
       * callonce variables
 
@@ -40,7 +39,6 @@
 
 
       ## Create fund and budgets
-      * configure headers = headersAdmin
       * def v = call createFund { id: '#(fundId)', code: '#(fundId)', ledgerId: '#(ledgerId)' }
       * def v = call createBudget { id: '#(budgetId1)', fundId: '#(fundId)', fiscalYearId: '#(fyId1)', allocated: 100, status: 'Active' }
       * def v = call createBudget { id: '#(budgetId2)', fundId: '#(fundId)', fiscalYearId: '#(fyId2)', allocated: 100, status: 'Active' }

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/unopen-approve-invoice-reopen.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/unopen-approve-invoice-reopen.feature
@@ -4,20 +4,13 @@ Feature: Unopen order, approve invoice and reopen
 
   Background:
     * print karate.info.scenarioName
-
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
-
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-audit-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
-    * def createInvoice = read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature')
-    * def approveInvoice = read('classpath:thunderjet/mod-invoice/reusable/approve-invoice.feature')
 
     * def invoiceLineTemplate = read('classpath:samples/mod-invoice/invoices/global/invoice-line-percentage.json')
 
@@ -30,7 +23,6 @@ Feature: Unopen order, approve invoice and reopen
 
 
   Scenario: Prepare finances
-    * configure headers = headersAdmin
     * def v = call createFund { id: #(fundId) }
     * def v = call createBudget { id: #(budgetId), fundId: #(fundId), allocated: 1000 }
 

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/unopen-order-and-add-addition-pol-and-check-encumbrances.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/unopen-order-and-add-addition-pol-and-check-encumbrances.feature
@@ -1,19 +1,20 @@
+@parallel=false
 Feature: UnOpen order and add addition POL and 1 Fund. Also verify encumbrances
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-    #* callonce dev {tenant: 'testcrossmodules'}
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
-    # load global variables
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def orderId = callonce uuid1
     * def orderLineIdOne = callonce uuid2
     * def unOpenOrderLineId = callonce uuid3
+
 
   Scenario: Create orders
     Given path 'orders/composite-orders'
@@ -27,6 +28,7 @@ Feature: UnOpen order and add addition POL and 1 Fund. Also verify encumbrances
     """
     When method POST
     Then status 201
+
 
   Scenario Outline: Create order lines for <orderLineId>
     * def orderId = <orderId>
@@ -43,6 +45,7 @@ Feature: UnOpen order and add addition POL and 1 Fund. Also verify encumbrances
       | orderId | orderLineId    |
       | orderId | orderLineIdOne |
 
+
   Scenario: Open order
     # ============= get order to open ===================
     Given path 'orders/composite-orders', orderId
@@ -58,6 +61,7 @@ Feature: UnOpen order and add addition POL and 1 Fund. Also verify encumbrances
     When method PUT
     Then status 204
 
+
   Scenario: Check that order status Open in encumbrance after Open order
     Given path 'finance/transactions'
     And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId
@@ -69,6 +73,7 @@ Feature: UnOpen order and add addition POL and 1 Fund. Also verify encumbrances
     And match transaction.encumbrance.initialAmountEncumbered == 1.0
     And match transaction.encumbrance.status == 'Unreleased'
     And match transaction.encumbrance.orderStatus == 'Open'
+
 
   Scenario: UnOpen order
     # ============= get order to open ===================
@@ -85,6 +90,7 @@ Feature: UnOpen order and add addition POL and 1 Fund. Also verify encumbrances
     When method PUT
     Then status 204
 
+
   Scenario: Check order workflow status is Pending after UnOpen
     # ============= get order to open ===================
     Given path 'orders/composite-orders', orderId
@@ -92,6 +98,7 @@ Feature: UnOpen order and add addition POL and 1 Fund. Also verify encumbrances
     Then status 200
     * def orderResponse = $
     And match orderResponse.workflowStatus == "Pending"
+
 
   Scenario: Check that order status Pending in encumbrance after UnOpen order
     Given path 'finance/transactions'
@@ -123,6 +130,7 @@ Feature: UnOpen order and add addition POL and 1 Fund. Also verify encumbrances
       | orderId | unOpenOrderLineId |
       | orderId | unOpenOrderLineId |
 
+
   Scenario: ReOpen order
     # ============= get order to open ===================
     Given path 'orders/composite-orders', orderId
@@ -138,6 +146,7 @@ Feature: UnOpen order and add addition POL and 1 Fund. Also verify encumbrances
     When method PUT
     Then status 204
 
+
   Scenario: Check order after ReOpen
     # ============= get order to open ===================
     Given path 'orders/composite-orders', orderId
@@ -145,6 +154,7 @@ Feature: UnOpen order and add addition POL and 1 Fund. Also verify encumbrances
     Then status 200
     * def orderResponse = $
     * set orderResponse.workflowStatus = "Open"
+
 
   Scenario: Check that order status Open in encumbrance after ReOpen order
     Given path 'finance/transactions'

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/unopen-order-simple-case.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/unopen-order-simple-case.feature
@@ -1,18 +1,19 @@
+@parallel=false
 Feature: Unpopen order with one line and check encumbrance
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    # uncomment below line for development
-    #* callonce dev {tenant: 'testcrossmodules'}
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
-    # load global variables
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
     * callonce variables
 
     * def orderId = callonce uuid1
     * def orderLineIdOne = callonce uuid2
+
 
   Scenario: Create orders
     Given path 'orders/composite-orders'
@@ -26,6 +27,7 @@ Feature: Unpopen order with one line and check encumbrance
     """
     When method POST
     Then status 201
+
 
   Scenario Outline: Create order lines for <orderLineId>
     * def orderId = <orderId>
@@ -42,6 +44,7 @@ Feature: Unpopen order with one line and check encumbrance
       | orderId | orderLineId    |
       | orderId | orderLineIdOne |
 
+
   Scenario: Open order
     # ============= get order to open ===================
     Given path 'orders/composite-orders', orderId
@@ -57,6 +60,7 @@ Feature: Unpopen order with one line and check encumbrance
     When method PUT
     Then status 204
 
+
   Scenario: Check that order status Open in encumbrance after Open order
     Given path 'finance/transactions'
     And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId
@@ -68,6 +72,7 @@ Feature: Unpopen order with one line and check encumbrance
     And match transaction.encumbrance.initialAmountEncumbered == 1.0
     And match transaction.encumbrance.status == 'Unreleased'
     And match transaction.encumbrance.orderStatus == 'Open'
+
 
   Scenario: UnOpen order
     # ============= get order to open ===================
@@ -84,6 +89,7 @@ Feature: Unpopen order with one line and check encumbrance
     When method PUT
     Then status 204
 
+
   Scenario: Check order workflow status is Pending after UnOpen
     # ============= get order to open ===================
     Given path 'orders/composite-orders', orderId
@@ -91,6 +97,7 @@ Feature: Unpopen order with one line and check encumbrance
     Then status 200
     * def orderResponse = $
     And match orderResponse.workflowStatus == "Pending"
+
 
   Scenario: Check that order status Pending in encumbrance after UnOpen order
     Given path 'finance/transactions'

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/update-encumbrance-links-with-fiscal-year.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/update-encumbrance-links-with-fiscal-year.feature
@@ -5,20 +5,12 @@ Feature: Update encumbrance links with fiscal year
   Background:
     * print karate.info.scenarioName
     * url baseUrl
-    * callonce login testAdmin
-    * def okapitokenAdmin = okapitoken
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant':'#(testTenant)' }
-    * configure headers = headersAdmin
+
+    * callonce login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
     * callonce variables
-
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-audit-order-line.feature')
-    * def openOrder = read('classpath:thunderjet/mod-orders/reusable/open-order.feature')
-    * def createInvoice = read('classpath:thunderjet/mod-invoice/reusable/create-invoice.feature')
-    * def createInvoiceLine = read('classpath:thunderjet/mod-invoice/reusable/create-invoice-line.feature')
-    * def createFiscalYear = read('classpath:thunderjet/mod-finance/reusable/createFiscalYear.feature')
-    * def createTransaction = read('classpath:thunderjet/mod-finance/reusable/createTransaction.feature')
 
     * def currentYear = callonce getCurrentYear
     * def currentStart = currentYear + '-01-01T00:00:00Z'
@@ -32,7 +24,6 @@ Feature: Update encumbrance links with fiscal year
 
 
   Scenario: Create finances
-    * configure headers = headersAdmin
     * def v = call createFiscalYear { id: #(pastFiscalYearId), code: 'INVTEST2020', periodStart: '2020-01-01T00:00:00Z', periodEnd: '2020-12-30T23:59:59Z', series: 'INVTEST' }
     * def v = call createFiscalYear { id: #(currentFiscalYearId), code: #('INVTEST' + currentYear), periodStart: #(currentStart), periodEnd: #(currentEnd), series: 'INVTEST' }
     * def v = call createLedger { id: #(ledgerId), fiscalYearId: #(pastFiscalYearId), restrictEncumbrance: false, restrictExpenditures: false }
@@ -61,7 +52,6 @@ Feature: Update encumbrance links with fiscal year
     * def currentEncumbranceId = poLine.fundDistribution[0].encumbrance
 
     * print "Create the past encumbrance"
-    * configure headers = headersAdmin
     * def v = call createTransaction { id: #(pastEncumbranceId), transactionType: 'Encumbrance', fiscalYearId: #(pastFiscalYearId), fundId: #(fundId), amount: 10.0, orderId: #(orderId), poLineId: #(poLineId) }
 
     * print "Create an invoice in the past fiscal year"
@@ -105,7 +95,6 @@ Feature: Update encumbrance links with fiscal year
     * def currentEncumbranceId2 = poLine.fundDistribution[0].encumbrance
 
     * print "Create one past encumbrance"
-    * configure headers = headersAdmin
     * def v = call createTransaction { id: #(pastEncumbranceId), transactionType: 'Encumbrance', fiscalYearId: #(pastFiscalYearId), fundId: #(fundId), amount: 10.0, orderId: #(orderId), poLineId: #(poLineId1) }
 
     * print "Create an invoice in the current fiscal year"

--- a/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/data-export-spring-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/data-export-spring-junit.feature
@@ -1,3 +1,4 @@
+@parallel=false
 Feature: mod-data-export-spring integration tests
 
   Background:
@@ -37,21 +38,14 @@ Feature: mod-data-export-spring integration tests
       | 'finance.fiscal-years.item.post'                              |
       | 'finance.fiscal-years.item.put'                               |
       | 'finance.fiscal-years.item.get'                               |
-      | 'finance.ledger-rollovers.item.post'                          |
-      | 'finance.ledger-rollovers-logs.item.get'                      |
-      | 'finance.ledger-rollovers-errors.collection.get'              |
-      | 'finance.ledger-rollovers-progress.collection.get'            |
       | 'finance.ledgers.item.post'                                   |
-      | 'finance.release-encumbrance.item.post'                       |
       | 'finance.transactions.batch.execute'                          |
       | 'finance.transactions.item.get'                               |
       | 'finance.transactions.collection.get'                         |
       | 'finance.fund-types.item.post'                                |
       | 'finance.funds.item.get'                                      |
-      | 'finance-storage.funds.item.post'                             |
-      | 'finance-storage.ledgers.item.post'                           |
-      | 'finance-storage.transactions.batch.execute'                  |
-      | 'finance-storage.transactions.collection.get'                 |
+      | 'finance.funds.item.post'                                     |
+      | 'finance.funds.item.put'                                      |
       | 'inventory-storage.contributor-name-types.item.post'          |
       | 'inventory-storage.electronic-access-relationships.item.post' |
       | 'inventory-storage.holdings-sources.item.post'                |
@@ -67,21 +61,6 @@ Feature: mod-data-export-spring integration tests
       | 'inventory-storage.material-types.item.post'                  |
       | 'inventory-storage.service-points.item.post'                  |
       | 'inventory.instances.item.post'                               |
-      | 'invoice.invoice-lines.collection.get'                        |
-      | 'invoice.invoice-lines.item.delete'                           |
-      | 'invoice.invoice-lines.item.get'                              |
-      | 'invoice.invoice-lines.item.post'                             |
-      | 'invoice.invoice-lines.item.put'                              |
-      | 'invoice.invoices.item.delete'                                |
-      | 'invoice.invoices.item.get'                                   |
-      | 'invoice.invoices.item.post'                                  |
-      | 'invoice.invoices.item.put'                                   |
-      | 'invoice.item.approve.execute'                                |
-      | 'invoice.item.cancel.execute'                                 |
-      | 'invoice.item.pay.execute'                                    |
-      | 'invoices.fiscal-year.update.execute'                         |
-      | 'invoice-storage.invoices.item.get'                           |
-      | 'invoice-storage.invoices.item.put'                           |
       | 'orders.check-in.collection.post'                             |
       | 'orders.collection.get'                                       |
       | 'orders.item.approve'                                         |
@@ -100,10 +79,9 @@ Feature: mod-data-export-spring integration tests
       | 'orders-storage.order-invoice-relationships.collection.get'   |
       | 'orders-storage.po-lines.item.get'                            |
       | 'orders-storage.po-lines.item.put'                            |
-      | 'organizations-storage.organizations.item.post'               |
+      | 'organizations.organizations.item.post'                       |
       | 'voucher.vouchers.collection.get'                             |
       | 'orders.pieces.item.delete'                                   |
-      | 'finance.funds.item.put'                                      |
       | 'perms.users.get'                                             |
       | 'perms.users.item.put'                                        |
       | 'data-export.config.collection.get'                           |

--- a/acquisitions/src/main/resources/thunderjet/mod-ebsconet/ebsconet-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-ebsconet/ebsconet-junit.feature
@@ -29,14 +29,6 @@ Feature: mod-ebsconet integration tests
       | 'acquisitions-units.memberships.item.post'                    |
       | 'acquisitions-units.units.item.post'                          |
       | 'configuration.entries.item.post'                             |
-      | 'data-export.config.collection.get'                           |
-      | 'data-export.config.item.delete'                              |
-      | 'data-export.config.item.get'                                 |
-      | 'data-export.config.item.post'                                |
-      | 'data-export.config.item.put'                                 |
-      | 'data-export.job.collection.get'                              |
-      | 'data-export.job.item.download'                               |
-      | 'data-export.job.item.resend'                                 |
       | 'ebsconet.order-lines.item.get'                               |
       | 'ebsconet.order-lines.item.put'                               |
       | 'finance.budgets.collection.get'                              |
@@ -50,20 +42,12 @@ Feature: mod-ebsconet integration tests
       | 'finance.fiscal-years.item.put'                               |
       | 'finance.fund-types.item.post'                                |
       | 'finance.funds.item.get'                                      |
+      | 'finance.funds.item.post'                                     |
       | 'finance.funds.item.put'                                      |
-      | 'finance.ledger-rollovers-errors.collection.get'              |
-      | 'finance.ledger-rollovers-logs.item.get'                      |
-      | 'finance.ledger-rollovers-progress.collection.get'            |
-      | 'finance.ledger-rollovers.item.post'                          |
       | 'finance.ledgers.item.post'                                   |
-      | 'finance.release-encumbrance.item.post'                       |
       | 'finance.transactions.batch.execute'                          |
       | 'finance.transactions.collection.get'                         |
       | 'finance.transactions.item.get'                               |
-      | 'finance-storage.funds.item.post'                             |
-      | 'finance-storage.ledgers.item.post'                           |
-      | 'finance-storage.transactions.batch.execute'                  |
-      | 'finance-storage.transactions.collection.get'                 |
       | 'inventory-storage.contributor-name-types.item.post'          |
       | 'inventory-storage.electronic-access-relationships.item.post' |
       | 'inventory-storage.holdings-sources.item.post'                |
@@ -79,21 +63,6 @@ Feature: mod-ebsconet integration tests
       | 'inventory-storage.material-types.item.post'                  |
       | 'inventory-storage.service-points.item.post'                  |
       | 'inventory.instances.item.post'                               |
-      | 'invoice.invoice-lines.collection.get'                        |
-      | 'invoice.invoice-lines.item.delete'                           |
-      | 'invoice.invoice-lines.item.get'                              |
-      | 'invoice.invoice-lines.item.post'                             |
-      | 'invoice.invoice-lines.item.put'                              |
-      | 'invoice.invoices.item.delete'                                |
-      | 'invoice.invoices.item.get'                                   |
-      | 'invoice.invoices.item.post'                                  |
-      | 'invoice.invoices.item.put'                                   |
-      | 'invoice.item.approve.execute'                                |
-      | 'invoice.item.cancel.execute'                                 |
-      | 'invoice.item.pay.execute'                                    |
-      | 'invoice-storage.invoices.item.get'                           |
-      | 'invoice-storage.invoices.item.put'                           |
-      | 'invoices.fiscal-year.update.execute'                         |
       | 'orders.check-in.collection.post'                             |
       | 'orders.collection.get'                                       |
       | 'orders.item.approve'                                         |
@@ -117,11 +86,9 @@ Feature: mod-ebsconet integration tests
       | 'organizations.organizations.item.get'                        |
       | 'organizations.organizations.item.post'                       |
       | 'organizations.organizations.item.put'                        |
-      | 'organizations-storage.organizations.item.post'               |
       | 'perms.users.get'                                             |
       | 'perms.users.item.put'                                        |
       | 'pieces.send-claims.collection.post'                          |
-      | 'voucher.vouchers.collection.get'                             |
 
   Scenario: create tenant and users for testing
     * def testUser = testAdmin

--- a/acquisitions/src/main/resources/thunderjet/mod-gobi/gobi-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-gobi/gobi-junit.feature
@@ -1,7 +1,10 @@
+@parallel=false
 Feature: mod-gobi integration tests
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
+
     * table modules
       | name                        |
       | 'mod-permissions'           |
@@ -30,51 +33,21 @@ Feature: mod-gobi integration tests
 
     * table userPermissions
       | name                                                          |
-      | 'acquisitions-units.memberships.item.delete'                  |
-      | 'acquisitions-units.memberships.item.post'                    |
-      | 'acquisitions-units.units.item.post'                          |
       | 'configuration.entries.collection.get'                        |
       | 'configuration.entries.item.delete'                           |
       | 'configuration.entries.item.post'                             |
       | 'configuration.entries.item.put'                              |
-      | 'finance.budgets-expense-classes-totals.collection.get'       |
-      | 'finance.budgets.collection.get'                              |
-      | 'finance.budgets.item.delete'                                 |
-      | 'finance.budgets.item.get'                                    |
       | 'finance.budgets.item.post'                                   |
-      | 'finance.budgets.item.put'                                    |
-      | 'finance.finance-data.collection.get'                         |
-      | 'finance.finance-data.collection.put'                         |
-      | 'finance.fiscal-years.item.delete'                            |
-      | 'finance.fiscal-years.item.get'                               |
+      | 'finance.expense-classes.item.post'                           |
       | 'finance.fiscal-years.item.post'                              |
-      | 'finance.fiscal-years.item.put'                               |
       | 'finance.fund-types.item.post'                                |
-      | 'finance.funds.budget.item.get'                               |
       | 'finance.funds.collection.get'                                |
-      | 'finance.funds.item.get'                                      |
-      | 'finance.funds.item.put'                                      |
-      | 'finance.group-fiscal-year-summaries.collection.get'          |
-      | 'finance.group-fund-fiscal-years.item.post'                   |
-      | 'finance.groups-expense-classes-totals.collection.get'        |
+      | 'finance.funds.item.post'                                     |
       | 'finance.groups.item.post'                                    |
-      | 'finance.ledger-rollovers-budgets.collection.get'             |
-      | 'finance.ledger-rollovers-budgets.item.get'                   |
-      | 'finance.ledger-rollovers-errors.collection.get'              |
-      | 'finance.ledger-rollovers-logs.collection.get'                |
-      | 'finance.ledger-rollovers-logs.item.get'                      |
-      | 'finance.ledger-rollovers-progress.collection.get'            |
-      | 'finance.ledger-rollovers-progress.item.put'                  |
       | 'finance.ledger-rollovers.item.post'                          |
-      | 'finance.ledgers.collection.get'                              |
-      | 'finance.ledgers.current-fiscal-year.item.get'                |
-      | 'finance.ledgers.item.delete'                                 |
-      | 'finance.ledgers.item.get'                                    |
       | 'finance.ledgers.item.post'                                   |
       | 'finance.release-encumbrance.item.post'                       |
       | 'finance.transactions.batch.execute'                          |
-      | 'finance.transactions.collection.get'                         |
-      | 'finance.transactions.item.get'                               |
       | 'gobi.custom-mappings.collection.get'                         |
       | 'gobi.custom-mappings.item.delete'                            |
       | 'gobi.custom-mappings.item.get'                               |
@@ -86,7 +59,6 @@ Feature: mod-gobi integration tests
       | 'inventory-storage.contributor-name-types.item.post'          |
       | 'inventory-storage.electronic-access-relationships.item.post' |
       | 'inventory-storage.holdings-sources.item.post'                |
-      | 'inventory-storage.holdings.collection.get'                   |
       | 'inventory-storage.holdings.item.post'                        |
       | 'inventory-storage.identifier-types.item.post'                |
       | 'inventory-storage.instance-statuses.item.post'               |
@@ -99,19 +71,9 @@ Feature: mod-gobi integration tests
       | 'inventory-storage.material-types.item.post'                  |
       | 'inventory-storage.service-points.item.post'                  |
       | 'inventory.instances.item.post'                               |
-      | 'invoice.invoice-lines.item.post'                             |
-      | 'invoice.invoices.item.get'                                   |
-      | 'invoice.invoices.item.post'                                  |
-      | 'invoice.invoices.item.put'                                   |
-      | 'organizations-storage.organizations.item.post'               |
-      | 'organizations.organizations.item.get'                        |
       | 'organizations.organizations.item.post'                       |
-      | 'organizations.organizations.item.put'                        |
       | 'orders.collection.get'                                       |
       | 'orders.po-lines.collection.get'                              |
-      | 'finance-storage.ledgers.item.post'                           |
-      | 'finance.expense-classes.item.post'                           |
-      | 'finance-storage.funds.item.post'                             |
 
 
     # Test tenant name creation:
@@ -125,7 +87,7 @@ Feature: mod-gobi integration tests
     * def testUser = testAdmin
     * call read('classpath:common/eureka/setup-users.feature')
 
-  Scenario: init global data
+  Scenario: Init global data
     * call login testAdmin
     * callonce variables
 

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/invoice-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/invoice-junit.feature
@@ -1,3 +1,4 @@
+@parallel=false
 Feature: mod-invoice integration tests
 
   Background:

--- a/acquisitions/src/main/resources/thunderjet/mod-organizations/features/acquisitions-api-tests.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-organizations/features/acquisitions-api-tests.feature
@@ -1,16 +1,18 @@
+@parallel=false
 Feature: Organizations API tests.
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
 
-    # uncomment below line for development
-    #* callonce dev {tenant: 'testmodorgs'}
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
-
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)'  }
-
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
     * configure headers = headersAdmin
+
     * callonce variables
 
     * def readOnlyAcqUnitId = callonce uuid1
@@ -24,6 +26,7 @@ Feature: Organizations API tests.
     * def v = callonce createAcqUnit acqUnitsData
 
 
+    * configure headers = headersUser
     * def noAcqOrganizationId = callonce uuid4
     * def readOnlyOrganizationId = callonce uuid5
     * def updateOnlyOrganizationId = callonce uuid6
@@ -36,6 +39,7 @@ Feature: Organizations API tests.
       | updateOnlyOrganizationId    | 'UPDATE_ONLY_ORG'    | 'Active' | ['#(updateOnlyAcqUnitId)']    |
       | fullProtectedOrganizationId | 'FULL_PROTECTED_ORG' | 'Active' | ['#(fullProtectedAcqUnitId)'] |
     * def v = callonce createOrganization organizationsData
+
 
   @Positive
   Scenario: Get not protected org
@@ -68,7 +72,7 @@ Feature: Organizations API tests.
   Scenario: Assign user to read-open unit
     * configure headers = headersAdmin
     Given path '/users'
-    And param query = 'username=' + testAdmin.name
+    And param query = 'username=' + testUser.name
     When method GET
     Then status 200
     * def userId = $.users[0].id
@@ -116,7 +120,7 @@ Feature: Organizations API tests.
   Scenario: Assign user to read-open unit
     * configure headers = headersAdmin
     Given path '/users'
-    And param query = 'username=' + testAdmin.name
+    And param query = 'username=' + testUser.name
     When method GET
     Then status 200
     * def userId = $.users[0].id
@@ -136,7 +140,7 @@ Feature: Organizations API tests.
   Scenario: Assign user to full-protected unit
     * configure headers = headersAdmin
     Given path '/users'
-    And param query = 'username=' + testAdmin.name
+    And param query = 'username=' + testUser.name
     When method GET
     Then status 200
     * def userId = $.users[0].id

--- a/acquisitions/src/main/resources/thunderjet/mod-organizations/features/audit-event-organization.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-organizations/features/audit-event-organization.feature
@@ -4,12 +4,15 @@ Feature: Audit events for Organization
   Background:
     * print karate.info.scenarioName
     * url baseUrl
+
     * callonce login testAdmin
     * def okapitokenAdmin = okapitoken
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
 
-    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)'  }
-
-    * configure headers = headersAdmin
     * configure retry = { count: 10, interval: 10000 }
 
     * callonce variables
@@ -62,6 +65,7 @@ Feature: Audit events for Organization
 
   @ignore @VerifyAuditEvents
   Scenario: Verify Audit Events
+    * configure headers = headersAdmin
     Given path '/audit-data/acquisition/organization', eventEntityId
     And retry until response.totalItems == eventCount
     When method GET
@@ -69,6 +73,7 @@ Feature: Audit events for Organization
     And match response.totalItems == eventCount
     And match response.organizationAuditEvents[*].action contains eventType
     And match response.organizationAuditEvents[*].organizationId contains eventEntityId
+    * configure headers = headersUser
 
   @ignore @UpdateOrganization
   Scenario: Update Organization

--- a/acquisitions/src/main/resources/thunderjet/mod-organizations/organizations-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-organizations/organizations-junit.feature
@@ -1,7 +1,10 @@
+@parallel=false
 Feature: mod-organizations integration tests
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
+
     * table modules
       | name                        |
       | 'mod-configuration'         |
@@ -15,119 +18,24 @@ Feature: mod-organizations integration tests
 
     * table userPermissions
       | name                                                        |
-      | 'acquisition.invoice.events.get'                            |
-      | 'acquisition.invoice-line.events.get'                       |
-      | 'acquisitions-units.memberships.item.delete'                |
-      | 'acquisitions-units.memberships.item.get'                   |
-      | 'acquisitions-units.memberships.item.post'                  |
-      | 'acquisitions-units.units.item.post'                        |
-      | 'acquisitions-units-storage.memberships.collection.get'     |
-      | 'acquisitions-units-storage.memberships.item.delete'        |
-      | 'acquisitions-units-storage.memberships.item.post'          |
-      | 'acquisitions-units-storage.memberships.item.put'           |
-      | 'acquisitions-units-storage.units.item.delete'              |
-      | 'acquisitions-units-storage.units.item.get'                 |
-      | 'acquisitions-units-storage.units.item.post'                |
-      | 'acquisitions-units-storage.units.item.put'                 |
-      | 'batch-groups.collection.get'                               |
-      | 'batch-groups.item.post'                                    |
-      | 'batch-voucher.batch-voucher-exports.item.get'              |
-      | 'batch-voucher.batch-voucher-exports.item.post'             |
-      | 'batch-voucher.batch-vouchers.item.get'                     |
-      | 'batch-voucher.export-configurations.credentials.item.post' |
-      | 'batch-voucher.export-configurations.item.post'             |
-      | 'configuration.entries.collection.get'                      |
-      | 'configuration.entries.item.delete'                         |
-      | 'configuration.entries.item.post'                           |
-      | 'configuration.entries.item.put'                            |
-      | 'finance.budgets-expense-classes-totals.collection.get'     |
-      | 'finance.budgets.collection.get'                            |
-      | 'finance.budgets.item.delete'                               |
-      | 'finance.budgets.item.get'                                  |
-      | 'finance.budgets.item.post'                                 |
-      | 'finance.budgets.item.put'                                  |
-      | 'finance.expense-classes.item.post'                         |
-      | 'finance.fiscal-years.item.delete'                          |
-      | 'finance.fiscal-years.item.get'                             |
-      | 'finance.fiscal-years.item.post'                            |
-      | 'finance.fiscal-years.item.put'                             |
-      | 'finance.fund-types.item.post'                              |
-      | 'finance.funds.budget.item.get'                             |
-      | 'finance.funds.collection.get'                              |
-      | 'finance.funds.item.get'                                    |
-      | 'finance.funds.item.put'                                    |
-      | 'finance.groups-expense-classes-totals.collection.get'      |
-      | 'finance.groups.item.post'                                  |
-      | 'finance.group-fiscal-year-summaries.collection.get'        |
-      | 'finance.group-fund-fiscal-years.item.post'                 |
-      | 'finance.ledger-rollovers-budgets.collection.get'           |
-      | 'finance.ledger-rollovers-budgets.item.get'                 |
-      | 'finance.ledger-rollovers-errors.collection.get'            |
-      | 'finance.ledger-rollovers-logs.collection.get'              |
-      | 'finance.ledger-rollovers-logs.item.get'                    |
-      | 'finance.ledger-rollovers-progress.collection.get'          |
-      | 'finance.ledger-rollovers-progress.item.put'                |
-      | 'finance.ledger-rollovers.item.post'                        |
-      | 'finance.ledgers.collection.get'                            |
-      | 'finance.ledgers.current-fiscal-year.item.get'              |
-      | 'finance.ledgers.item.delete'                               |
-      | 'finance.ledgers.item.get'                                  |
-      | 'finance.ledgers.item.post'                                 |
-      | 'finance.release-encumbrance.item.post'                     |
-      | 'finance.transactions.batch.execute'                        |
-      | 'finance.transactions.collection.get'                       |
-      | 'finance.transactions.item.get'                             |
-      | 'finance-storage.budget-expense-classes.collection.get'     |
-      | 'finance-storage.budget-expense-classes.item.post'          |
-      | 'finance-storage.budgets.item.get'                          |
-      | 'finance-storage.budgets.item.post'                         |
-      | 'finance-storage.funds.item.delete'                         |
-      | 'finance-storage.funds.item.post'                           |
-      | 'finance-storage.group-fund-fiscal-years.collection.get'    |
-      | 'finance-storage.group-fund-fiscal-years.item.post'         |
-      | 'finance-storage.ledger-rollovers-errors.collection.get'    |
-      | 'finance-storage.ledger-rollovers.item.delete'              |
-      | 'finance-storage.ledgers.item.post'                         |
-      | 'finance-storage.transactions.batch.execute'                |
-      | 'finance-storage.transactions.collection.get'               |
-      | 'invoice.invoices.collection.get'                           |
-      | 'invoice.invoices.documents.item.post'                      |
-      | 'invoice.invoices.fiscal-years.collection.get'              |
-      | 'invoice.invoices.item.delete'                              |
-      | 'invoice.invoices.item.get'                                 |
-      | 'invoice.invoices.item.post'                                |
-      | 'invoice.invoices.item.put'                                 |
-      | 'invoice.invoice-lines.collection.get'                      |
-      | 'invoice.invoice-lines.item.delete'                         |
-      | 'invoice.invoice-lines.item.get'                            |
-      | 'invoice.invoice-lines.item.post'                           |
-      | 'invoice.invoice-lines.item.put'                            |
-      | 'invoice.item.approve.execute'                              |
-      | 'invoice.item.cancel.execute'                               |
-      | 'invoice.item.pay.execute'                                  |
-      | 'inventory-storage.holdings.collection.get'                 |
-      | 'inventory-storage.instances.item.get'                      |
-      | 'inventory-storage.items.item.get'                          |
-      | 'inventory.instances.item.post'                             |
-      | 'organizations-storage.organizations.item.post'             |
+      | 'organizations.organizations.collection.get'                |
       | 'organizations.organizations.item.get'                      |
       | 'organizations.organizations.item.post'                     |
       | 'organizations.organizations.item.put'                      |
-      | 'orders-storage.claiming.process.execute'                   |
-      | 'orders-storage.titles.item.get'                            |
-      | 'orders.collection.get'                                     |
-      | 'orders.item.approve'                                       |
-      | 'orders.item.get'                                           |
-      | 'orders.item.post'                                          |
-      | 'orders.item.put'                                           |
-      | 'orders.item.reopen'                                        |
-      | 'orders.item.unopen'                                        |
-      | 'orders.po-lines.collection.get'                            |
-      | 'orders.po-lines.item.post'                                 |
-      | 'organizations.organizations.collection.get'                |
-      | 'users.collection.get'                                      |
+
+    * table adminPermissions
+      | name                                                        |
       | 'acquisition.organization.events.get'                       |
+      | 'acquisitions-units.memberships.item.get'                   |
+      | 'acquisitions-units.memberships.item.post'                  |
+      | 'acquisitions-units-storage.memberships.item.post'          |
+      | 'acquisitions-units-storage.memberships.item.put'           |
+      | 'acquisitions-units-storage.units.item.post'                |
+      | 'acquisitions-units.units.item.post'                        |
+      | 'users.collection.get'                                      |
 
   Scenario: Create tenant and users for testing
-    * def testUser = testAdmin
     * call read('classpath:common/eureka/setup-users.feature')
+
+  Scenario: Create admin user
+    * def v = call createAdditionalUser { testUser: '#(testAdmin)',  userPermissions: '#(adminPermissions)' }


### PR DESCRIPTION
## Purpose
[MODORDERS-1272](https://folio-org.atlassian.net/browse/MODORDERS-1272) - Run ACQ Karate tests on Eureka platform

## Approach
- Updated cross-module tests to use a test user and an admin user with different permissions. The test user has all non-storage permissions for mod-finance, mod-orders, mod-invoice and mod-organizations, the admin user has all the other permissions.
- Fixed other issues related to permissions in other modules, but without separating permissions yet
- Removed some unused permissions
- Removed some redundant prints (in cross-module tests)
- Removed function definitions already defined globally (in cross-module tests)

### TODOS
- mod-consortia and other remaining tests; currently mod-consortia tests do not run with eureka-cli, there is a login issue
- See if it's possible to use the non-junit feature files
