### PR TITLE
[MODORDERS-1272] Fixed users and permissions for consortia tests

### DIFF
--- a/acquisitions/src/main/resources/karate-config.js
+++ b/acquisitions/src/main/resources/karate-config.js
@@ -35,6 +35,7 @@ function fn() {
     login: karate.read('classpath:common/login.feature'),
     loginRegularUser: karate.read('classpath:common/login.feature'),
     loginAdmin: karate.read('classpath:common/login.feature'),
+    eurekaLogin: read('classpath:common-consortia/eureka/initData.feature@Login'),
     dev: karate.read('classpath:common/dev.feature'),
     variables: karate.read('classpath:global/variables.feature'),
 

--- a/acquisitions/src/main/resources/thunderjet/consortia/consortia-orders-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/consortia-orders-junit.feature
@@ -1,10 +1,14 @@
+@parallel=false
 Feature: mod-consortia integration tests
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
+
     * configure readTimeout = 600000
     * configure connectTimeout = 600000
 
+    # Permissions for consortiaAdmin and universityUser
     * table userPermissions
       | name                                                        |
       | 'circulation.rules.put'                                     |
@@ -23,7 +27,6 @@ Feature: mod-consortia integration tests
       | 'finance.fiscal-years.item.post'                            |
       | 'finance.funds.item.post'                                   |
       | 'finance.ledgers.item.post'                                 |
-      | 'finance-storage.funds.item.post'                           |
       | 'inventory-storage.holdings-sources.item.post'              |
       | 'inventory-storage.holdings.collection.get'                 |
       | 'inventory-storage.holdings.item.get'                       |
@@ -75,7 +78,6 @@ Feature: mod-consortia integration tests
       | 'orders.titles.item.post'                                   |
       | 'orders-storage.settings.item.post'                         |
       | 'organizations.organizations.item.post'                     |
-      | 'organizations-storage.organizations.item.post'             |
       | 'overdue-fines-policies.collection.get'                     |
       | 'overdue-fines-policies.item.post'                          |
       | 'perms.users.get'                                           |
@@ -95,26 +97,33 @@ Feature: mod-consortia integration tests
 
     # generate names for tenants
     * def random = callonce randomMillis
-    * def uuids = callonce uuids 6
+    * def uuids = callonce uuids 4
     * def centralTenantId = uuids[0]
     * def centralTenantName = 'central' + random
-    * def centralTenant = {id : '#(centralTenantId)', name: '#(centralTenantName)'}
+    * def centralTenant = { id : '#(centralTenantId)', name: '#(centralTenantName)' }
     * def universityTenantId = uuids[1]
     * def universityTenantName = 'university' + random
-    * def universityTenant = {id : '#(universityTenantId)', name: '#(universityTenantName)'}
+    * def universityTenant = { id : '#(universityTenantId)', name: '#(universityTenantName)' }
 
     * def universityUserId = uuids[2]
-    * def centralAdminId = uuids[3]
-    * def centralUserId = uuids[4]
 
     # define consortium
-    * def consortiumId = uuids[5]
+    * def consortiumId = uuids[3]
 
     # define main users
-    * def consortiaAdmin = { id: '#(centralAdminId)', username: 'consortia_admin', password: 'consortia_admin_password', tenant: '#(centralTenant.name)'}
-    * def universityUser = { id: '#(universityUserId)', username: 'university_user', password: 'university_user_password', type: 'staff', tenant: '#(universityTenant.name)'}
+    * def consortiaAdmin = { id: '#(centralAdminId)', username: 'consortia_admin', password: 'consortia_admin_password', tenant: '#(centralTenantName)' }
+    * def universityUser = { id: '#(universityUserId)', username: 'university_user', password: 'university_user_password', type: 'staff', tenant: '#(universityTenantName)' }
 
-    * def centralUser = { id: '#(centralUserId)', username: 'central_user', password: 'central_user_password', type: 'staff', tenant: '#(centralTenant.name)'}
+    * def centralUser = { id: '#(centralUserId)', username: 'central_user', password: 'central_user_password', type: 'staff', tenant: '#(centralTenantName)' }
+
+    # reusable features
+    * def setupTenant = read('classpath:common-consortia/eureka/tenant-and-local-admin-setup.feature@SetupTenant')
+    * def postUser = read('classpath:common-consortia/eureka/initData.feature@PostUser')
+    * def putCaps = read('classpath:common-consortia/eureka/initData.feature@PutCaps')
+    * def getAuthorizationToken = read('classpath:common-consortia/eureka/keycloak.feature@getAuthorizationToken')
+    * def enableCentralOrdering = read('tenant-utils/consortium.feature@EnableCentralOrdering')
+    * def configureAccessTokenTime = read('classpath:common/eureka/keycloak.feature@configureAccessTokenTime')
+    * def deleteTenantAndEntitlement = read('classpath:common-consortia/eureka/initData.feature@DeleteTenantAndEntitlement')
 
   @SetupTenants
   Scenario: Create ['central', 'university'] tenants and set up admins
@@ -141,7 +150,7 @@ Feature: mod-consortia integration tests
       | 'mod-circulation'           |
       | 'mod-feesfines'             |
       | 'mod-consortia-keycloak'    |
-    * call read('classpath:common-consortia/eureka/tenant-and-local-admin-setup.feature@SetupTenant') { tenantId: '#(centralTenant.id)', tenant: '#(centralTenant.name)', user: '#(consortiaAdmin)'}
+    * call setupTenant { tenantId: '#(centralTenantId)', tenant: '#(centralTenantName)', user: '#(consortiaAdmin)' }
 
     * table modules
       | name                        |
@@ -166,266 +175,113 @@ Feature: mod-consortia integration tests
       | 'mod-circulation'           |
       | 'mod-feesfines'             |
       | 'mod-consortia-keycloak'    |
-    * call read('classpath:common-consortia/eureka/tenant-and-local-admin-setup.feature@SetupTenant') { tenantId: '#(universityTenant.id)', tenant: '#(universityTenant.name)', user: '#(universityUser)'}
+    * call setupTenant { tenantId: '#(universityTenant.id)', tenant: '#(universityTenantName)', user: '#(universityUser)' }
 
+    # Permissions for centralUser
     * table userPermissions
       | name                                                        |
-      | 'circulation.rules.put'                                     |
-      | 'circulation.requests.item.get'                             |
-      | 'circulation.requests.item.post'                            |
-      | 'circulation-storage.loan-policies.collection.get'          |
-      | 'circulation-storage.loan-policies.item.post'               |
-      | 'circulation-storage.patron-notice-policies.collection.get' |
-      | 'circulation-storage.patron-notice-policies.item.post'      |
-      | 'circulation-storage.request-policies.collection.get'       |
-      | 'circulation-storage.request-policies.item.post'            |
-      | 'inventory-storage.holdings.collection.get'                 |
-      | 'inventory-storage.holdings.item.get'                       |
-      | 'inventory-storage.instances.item.get'                      |
-      | 'inventory.holdings.move.item.post'                         |
-      | 'inventory.holdings.update-ownership.item.post'             |
-      | 'inventory.instances.item.get'                              |
-      | 'inventory.items-by-holdings-id.collection.get'             |
-      | 'inventory.items.collection.get'                            |
-      | 'inventory.items.item.delete'                               |
-      | 'inventory.items.item.get'                                  |
-      | 'inventory.items.move.item.post'                            |
-      | 'inventory.tenant-items.collection.get'                     |
-      | 'lost-item-fees-policies.collection.get'                    |
-      | 'lost-item-fees-policies.item.post'                         |
-      | 'orders.bind-pieces.collection.post'                        |
-      | 'orders.bind-pieces.item.delete'                            |
-      | 'orders.check-in.collection.post'                           |
-      | 'orders.collection.get'                                     |
-      | 'orders.expect.collection.post'                             |
-      | 'orders.holding-summary.collection.get'                     |
-      | 'orders.item.delete'                                        |
-      | 'orders.item.get'                                           |
-      | 'orders.item.post'                                          |
-      | 'orders.item.put'                                           |
-      | 'orders.item.reopen'                                        |
-      | 'orders.item.unopen'                                        |
-      | 'orders.piece-requests.collection.get'                      |
       | 'orders.pieces.collection.get'                              |
-      | 'orders.pieces.item.delete'                                 |
-      | 'orders.pieces.item.get'                                    |
-      | 'orders.pieces.item.post'                                   |
-      | 'orders.pieces.item.put'                                    |
-      | 'orders.po-lines.collection.get'                            |
-      | 'orders.po-lines.fund-distributions.validate'               |
-      | 'orders.po-lines.item.delete'                               |
       | 'orders.po-lines.item.get'                                  |
-      | 'orders.po-lines.item.post'                                 |
       | 'orders.po-lines.item.put'                                  |
-      | 'orders.po-number.item.get'                                 |
-      | 'orders.po-number.item.post'                                |
-      | 'orders.re-encumber.item.post'                              |
-      | 'orders.receiving.collection.post'                          |
-      | 'orders.receiving-history.collection.get'                   |
-      | 'orders.rollover.item.post'                                 |
-      | 'orders.titles.collection.get'                              |
-      | 'orders.titles.item.get'                                    |
-      | 'orders.titles.item.post'                                   |
-      | 'orders-storage.settings.item.post'                         |
-      | 'usergroups.item.post'                                      |
-      | 'users.item.get'                                            |
-      | 'users.item.post'                                           |
-      | 'users.item.put'                                            |
-      | 'overdue-fines-policies.collection.get'                     |
-      | 'overdue-fines-policies.item.post'                          |
 
-    * call read('classpath:common-consortia/eureka/initData.feature@PostUser') {tenant: '#(centralTenant.name)', user: '#(centralUser)'}
-    * call read('classpath:common-consortia/eureka/initData.feature@PutCaps') {tenant: '#(centralTenant.name)', user: '#(centralUser)'}
+    * call postUser { tenant: '#(centralTenantName)', user: '#(centralUser)' }
+    * call putCaps { tenant: '#(centralTenantName)', user: '#(centralUser)' }
 
   @SetupConsortia
   Scenario: Setup Consortia
     # 1. Create Consortia
-    * def result = call read('classpath:common-consortia/eureka/initData.feature@Login') { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenant.name)'}
-    * call read('tenant-utils/consortium.feature@SetupConsortia') {token: '#(result.okapitoken)', tenant: '#(centralTenant)'}
+    * def result = call eurekaLogin { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenantName)' }
+    * call read('tenant-utils/consortium.feature@SetupConsortia') { token: '#(result.okapitoken)', tenant: '#(centralTenant)' }
 
 #     2. Add 2 tenants to consortium
-    * call read('tenant-utils/tenant.feature') {token: '#(result.okapitoken)', centralTenantName: '#(centralTenant.name)', uniTenant: '#(universityTenant)', consortiaAdmin: '#(consortiaAdmin)'}
+    * call read('tenant-utils/tenant.feature') { token: '#(result.okapitoken)', centralTenantName: '#(centralTenantName)', uniTenant: '#(universityTenant)', consortiaAdmin: '#(consortiaAdmin)' }
 
 #     3. Add permissions to consortia_admin
+    # Permissions for shadowConsortiaAdmin (consortia_admin in university tenant)
     * table userPermissions
       | name                                                        |
-      | 'circulation.rules.put'                                     |
       | 'circulation.requests.item.get'                             |
       | 'circulation.requests.item.post'                            |
+      | 'circulation.rules.put'                                     |
       | 'circulation-storage.loan-policies.collection.get'          |
       | 'circulation-storage.loan-policies.item.post'               |
       | 'circulation-storage.patron-notice-policies.collection.get' |
       | 'circulation-storage.patron-notice-policies.item.post'      |
       | 'circulation-storage.request-policies.collection.get'       |
       | 'circulation-storage.request-policies.item.post'            |
-      | 'configuration.entries.item.post'                           |
-      | 'consortia.consortia-configuration.item.delete'             |
-      | 'consortia.consortia-configuration.item.post'               |
-      | 'consortia.consortium.item.get'                             |
-      | 'consortia.consortium.item.post'                            |
-      | 'consortia.consortium.item.put'                             |
-      | 'consortia.create-primary-affiliations.item.post'           |
-      | 'consortia.custom-login.item.post'                          |
-      | 'consortia.identity-provider.item.delete'                   |
-      | 'consortia.identity-provider.item.post'                     |
-      | 'consortia.inventory.local.sharing-instances.execute'       |
-      | 'consortia.inventory.update-ownership.item.post'            |
-      | 'consortia.publications-results.item.get'                   |
-      | 'consortia.publications.item.delete'                        |
-      | 'consortia.publications.item.get'                           |
-      | 'consortia.publications.item.post'                          |
       | 'consortia.sharing-instances.collection.get'                |
-      | 'consortia.sharing-instances.item.get'                      |
       | 'consortia.sharing-instances.item.post'                     |
-      | 'consortia.sharing-policies.item.delete'                    |
-      | 'consortia.sharing-policies.item.post'                      |
-      | 'consortia.sharing-roles-all.item.delete'                   |
-      | 'consortia.sharing-roles-all.item.post'                     |
-      | 'consortia.sharing-roles-capabilities.item.delete'          |
-      | 'consortia.sharing-roles-capabilities.item.post'            |
-      | 'consortia.sharing-roles-capability-sets.item.delete'       |
-      | 'consortia.sharing-roles-capability-sets.item.post'         |
-      | 'consortia.sharing-roles.item.delete'                       |
-      | 'consortia.sharing-roles.item.post'                         |
-      | 'consortia.sharing-settings.item.delete'                    |
-      | 'consortia.sharing-settings.item.post'                      |
-      | 'consortia.sync-primary-affiliations.item.post'             |
-      | 'consortia.tenants.item.delete'                             |
-      | 'consortia.tenants.item.get'                                |
-      | 'consortia.tenants.item.post'                               |
-      | 'consortia.tenants.item.put'                                |
-      | 'consortia.user-tenants.collection.get'                     |
-      | 'consortia.user-tenants.item.delete'                        |
-      | 'consortia.user-tenants.item.get'                           |
-      | 'consortia.user-tenants.item.post'                          |
-      | 'finance-storage.funds.item.post'                           |
-      | 'finance.budgets.collection.get'                            |
-      | 'finance.budgets.item.post'                                 |
-      | 'finance.expense-classes.item.post'                         |
-      | 'finance.fiscal-years.item.post'                            |
-      | 'finance.funds.item.post'                                   |
-      | 'finance.ledgers.item.post'                                 |
-      | 'inventory-storage.holdings-sources.item.post'              |
-      | 'inventory-storage.holdings.collection.get'                 |
-      | 'inventory-storage.holdings.item.get'                       |
-      | 'inventory-storage.holdings.item.post'                      |
-      | 'inventory-storage.instance-statuses.item.post'             |
-      | 'inventory-storage.instance-types.item.post'                |
-      | 'inventory-storage.instances.item.get'                      |
-      | 'inventory-storage.locations.item.post'                     |
-      | 'inventory-storage.loan-types.item.post'                    |
-      | 'inventory-storage.location-units.campuses.item.post'       |
-      | 'inventory-storage.location-units.institutions.item.post'   |
-      | 'inventory-storage.location-units.libraries.item.post'      |
-      | 'inventory-storage.material-types.item.post'                |
-      | 'inventory-storage.service-points.item.post'                |
+      | 'inventory.holdings.update-ownership.item.post'             |
       | 'inventory.instances.item.get'                              |
       | 'inventory.instances.item.post'                             |
       | 'inventory.items-by-holdings-id.collection.get'             |
       | 'inventory.items.collection.get'                            |
       | 'inventory.items.item.delete'                               |
-      | 'inventory.items.item.get'                                  |
-      | 'inventory.items.move.item.post'                            |
-      | 'inventory.tenant-items.collection.get'                     |
-      | 'inventory.holdings.move.item.post'                         |
-      | 'inventory.holdings.update-ownership.item.post'             |
+      | 'inventory-storage.holdings.collection.get'                 |
+      | 'inventory-storage.holdings.item.get'                       |
+      | 'inventory-storage.holdings.item.post'                      |
+      | 'inventory-storage.holdings-sources.item.post'              |
+      | 'inventory-storage.instance-statuses.item.post'             |
+      | 'inventory-storage.instance-types.item.post'                |
+      | 'inventory-storage.instances.item.get'                      |
+      | 'inventory-storage.loan-types.item.post'                    |
+      | 'inventory-storage.locations.item.post'                     |
+      | 'inventory-storage.location-units.campuses.item.post'       |
+      | 'inventory-storage.location-units.institutions.item.post'   |
+      | 'inventory-storage.location-units.libraries.item.post'      |
+      | 'inventory-storage.material-types.item.post'                |
+      | 'inventory-storage.service-points.item.post'                |
       | 'lost-item-fees-policies.collection.get'                    |
       | 'lost-item-fees-policies.item.post'                         |
-      | 'orders.acquisition-method.item.post'                       |
-      | 'orders.bind-pieces.collection.post'                        |
-      | 'orders.bind-pieces.item.delete'                            |
-      | 'orders.check-in.collection.post'                           |
-      | 'orders.item.post'                                          |
-      | 'orders.item.reopen'                                        |
-      | 'orders.item.unopen'                                        |
-      | 'orders.piece-requests.collection.get'                      |
-      | 'orders.pieces.collection.get'                              |
-      | 'orders.pieces.item.delete'                                 |
-      | 'orders.pieces.item.get'                                    |
-      | 'orders.pieces.item.post'                                   |
-      | 'orders.pieces.item.put'                                    |
-      | 'orders.po-lines.collection.get'                            |
-      | 'orders.po-lines.item.get'                                  |
-      | 'orders.po-lines.item.post'                                 |
-      | 'orders.po-lines.item.put'                                  |
-      | 'orders.receiving.collection.post'                          |
-      | 'orders-storage.settings.item.post'                         |
-      | 'orders.titles.collection.get'                              |
-      | 'orders.titles.item.get'                                    |
-      | 'orders.titles.item.post'                                   |
-      | 'organizations.organizations.item.post'                     |
-      | 'organizations-storage.organizations.item.post'             |
       | 'overdue-fines-policies.collection.get'                     |
       | 'overdue-fines-policies.item.post'                          |
-      | 'perms.users.get'                                           |
-      | 'perms.users.item.put'                                      |
-      | 'tags.collection.get'                                       |
-      | 'tags.item.delete'                                          |
-      | 'tags.item.get'                                             |
-      | 'tags.item.post'                                            |
-      | 'tags.item.put'                                             |
-      | 'user-tenants.collection.get'                               |
-      | 'usergroups.item.post'                                      |
-      | 'users.item.get'                                            |
-      | 'users.item.post'                                           |
-      | 'users.item.put'                                            |
 
-    * call read('classpath:common-consortia/eureka/keycloak.feature@getAuthorizationToken') {tenant: '#(universityTenant.name)'}
-    * def shadowConsortiaAdmin = { id: '#(centralAdminId)', tenant: '#(universityTenant.name)'}
+    * call getAuthorizationToken { tenant: '#(universityTenantName)' }
+    * def shadowConsortiaAdmin = { id: '#(centralAdminId)', tenant: '#(universityTenantName)' }
     * configure cookies = null
-    * call read('classpath:common-consortia/eureka/initData.feature@PutCaps') {tenant: '#(universityTenant.name)', user: '#(shadowConsortiaAdmin)'}
+    * call putCaps { tenant: '#(universityTenantName)', user: '#(shadowConsortiaAdmin)' }
 
     # 4. Enable central ordering
-    * def result = call read('classpath:common-consortia/eureka/initData.feature@Login') { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenant.name)'}
-    * call read('tenant-utils/consortium.feature@EnableCentralOrdering') {token: '#(result.token)', tenant: '#(centralTenant)'}
+    * def result = call eurekaLogin { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenantName)' }
+    * call enableCentralOrdering { token: '#(result.token)', tenant: '#(centralTenant)' }
 
-    * call read('classpath:common/eureka/keycloak.feature@configureAccessTokenTime') { 'AccessTokenLifespance' : 3600, testTenant: '#(centralTenant.name)' }
+    * call configureAccessTokenTime { 'AccessTokenLifespance' : 3600, testTenant: '#(centralTenantName)' }
 
   @InitData
   Scenario: Prepare data
-    * def result = call read('classpath:common-consortia/eureka/initData.feature@Login') { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenant.name)'}
-    * call read('order-utils/inventory.feature') {token: '#(result.okapitoken)', tenant: '#(centralTenant)'}
-    * call read('order-utils/inventory-university.feature') {token: '#(result.okapitoken)', tenant: '#(universityTenant)'}
-    * call read('order-utils/configuration.feature') {token: '#(result.okapitoken)', tenant: '#(centralTenant)'}
-    * call read('order-utils/finances.feature') {token: '#(result.okapitoken)', tenant: '#(centralTenant)'}
-    * call read('order-utils/organizations.feature') {okapitoken: '#(result.okapitoken)', tenantName: '#(centralTenant.name)'}
-    * call read('order-utils/orders.feature') {token: '#(result.okapitoken)', tenant: '#(centralTenant)'}
+    * call eurekaLogin { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenantName)' }
+    * call read('order-utils/inventory.feature')
+    * call read('order-utils/inventory-university.feature')
+    * call read('order-utils/configuration.feature')
+    * call read('order-utils/finances.feature')
+    * call read('order-utils/organizations.feature')
+    * call read('order-utils/orders.feature')
 
   Scenario: Open order with locations from different tenants
-    * def result = call read('classpath:common-consortia/eureka/initData.feature@Login') { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenant.name)'}
-    Given call read('features/open-order-with-locations-from-different-tenants.feature') {okapitoken: '#(result.okapitoken)', centralTenant: '#(centralTenant.name)', universityTenant: '#(universityTenant)'}
+    * call read('features/open-order-with-locations-from-different-tenants.feature')
 
   Scenario: Reopen order and change instance connection orderLine
-    * def result = call read('classpath:common-consortia/eureka/initData.feature@Login') { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenant.name)'}
-    Given call read('features/reopen-and-change-instance-connection-order-with-locations-from-different-tenants.feature') {okapitoken: '#(result.okapitoken)', centralTenant: '#(centralTenant.name)', universityTenant: '#(universityTenant.name)'}
+    * call read('features/reopen-and-change-instance-connection-order-with-locations-from-different-tenants.feature')
 
   Scenario: Performance Open order wtih many locations from different tenants
-    * def result = call read('classpath:common-consortia/eureka/initData.feature@Login') { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenant.name)'}
-    Given call read('features/prf-open-order-with-many-locations-from-different-tenants.feature') {okapitoken: '#(result.okapitoken)', centralTenant: '#(centralTenant.name)', universityTenant: '#(universityTenant.name)'}
+    * call read('features/prf-open-order-with-many-locations-from-different-tenants.feature')
 
   Scenario: Piece Api Test for cross tenant envs
-    * def resultAdmin = call read('classpath:common-consortia/eureka/initData.feature@Login') { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenant.name)'}
-    * def resultUniAdmin = call read('classpath:common-consortia/eureka/initData.feature@Login') { username: '#(universityUser.username)', password: '#(universityUser.password)', tenant: '#(universityTenant.name)'}
-    * def resultUser = call read('classpath:common-consortia/eureka/initData.feature@Login') { username: '#(centralUser.username)', password: '#(centralUser.password)', tenant: '#(centralTenant.name)'}
-    Given call read("features/pieces-api-test-for-cross-tenant-envs.feature") {okapitoken: '#(resultAdmin.okapitoken)', okapitokenUser: '#(resultUser.okapitoken)', okapitokenUni: '#(resultUniAdmin.okapitoken)' , centralTenant: '#(centralTenant.name)', universityTenant: '#(universityTenant.name)', centralAdminId: '#(centralAdminId)', universityUserId: '#(universityUserId)', universityUser: '#(universityUser)'}
+    * call read("features/pieces-api-test-for-cross-tenant-envs.feature")
 
   Scenario: Bind pieces features in ECS environment
-    * def result = call read('classpath:common-consortia/eureka/initData.feature@Login') { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenant.name)'}
-    Given call read("features/bind-pieces-ecs.feature") {okapitoken: '#(result.okapitoken)', centralTenant: '#(centralTenant.name)', universityTenant: '#(universityTenant.name)'}
+    * call read("features/bind-pieces-ecs.feature")
 
   Scenario: Update unaffiliated PoLine locations
-    * def resultAdmin = call read('classpath:common-consortia/eureka/initData.feature@Login') { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenant.name)'}
-    * def resultUser = call read('classpath:common-consortia/eureka/initData.feature@Login') { username: '#(centralUser.username)', password: '#(centralUser.password)', tenant: '#(centralTenant.name)'}
-    Given call read("features/update-unaffiliated-pol-locations.feature") {okapitoken: '#(resultAdmin.okapitoken)', okapitokenUser: '#(resultUser.okapitoken)', centralTenant: '#(centralTenant.name)', universityTenant: '#(universityTenant.name)', centralAdminId: '#(centralAdminId)', universityUserId: '#(universityUserId)', universityUser: '#(universityUser)'}
+    * call read("features/update-unaffiliated-pol-locations.feature")
 
   Scenario: Update inventory ownership changes order data
-    * def result = call read('classpath:common-consortia/eureka/initData.feature@Login') { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenant.name)'}
-    Given call read("features/update-inventory-ownership-changes-order-data.feature") {okapitoken: '#(result.okapitoken)', centralTenant: '#(centralTenant.name)', universityTenant: '#(universityTenant.name)'}
+    * call read("features/update-inventory-ownership-changes-order-data.feature")
 
   Scenario: Move Item and Holding to update order data in ECS environment
-    Given call read("features/mode-item-and-holding-to-update-order-data-ecs.feature") {consortiaAdmin: '#(consortiaAdmin)', centralTenant: '#(centralTenant.name)'}
+    * call read("features/mode-item-and-holding-to-update-order-data-ecs.feature")
 
   @DestroyData
   Scenario: Destroy created ['central', 'university'] tenants
-    * call read('classpath:common-consortia/eureka/initData.feature@DeleteTenantAndEntitlement') { tenantId: '#(universityTenantId)'}
-    * call read('classpath:common-consortia/eureka/initData.feature@DeleteTenantAndEntitlement') { tenantId: '#(centralTenantId)'}
+    * call deleteTenantAndEntitlement { tenantId: '#(universityTenantId)' }
+    * call deleteTenantAndEntitlement { tenantId: '#(centralTenantId)' }

--- a/acquisitions/src/main/resources/thunderjet/consortia/features/bind-pieces-ecs.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/features/bind-pieces-ecs.feature
@@ -4,8 +4,5 @@ Feature: Verify Bind Piece feature in ECS environment
     * def bindPiecesFeatures = read('classpath:thunderjet/mod-orders/features/bind-piece.feature')
 
   Scenario: Test bind pieces features
-    * table tenants
-      | tenantId1     | tenantId2        | holdingId1        | holdingId2           | holdingId3        |
-      | centralTenant | universityTenant | centralHoldingId1 | universityHoldingId1 | centralHoldingId2 |
-    * def proxyConsortiaAdmin = {name: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenant)'}
-    * def v = call bindPiecesFeatures {tenantId1: '#(centralTenant)', tenantId2: '#(universityTenant)', holdingId1: '#(centralHoldingId1)', holdingId2: '#(universityHoldingId1)', holdingId3: '#(centralHoldingId2)', testAdmin: '#(proxyConsortiaAdmin)', testTenant: '#(centralTenant)'}
+    * def proxyConsortiaAdmin = { name: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenantName)' }
+    * def v = call bindPiecesFeatures { tenantId1: '#(centralTenantName)', tenantId2: '#(universityTenantName)', holdingId1: '#(centralHoldingId1)', holdingId2: '#(universityHoldingId1)', holdingId3: '#(centralHoldingId2)', testAdmin: '#(proxyConsortiaAdmin)', testUser: '#(proxyConsortiaAdmin)', testTenant: '#(centralTenantName)' }

--- a/acquisitions/src/main/resources/thunderjet/consortia/features/mode-item-and-holding-to-update-order-data-ecs.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/features/mode-item-and-holding-to-update-order-data-ecs.feature
@@ -4,8 +4,5 @@ Feature: Move Item and Holding to update order data
     * def moveItemAndHoldingFeature = read('classpath:thunderjet/mod-orders/features/mode-item-and-holding-to-update-order-data.feature')
 
   Scenario: Test Moving Item and Holding to update order data in ECS environment
-    * def proxyConsortiaAdmin = {name: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenant)'}
-    * table tenants
-      | testAdmin      |
-      | proxyConsortiaAdmin |
-    * def v = call moveItemAndHoldingFeature {testAdmin: '#(proxyConsortiaAdmin)', testTenant: '#(centralTenant)'}
+    * def proxyConsortiaAdmin = {name: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenantName)'}
+    * def v = call moveItemAndHoldingFeature {testAdmin: '#(proxyConsortiaAdmin)', testUser: '#(proxyConsortiaAdmin)', testTenant: '#(centralTenantName)'}

--- a/acquisitions/src/main/resources/thunderjet/consortia/features/pieces-api-test-for-cross-tenant-envs.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/features/pieces-api-test-for-cross-tenant-envs.feature
@@ -1,20 +1,26 @@
+@parallel=false
 Feature: Pieces API tests for cross-tenant envs
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * def headersUser = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitokenUser)', 'x-okapi-tenant': '#(centralTenant)', 'Accept': 'application/json' }
-    * def headersUni = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(universityTenant)', 'Accept': 'application/json' }
-    * def headersUniAdmin = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitokenUni)', 'x-okapi-tenant': '#(universityTenant)', 'Accept': 'application/json' }
-    * def headersCentral = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(centralTenant)', 'Accept': 'application/json' }
+
+    * def resultAdmin = call eurekaLogin { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenantName)' }
+    * def okapitoken = resultAdmin.okapitoken
+    * def resultUniAdmin = call eurekaLogin { username: '#(universityUser.username)', password: '#(universityUser.password)', tenant: '#(universityTenantName)'}
+    * def okapitokenUni = resultUniAdmin.okapitoken
+    * def resultUser = call eurekaLogin { username: '#(centralUser.username)', password: '#(centralUser.password)', tenant: '#(centralTenantName)'}
+    * def okapitokenUser = resultUser.okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitokenUser)', 'x-okapi-tenant': '#(centralTenantName)', 'Accept': 'application/json' }
+    * def headersUni = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(universityTenantName)', 'Accept': 'application/json' }
+    * def headersUniAdmin = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitokenUni)', 'x-okapi-tenant': '#(universityTenantName)', 'Accept': 'application/json, text/plain' }
+    * def headersCentral = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(centralTenantName)', 'Accept': 'application/json, text/plain' }
     * configure headers = headersCentral
 
     * callonce variables
     * callonce variablesCentral
     * callonce variablesUniversity
 
-    * def createOrder = read('classpath:thunderjet/mod-orders/reusable/create-order.feature')
-    * def createOrderLine = read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature')
-    * def createPieceWithHolding = read('classpath:thunderjet/mod-orders/reusable/create-piece-with-holding.feature')
     * def minimalPiece = read('classpath:samples/consortia/pieces/minimal-piece.json')
     * def createCirculationRequest = read('classpath:thunderjet/mod-orders/reusable/create-circulation-request.feature')
     * def createUserGroup = read('classpath:thunderjet/mod-orders/reusable/user-init-data.feature@CreateGroup')
@@ -27,7 +33,7 @@ Feature: Pieces API tests for cross-tenant envs
     * def pieceId = callonce uuid
 
     * callonce createOrder { id: '#(orderId)' }
-    * callonce createOrderLine { 'id': '#(poLineId)', 'orderId': '#(orderId)', 'checkinItems': true, isPackage: True}
+    * callonce createOrderLine { 'id': '#(poLineId)', 'orderId': '#(orderId)', 'checkinItems': true, isPackage: True }
     * callonce createTitle { titleId: '#(titleId)', poLineId: '#(poLineId)' }
 
 
@@ -37,9 +43,8 @@ Feature: Pieces API tests for cross-tenant envs
     * set minimalPiece.titleId = titleId
     * set minimalPiece.poLineId = poLineId
     * set minimalPiece.locationId = universityLocationsId
-    * set minimalPiece.receivingTenantId = universityTenant
+    * set minimalPiece.receivingTenantId = universityTenantName
     Given path 'orders/pieces'
-    And header x-okapi-tenant = centralTenant
     And param createItem = true
     And request minimalPiece
     When method POST
@@ -49,13 +54,12 @@ Feature: Pieces API tests for cross-tenant envs
     And match response.titleId == '#(titleId)'
     And match response.itemId == '#present'
     And match response.holdingId == '#present'
-    And match response.receivingTenantId == '#(universityTenant)'
+    And match response.receivingTenantId == '#(universityTenantName)'
     And def holdingId = response.holdingId
 
     * configure headers = headersUni
     # Check the created holding record in specified tenant
     Given path '/holdings-storage/holdings/', holdingId
-    And header x-okapi-tenant = universityTenant
     When method GET
     Then status 200
     And match response.instanceId == '#present'
@@ -63,13 +67,11 @@ Feature: Pieces API tests for cross-tenant envs
 
     # Check the created shared instance in specified tenant
     Given path '/instance-storage/instances', instanceId
-    And header x-okapi-tenant = universityTenant
     When method GET
     Then status 200
 
     # Check the created item in specified tenant
     Given path '/inventory/items'
-    And header x-okapi-tenant = universityTenant
     And param query = 'holdingsRecordId=' + holdingId
     When method GET
     Then status 200
@@ -90,9 +92,9 @@ Feature: Pieces API tests for cross-tenant envs
     * def poLine = read('classpath:samples/consortia/orderLines/multi-tenant-order-line.json')
     * set poLine.id = poLineId
     * set poLine.purchaseOrderId = orderId
-    * set poLine.locations[1].tenantId = centralTenant
+    * set poLine.locations[1].tenantId = centralTenantName
     * set poLine.locations[1].locationId = centralLocationsId
-    * set poLine.locations[2].tenantId = universityTenant
+    * set poLine.locations[2].tenantId = universityTenantName
     * set poLine.locations[2].locationId = universityLocationsId
     * set poLine.physical.createInventory = "Instance, Holding"
 
@@ -104,14 +106,12 @@ Feature: Pieces API tests for cross-tenant envs
     ## 3. Open order
     Given path 'orders/composite-orders', orderId
     When method GET
-    And header x-okapi-tenant = centralTenant
     Then status 200
 
     * def orderResponse = $
     * set orderResponse.workflowStatus = "Open"
 
     Given path 'orders/composite-orders', orderId
-    And header x-okapi-tenant = centralTenant
     And request orderResponse
     When method PUT
     Then status 204
@@ -125,12 +125,11 @@ Feature: Pieces API tests for cross-tenant envs
 
     ## 4. Verify pieces that 'universityTenant' and 'centralTenant' contains in receivingTenantId field
     Given path 'orders/pieces'
-    And header x-okapi-tenant = centralTenant
     And param query = 'titleId==' + titleId + ' and poLineId==' + poLineId + ' and receivingStatus==("Expected" or "Late" or "Claim delayed" or "Claim sent")'
     When method GET
     Then status 200
-    And match $.pieces[*].receivingTenantId contains universityTenant
-    And match $.pieces[*].receivingTenantId contains centralTenant
+    And match $.pieces[*].receivingTenantId contains universityTenantName
+    And match $.pieces[*].receivingTenantId contains universityTenantName
 
   Scenario: Check receivingTenantId populated when openining order with 'Instance, Holding, Item'
   `
@@ -146,9 +145,9 @@ Feature: Pieces API tests for cross-tenant envs
     * def poLine = read('classpath:samples/consortia/orderLines/multi-tenant-order-line.json')
     * set poLine.id = poLineId
     * set poLine.purchaseOrderId = orderId
-    * set poLine.locations[1].tenantId = centralTenant
+    * set poLine.locations[1].tenantId = centralTenantName
     * set poLine.locations[1].locationId = centralLocationsId
-    * set poLine.locations[2].tenantId = universityTenant
+    * set poLine.locations[2].tenantId = universityTenantName
     * set poLine.locations[2].locationId = universityLocationsId
     * set poLine.physical.createInventory = "Instance, Holding, Item"
 
@@ -160,14 +159,12 @@ Feature: Pieces API tests for cross-tenant envs
     ## 3. Open order
     Given path 'orders/composite-orders', orderId
     When method GET
-    And header x-okapi-tenant = centralTenant
     Then status 200
 
     * def orderResponse = $
     * set orderResponse.workflowStatus = "Open"
 
     Given path 'orders/composite-orders', orderId
-    And header x-okapi-tenant = centralTenant
     And request orderResponse
     When method PUT
     Then status 204
@@ -181,17 +178,15 @@ Feature: Pieces API tests for cross-tenant envs
 
     ## 4. Verify pieces that 'universityTenant' and 'centralTenant' contains in receivingTenantId field
     Given path 'orders/pieces'
-    And header x-okapi-tenant = centralTenant
     And param query = 'titleId==' + titleId + ' and poLineId==' + poLineId + ' and receivingStatus==("Expected" or "Late" or "Claim delayed" or "Claim sent")'
     When method GET
     Then status 200
-    And match $.pieces[*].receivingTenantId contains universityTenant
-    And match $.pieces[*].receivingTenantId contains centralTenant
+    And match $.pieces[*].receivingTenantId contains universityTenantName
+    And match $.pieces[*].receivingTenantId contains centralTenantName
 
   Scenario: Check Holding and Item updated in member tenant when updating piece without itemId and deleteHolding=true
     # Get existing holdingId and itemId in specified tenant
     Given path 'orders/pieces', pieceId
-    And header x-okapi-tenant = centralTenant
     When method GET
     Then status 200
     And match response.itemId == '#present'
@@ -202,7 +197,6 @@ Feature: Pieces API tests for cross-tenant envs
     * configure headers = headersUni
     # Delete associated item for holding to be deleted in specified tenant
     Given path '/inventory/items', oldItemId
-    And header x-okapi-tenant = universityTenant
     When method DELETE
     Then status 204
 
@@ -212,9 +206,8 @@ Feature: Pieces API tests for cross-tenant envs
     * set minimalPiece.titleId = titleId
     * set minimalPiece.poLineId = poLineId
     * set minimalPiece.locationId = universityLocationsId
-    * set minimalPiece.receivingTenantId = universityTenant
+    * set minimalPiece.receivingTenantId = universityTenantName
     Given path 'orders/pieces', pieceId
-    And header x-okapi-tenant = centralTenant
     And param createItem = true
     And param deleteHolding = true
     And request minimalPiece
@@ -223,7 +216,6 @@ Feature: Pieces API tests for cross-tenant envs
 
     # Get updated holdingId and itemId in specified tenant
     Given path 'orders/pieces', pieceId
-    And header x-okapi-tenant = centralTenant
     When method GET
     Then status 200
     And match response.id == '#(pieceId)'
@@ -238,20 +230,17 @@ Feature: Pieces API tests for cross-tenant envs
     * configure headers = headersUni
     # Check the created holding record in specified tenant
     Given path '/holdings-storage/holdings/', holdingId
-    And header x-okapi-tenant = universityTenant
     When method GET
     Then status 200
     And match response.instanceId == '#present'
 
     # Check the deleted old holding record in specified tenant
     Given path '/holdings-storage/holdings/', oldHoldingId
-    And header x-okapi-tenant = universityTenant
     When method GET
     Then status 404
 
     # Check the created item in specified tenant
     Given path '/inventory/items'
-    And header x-okapi-tenant = universityTenant
     And param query = 'holdingsRecordId=' + holdingId
     When method GET
     Then status 200
@@ -263,7 +252,6 @@ Feature: Pieces API tests for cross-tenant envs
   Scenario: Check Holding and Item after receiving the piece
     # Receive piece
     Given path 'orders/check-in'
-    And header x-okapi-tenant = centralTenant
     And request
     """
     {
@@ -275,7 +263,7 @@ Feature: Pieces API tests for cross-tenant envs
               id: "#(pieceId)",
               itemStatus: "In process",
               locationId: "#(universityLocationsId)",
-              receivingTenantId: "#(universityTenant)"
+              receivingTenantId: "#(universityTenantName)"
             }
           ],
           poLineId: "#(poLineId)"
@@ -290,7 +278,6 @@ Feature: Pieces API tests for cross-tenant envs
 
     # Get existing holdingId in specified tenant
     Given path 'orders/pieces', pieceId
-    And header x-okapi-tenant = centralTenant
     When method GET
     Then status 200
     And match response.itemId == '#present'
@@ -301,14 +288,12 @@ Feature: Pieces API tests for cross-tenant envs
     * configure headers = headersUni
     # Check the holding record in specified tenant
     Given path '/holdings-storage/holdings/', holdingId
-    And header x-okapi-tenant = universityTenant
     When method GET
     Then status 200
     And match response.instanceId == '#present'
 
     # Check the item in specified tenant
     Given path '/inventory/items'
-    And header x-okapi-tenant = universityTenant
     And param query = 'holdingsRecordId=' + holdingId
     When method GET
     Then status 200
@@ -321,7 +306,6 @@ Feature: Pieces API tests for cross-tenant envs
   Scenario: Check Holding and Item after unreceiving the piece
     # Unreceive piece
     Given path 'orders/receive'
-    And header x-okapi-tenant = centralTenant
     And request
     """
     {
@@ -346,7 +330,6 @@ Feature: Pieces API tests for cross-tenant envs
 
     # Get existing holdingId in specified tenant
     Given path 'orders/pieces', pieceId
-    And header x-okapi-tenant = centralTenant
     When method GET
     Then status 200
     And match response.itemId == '#present'
@@ -357,14 +340,12 @@ Feature: Pieces API tests for cross-tenant envs
     * configure headers = headersUni
     # Check the holding record in specified tenant
     Given path '/holdings-storage/holdings/', holdingId
-    And header x-okapi-tenant = universityTenant
     When method GET
     Then status 200
     And match response.instanceId == '#present'
 
     # Check the item in specified tenant
     Given path '/inventory/items'
-    And header x-okapi-tenant = universityTenant
     And param query = 'holdingsRecordId=' + holdingId
     When method GET
     Then status 200
@@ -377,7 +358,6 @@ Feature: Pieces API tests for cross-tenant envs
   Scenario: Check Holding and Item updated in member tenant when updating piece with itemId and deleteHolding=false
     # Get existing holdingId and itemId in specified tenant
     Given path 'orders/pieces', pieceId
-    And header x-okapi-tenant = centralTenant
     When method GET
     Then status 200
     And match response.itemId == '#present'
@@ -391,9 +371,8 @@ Feature: Pieces API tests for cross-tenant envs
     * set minimalPiece.poLineId = poLineId
     * set minimalPiece.itemId = oldItemId
     * set minimalPiece.locationId = universityLocationsId
-    * set minimalPiece.receivingTenantId = universityTenant
+    * set minimalPiece.receivingTenantId = universityTenantName
     Given path 'orders/pieces', pieceId
-    And header x-okapi-tenant = centralTenant
     And param createItem = true
     And param deleteHolding = false
     And request minimalPiece
@@ -402,7 +381,6 @@ Feature: Pieces API tests for cross-tenant envs
 
     # Get updated holdingId and itemId in specified tenant
     Given path 'orders/pieces', pieceId
-    And header x-okapi-tenant = centralTenant
     When method GET
     Then status 200
     And match response.id == '#(pieceId)'
@@ -416,20 +394,17 @@ Feature: Pieces API tests for cross-tenant envs
     * configure headers = headersUni
     # Check the updated holding record in specified tenant
     Given path '/holdings-storage/holdings/', holdingId
-    And header x-okapi-tenant = universityTenant
     When method GET
     Then status 200
     And match response.instanceId == '#present'
 
     # Check the old holding record as it should not be deleted in specified tenant
     Given path '/holdings-storage/holdings/', oldHoldingId
-    And header x-okapi-tenant = universityTenant
     When method GET
     Then status 200
 
     # Check the old item as it should not be deleted in specified tenant
     Given path '/inventory/items'
-    And header x-okapi-tenant = universityTenant
     And param query = 'holdingsRecordId=' + holdingId
     When method GET
     Then status 200
@@ -441,7 +416,6 @@ Feature: Pieces API tests for cross-tenant envs
   Scenario: Check Holding and Item updated in member tenant when updating piece with itemId and deleteHolding=true
     # Get existing holdingId and itemId in specified tenant
     Given path 'orders/pieces', pieceId
-    And header x-okapi-tenant = centralTenant
     When method GET
     Then status 200
     And match response.itemId == '#present'
@@ -455,9 +429,8 @@ Feature: Pieces API tests for cross-tenant envs
     * set minimalPiece.poLineId = poLineId
     * set minimalPiece.itemId = oldItemId
     * set minimalPiece.locationId = universityLocationsId
-    * set minimalPiece.receivingTenantId = universityTenant
+    * set minimalPiece.receivingTenantId = universityTenantName
     Given path 'orders/pieces', pieceId
-    And header x-okapi-tenant = centralTenant
     And param createItem = true
     And param deleteHolding = true
     And request minimalPiece
@@ -466,7 +439,6 @@ Feature: Pieces API tests for cross-tenant envs
 
     # Get updated holdingId and itemId in specified tenant
     Given path 'orders/pieces', pieceId
-    And header x-okapi-tenant = centralTenant
     When method GET
     Then status 200
     And match response.id == '#(pieceId)'
@@ -480,20 +452,17 @@ Feature: Pieces API tests for cross-tenant envs
     * configure headers = headersUni
     # Check the updated holding record in specified tenant
     Given path '/holdings-storage/holdings/', holdingId
-    And header x-okapi-tenant = universityTenant
     When method GET
     Then status 200
     And match response.instanceId == '#present'
 
     # Check the deleted holding record in specified tenant
     Given path '/holdings-storage/holdings/', oldHoldingId
-    And header x-okapi-tenant = universityTenant
     When method GET
     Then status 404
 
     # Check no items exist for deleted holding in the specified tenant
     Given path '/inventory/items'
-    And header x-okapi-tenant = universityTenant
     And param query = 'holdingsRecordId=' + oldHoldingId
     When method GET
     Then status 200
@@ -501,7 +470,6 @@ Feature: Pieces API tests for cross-tenant envs
 
     # Check new item in the specified tenant
     Given path '/inventory/items'
-    And header x-okapi-tenant = universityTenant
     And param query = 'holdingsRecordId=' + holdingId
     When method GET
     Then status 200
@@ -513,7 +481,6 @@ Feature: Pieces API tests for cross-tenant envs
   Scenario: Check Holding and Item deleted in member tenant when deleting piece
     # Get existing holdingId in specified tenant
     Given path 'orders/pieces', pieceId
-    And header x-okapi-tenant = centralTenant
     When method GET
     Then status 200
     And match response.itemId == '#present'
@@ -522,7 +489,6 @@ Feature: Pieces API tests for cross-tenant envs
 
     # Delete piece
     Given path 'orders/pieces', pieceId
-    And header x-okapi-tenant = centralTenant
     And param deleteHolding = true
     When method DELETE
     Then status 204
@@ -530,13 +496,11 @@ Feature: Pieces API tests for cross-tenant envs
     * configure headers = headersUni
     # Check the deleted holding record in specified tenant
     Given path '/holdings-storage/holdings/', holdingId
-    And header x-okapi-tenant = universityTenant
     When method GET
     Then status 404
 
     # Check the deleted item in specified tenant
     Given path '/inventory/items'
-    And header x-okapi-tenant = universityTenant
     And param query = 'holdingsRecordId=' + holdingId
     When method GET
     Then status 200
@@ -549,17 +513,16 @@ Feature: Pieces API tests for cross-tenant envs
     # 1.1 Create and set patron group for central tenant user
 
     * table groupDetails
-      | id            | group   | tenant        |
-      | patronGroupId | 'staff' | centralTenant |
+      | id            | group   | tenant            |
+      | patronGroupId | 'staff' | centralTenantName |
     * def v = call createUserGroup groupDetails
 
     * table userGroupDetails
-      | userId         | groupId       | tenant        |
-      | centralAdminId | patronGroupId | centralTenant |
+      | userId         | groupId       | tenant            |
+      | centralAdminId | patronGroupId | centralTenantName |
     * def v = call setUserPatronGroup userGroupDetails
 
     Given path 'users', centralAdminId
-    And header x-okapi-tenant = centralTenant
     And retry until response.patronGroup == patronGroupId
     When method GET
     Then status 200
@@ -569,17 +532,16 @@ Feature: Pieces API tests for cross-tenant envs
     * configure headers = headersUniAdmin
     * def patronGroupId2 = call uuid
     * table groupDetails
-      | id            | group   | tenant           |
-      | patronGroupId2 | 'staffUni' | universityTenant |
+      | id             | group      | tenant               |
+      | patronGroupId2 | 'staffUni' | universityTenantName |
     * def v = call createUserGroup groupDetails
 
     * table userGroupDetails
-      | userId            | groupId       | tenant           |
-      | universityUserId | patronGroupId2 | universityTenant |
+      | userId            | groupId       | tenant               |
+      | universityUserId | patronGroupId2 | universityTenantName |
     * def v = call setUserPatronGroup userGroupDetails
 
     Given path 'users', universityUserId
-    And header x-okapi-tenant = universityTenant
     And retry until response.patronGroup == patronGroupId2
     When method GET
     Then status 200
@@ -587,13 +549,13 @@ Feature: Pieces API tests for cross-tenant envs
     # 2. Setup Circulation Policy
     * configure headers = headersCentral
     * table tenant
-      | tenant        |
-      | centralTenant |
+      | tenant            |
+      | centralTenantName |
     * def v = call read('classpath:thunderjet/mod-orders/reusable/create-circulation-policy.feature') tenant
     * configure headers = headersUni
     * table tenant
-      | tenant           |
-      | universityTenant |
+      | tenant               |
+      | universityTenantName |
     * def v = call read('classpath:thunderjet/mod-orders/reusable/create-circulation-policy.feature') tenant
 
     * configure headers = headersCentral
@@ -604,7 +566,6 @@ Feature: Pieces API tests for cross-tenant envs
     * set minimalPiece.poLineId = poLineId
     * set minimalPiece.locationId = centralLocationsId
     Given path 'orders/pieces'
-    And header x-okapi-tenant = centralTenant
     And param createItem = true
     And request minimalPiece
     When method POST
@@ -622,9 +583,8 @@ Feature: Pieces API tests for cross-tenant envs
     * set minimalPiece.titleId = titleId
     * set minimalPiece.poLineId = poLineId
     * set minimalPiece.locationId = universityLocationsId
-    * set minimalPiece.receivingTenantId = universityTenant
+    * set minimalPiece.receivingTenantId = universityTenantName
     Given path 'orders/pieces'
-    And header x-okapi-tenant = centralTenant
     And param createItem = true
     And request minimalPiece
     When method POST
@@ -641,19 +601,18 @@ Feature: Pieces API tests for cross-tenant envs
     * def requestId2 = call uuid
 
     * table request1
-      | id         | userId         | itemId  | holdingId         | instanceId        | tenant        |
-      | requestId1 | centralAdminId | itemId1 | centralHoldingId1 | centralInstanceId | centralTenant |
+      | id         | userId         | itemId  | holdingId         | instanceId        | tenant            |
+      | requestId1 | centralAdminId | itemId1 | centralHoldingId1 | centralInstanceId | centralTenantName |
     * def v = call createCirculationRequest request1
 
     * configure headers = headersUni
     * table request2
-      | id         | userId            | itemId  | holdingId            | instanceId           | tenant           |
-      | requestId2 | universityUserId | itemId2 | universityHoldingId1 | universityInstanceId | universityTenant |
+      | id         | userId            | itemId  | holdingId            | instanceId           | tenant               |
+      | requestId2 | universityUserId | itemId2 | universityHoldingId1 | universityInstanceId | universityTenantName |
     * def v = call createCirculationRequest request2
 
     # 4.2 Verify circulation request 2
     Given path 'circulation', 'requests', requestId2
-    And header x-okapi-tenant = universityTenant
     And retry until responseStatus == 200
     When method GET
     Then status 200
@@ -662,7 +621,6 @@ Feature: Pieces API tests for cross-tenant envs
     * configure headers = headersCentral
     # 4.3 Verify circulation request 1
     Given path 'circulation', 'requests', requestId1
-    And header x-okapi-tenant = centralTenant
     And retry until responseStatus == 200
     When method GET
     Then status 200
@@ -670,7 +628,6 @@ Feature: Pieces API tests for cross-tenant envs
 
     # 5 Get requests by Piece Ids
     Given path '/orders/pieces-requests'
-    And header x-okapi-tenant = centralTenant
     And param status = 'Open - Not yet filled'
     And params { "pieceIds": [ '#(centralPieceId)', '#(universityPieceId)' ] }
     When method GET
@@ -686,10 +643,9 @@ Feature: Pieces API tests for cross-tenant envs
     * set minimalPiece.titleId = titleId
     * set minimalPiece.poLineId = poLineId
     * set minimalPiece.locationId = universityLocationsId
-    * set minimalPiece.receivingTenantId = universityTenant
+    * set minimalPiece.receivingTenantId = universityTenantName
 
     Given path 'orders/pieces'
-    And header x-okapi-tenant = centralTenant
     And param createItem = true
     And request minimalPiece
     When method POST
@@ -703,7 +659,6 @@ Feature: Pieces API tests for cross-tenant envs
     * configure headers = headersUni
     # 2.1 Check the created holding record in specified tenant
     Given path '/holdings-storage/holdings/', holdingId
-    And header x-okapi-tenant = universityTenant
     When method GET
     Then status 200
     And match response.instanceId == '#present'
@@ -711,13 +666,11 @@ Feature: Pieces API tests for cross-tenant envs
 
     # 2.2 Check the created shared instance in specified tenant
     Given path '/instance-storage/instances', instanceId
-    And header x-okapi-tenant = universityTenant
     When method GET
     Then status 200
 
     # 2.3 Check the created item in specified tenant
     Given path '/inventory/items'
-    And header x-okapi-tenant = universityTenant
     And param query = 'holdingsRecordId=' + holdingId
     When method GET
     Then status 200
@@ -728,24 +681,21 @@ Feature: Pieces API tests for cross-tenant envs
     * configure headers = headersCentral
     # 3. Change affliation in the piece
     Given path 'orders/pieces', pieceId
-    And header x-okapi-tenant = centralTenant
     When method GET
     Then status 200
     And def pieceResponse = response
 
-    * set pieceResponse.receivingTenantId = centralTenant
+    * set pieceResponse.receivingTenantId = centralTenantName
     * set pieceResponse.locationId = centralLocationsId
     * set pieceResponse.holdingId = null
 
     Given path 'orders/pieces', pieceId
-    And header x-okapi-tenant = centralTenant
     And request pieceResponse
     When method PUT
     Then status 204
 
     # 4.1 Verify changing of holding
     Given path 'orders/pieces', pieceId
-    And header x-okapi-tenant = centralTenant
     When method GET
     Then status 200
     And match holdingId != response.holdingId
@@ -753,20 +703,17 @@ Feature: Pieces API tests for cross-tenant envs
 
     # 4.2 Check the created holding record in 'centralTenant'
     Given path '/holdings-storage/holdings/', centralHoldingId
-    And header x-okapi-tenant = centralTenant
     When method GET
     Then status 200
     And match response.instanceId == '#present'
 
     # 4.3 Check the created shared instance in 'centralTenant'
     Given path '/instance-storage/instances', instanceId
-    And header x-okapi-tenant = centralTenant
     When method GET
     Then status 200
 
     # 4.4 Check the created item in 'centralTenant'
     Given path '/inventory/items'
-    And header x-okapi-tenant = centralTenant
     And param query = 'holdingsRecordId=' + centralHoldingId
     When method GET
     Then status 200
@@ -777,7 +724,6 @@ Feature: Pieces API tests for cross-tenant envs
     * configure headers = headersUni
     # 5.1 Verify that existing shared holding and item, and deletion of items in 'univeristyTenant'
     Given path '/holdings-storage/holdings/', holdingId
-    And header x-okapi-tenant = universityTenant
     When method GET
     Then status 200
     And match response.instanceId == '#present'
@@ -785,13 +731,11 @@ Feature: Pieces API tests for cross-tenant envs
 
     # 5.2 Check the existing shared instance in 'univeristyTenant'
     Given path '/instance-storage/instances', instanceId
-    And header x-okapi-tenant = universityTenant
     When method GET
     Then status 200
 
     # 5.3 Verify no item in 'univeristyTenant'
     Given path '/inventory/items'
-    And header x-okapi-tenant = universityTenant
     And param query = 'holdingsRecordId=' + holdingId
     When method GET
     Then status 200
@@ -813,10 +757,10 @@ Feature: Pieces API tests for cross-tenant envs
     # 2. Create three pieces with IDs 'pieceId1' and 'pieceId2'
     # One with associated tenant, one with no receiving tenant and one with unassociated tenant for user
     * table pieces
-      | id       | format     | poLineId | titleId  | holdingId            | receivingTenantId |
-      | pieceId1 | "Physical" | poLineId | titleId2 | centralHoldingId1    | null              |
-      | pieceId2 | "Physical" | poLineId | titleId2 | centralHoldingId1    | centralTenant     |
-      | pieceId3 | "Physical" | poLineId | titleId2 | universityHoldingId1 | universityTenant  |
+      | id       | format     | poLineId | titleId  | holdingId            | receivingTenantId     |
+      | pieceId1 | "Physical" | poLineId | titleId2 | centralHoldingId1    | null                  |
+      | pieceId2 | "Physical" | poLineId | titleId2 | centralHoldingId1    | centralTenantName     |
+      | pieceId3 | "Physical" | poLineId | titleId2 | universityHoldingId1 | universityTenantName  |
     * def v = call createPieceWithHolding pieces
 
     # 3. Fetch all pieces

--- a/acquisitions/src/main/resources/thunderjet/consortia/features/update-inventory-ownership-changes-order-data.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/features/update-inventory-ownership-changes-order-data.feature
@@ -3,9 +3,12 @@ Feature: Updating Holding ownership changes order data
   Background:
     * print karate.info.scenarioName
     * url baseUrl
-    * def headersCentral = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(centralTenant)' }
-    * def headersUniversity = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(universityTenant)' }
+
+    * call eurekaLogin { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenantName)' }
+    * def headersCentral = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(centralTenantName)' }
+    * def headersUniversity = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(universityTenantName)' }
     * configure headers = headersUniversity
+
     * configure retry = { interval: 1000, count: 5 }
 
     ### Before All ###
@@ -22,8 +25,8 @@ Feature: Updating Holding ownership changes order data
     * callonce createInstanceWithHrid instanceData
 
     * table shareInstanceData
-      | instanceId | sourceTenantId   | targetTenantId | consortiumId |
-      | instanceId | universityTenant | centralTenant  | consortiumId |
+      | instanceId | sourceTenantId       | targetTenantId     | consortiumId |
+      | instanceId | universityTenantName | centralTenantName  | consortiumId |
     * callonce shareInstance shareInstanceData
 
 
@@ -40,9 +43,9 @@ Feature: Updating Holding ownership changes order data
 
     * def poLineId = call uuid
     * table poLineLocations
-      | holdingId            | quantity | quantityPhysical | tenantId         |
-      | holdingId            | 1        | 1                | universityTenant |
-      | universityHoldingId1 | 1        | 1                | universityTenant |
+      | holdingId            | quantity | quantityPhysical | tenantId             |
+      | holdingId            | 1        | 1                | universityTenantName |
+      | universityHoldingId1 | 1        | 1                | universityTenantName |
     * table orderLineData
       | id       | orderId | locations       | quantity | fundId        | instanceId | titleOrPackage |
       | poLineId | orderId | poLineLocations | 2        | centralFundId | instanceId | instanceId     |
@@ -74,8 +77,8 @@ Feature: Updating Holding ownership changes order data
   Scenario: Test for changing ownership of Holdings to affect Pieces and PoLines
     # 1.1 Update holding ownership
     * table updateHoldingOwnershipData
-      | instanceId | holdingId | targetTenantId | targetLocationId   |
-      | instanceId | holdingId | centralTenant  | centralLocationsId |
+      | instanceId | holdingId | targetTenantId     | targetLocationId   |
+      | instanceId | holdingId | centralTenantName  | centralLocationsId |
     * def v = call updateHoldingOwnership updateHoldingOwnershipData
 
     # 1.2 Verify holding ownership
@@ -87,18 +90,18 @@ Feature: Updating Holding ownership changes order data
 
     # 2. Verify updated PoLine contains updated locations
     Given path 'orders/order-lines', poLineId
-    And retry until response.locations[0].tenantId == centralTenant || response.locations[1].tenantId == centralTenant
+    And retry until response.locations[0].tenantId == centralTenantName || response.locations[1].tenantId == centralTenantName
     When method GET
     Then status 200
-    And match response.locations[*].tenantId contains centralTenant
-    And match response.locations[*].tenantId contains universityTenant
+    And match response.locations[*].tenantId contains centralTenantName
+    And match response.locations[*].tenantId contains universityTenantName
     And match response.locations[*].holdingId contains holdingId
     And match response.locations[*].holdingId contains universityHoldingId1
 
     # 3. Verify updated Piece contains updated receivingTenantId and holdingId
     Given path 'orders/pieces', pieceId
-    And retry until response.receivingTenantId == centralTenant
+    And retry until response.receivingTenantId == centralTenantName
     When method GET
     Then status 200
     And match response.holdingId == holdingId
-    And match response.receivingTenantId == centralTenant
+    And match response.receivingTenantId == centralTenantName

--- a/acquisitions/src/main/resources/thunderjet/consortia/features/update-unaffiliated-pol-locations.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/features/update-unaffiliated-pol-locations.feature
@@ -1,10 +1,16 @@
 Feature: Update PoLine locations with tenantIds the user do not have affiliations with
 
   Background:
+    * print karate.info.scenarioName
     * url baseUrl
-    * def headersUser = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitokenUser)', 'x-okapi-tenant': '#(centralTenant)', 'Accept': 'application/json' }
-    * def headersUni = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(universityTenant)', 'Accept': 'application/json' }
-    * def headersCentral = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(centralTenant)', 'Accept': 'application/json' }
+
+    * def resultAdmin = call eurekaLogin { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenantName)' }
+    * def okapitoken = resultAdmin.okapitoken
+    * def resultUser = call eurekaLogin { username: '#(centralUser.username)', password: '#(centralUser.password)', tenant: '#(centralTenantName)' }
+    * def okapitokenUser = resultUser.okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitokenUser)', 'x-okapi-tenant': '#(centralTenantName)', 'Accept': 'application/json' }
+    * def headersUni = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(universityTenantName)', 'Accept': 'application/json' }
+    * def headersCentral = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(centralTenantName)', 'Accept': 'application/json' }
     * configure headers = headersCentral
 
     * callonce variables
@@ -16,11 +22,11 @@ Feature: Update PoLine locations with tenantIds the user do not have affiliation
     * def poLineId = callonce uuid
 
     * table poLineLocations
-      | locationId             | quantity | quantityPhysical | tenantId         |
-      | centralLocationsId     | 1        | 1                | centralTenant    |
-      | centralLocationsId2    | 1        | 1                | centralTenant    |
-      | universityLocationsId  | 1        | 1                | universityTenant |
-      | universityLocationsId2 | 1        | 1                | universityTenant |
+      | locationId             | quantity | quantityPhysical | tenantId             |
+      | centralLocationsId     | 1        | 1                | centralTenantName    |
+      | centralLocationsId2    | 1        | 1                | centralTenantName    |
+      | universityLocationsId  | 1        | 1                | universityTenantName |
+      | universityLocationsId2 | 1        | 1                | universityTenantName |
     * callonce createOrder { id: '#(orderId)' }
     * callonce createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', quantity: 4, locations: '#(poLineLocations)', isPackage: True }
 

--- a/acquisitions/src/main/resources/thunderjet/consortia/order-utils/configuration.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/order-utils/configuration.feature
@@ -2,7 +2,7 @@ Feature: global finances
 
   Background:
     * url baseUrl
-    * configure headers = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(token)', 'x-okapi-tenant': '#(tenant.name)', 'Accept': '*/*' }
+    * configure headers = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(centralTenantName)', 'Accept': '*/*' }
 
   Scenario: update configuration poline limit
     Given path 'configurations/entries'

--- a/acquisitions/src/main/resources/thunderjet/consortia/order-utils/finances.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/order-utils/finances.feature
@@ -1,27 +1,28 @@
-Feature: central finances
+@parallel=false
+Feature: Central finances
 
   Background:
     * url baseUrl
-    * configure headers = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(token)', 'x-okapi-tenant': '#(tenant.name)', 'Accept': '*/*' }
+    * configure headers = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(centralTenantName)', 'Accept': '*/*' }
 
     # load central variables
     * callonce variablesCentral
 
-  Scenario: create fiscal year
+  Scenario: Create fiscal years
     * table fiscalYears
       | id                         | code     | periodStart            | periodEnd              | series |
       | centralFiscalYearId        | 'FY2025' | '2025-01-01T00:00:00Z' | '2025-12-31T23:59:59Z' | 'FY'   |
       | centralPlannedFiscalYearId | 'FY2026' | '2026-01-01T00:00:00Z' | '2026-12-31T23:59:59Z' | 'FY'   |
     * def v = call createFiscalYear fiscalYears
 
-  Scenario: create ledgers
+  Scenario: Create ledgers
     * table ledgers
       | id                              | fiscalYearId        | restrictEncumbrance | restrictExpenditure |
       | centralLedgerId                 | centralFiscalYearId | false               | false               |
       | centralLedgerWithRestrictionsId | centralFiscalYearId | true                | true                |
     * def v = call createLedger ledgers
 
-  Scenario: create funds
+  Scenario: Create funds
     * table funds
       | id                       | code                         | ledgerId        | externalAccountNo              |
       | centralFundId            | centralFundCode              | centralLedgerId | '1111111111111111111111111'    |
@@ -30,7 +31,7 @@ Feature: central finances
       | centralFundWithoutBudget | centralFundWithoutBudgetCode | centralLedgerId | '2111111111111111111111111'    |
     * def v = call createFund funds
 
-  Scenario: create budgets
+  Scenario: Create budgets
     * table budgets
       | id               | fundId         | fiscalYearId        | allocated |
       | centralBudgetId  | centralFundId  | centralFiscalYearId | 9999999   |
@@ -38,7 +39,7 @@ Feature: central finances
       | centralBudgetId3 | centralFundId3 | centralFiscalYearId | 9999999   |
     * def v = call createBudget budgets
 
-  Scenario: create expense classes
+  Scenario: Create expense classes
     * table expenseClasses
       | id                         | code   | name         | externalAccountNumberExt |
       | centralElecExpenseClassId  | "Elec" | "Electronic" | "01"                     |

--- a/acquisitions/src/main/resources/thunderjet/consortia/order-utils/inventory-university.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/order-utils/inventory-university.feature
@@ -1,68 +1,69 @@
-Feature: global inventory
+@parallel=false
+Feature: Global inventory
 
   Background:
     * url baseUrl
-    * configure headers = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(token)', 'x-okapi-tenant': '#(tenant.name)', 'Accept': '*/*' }
+    * configure headers = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(universityTenantName)', 'Accept': '*/*' }
     * callonce variablesUniversity
 
-  Scenario: create instance types
+  Scenario: Create instance types
     * table instanceTypes
       | id                             | code                       |
       | universityInstanceTypeId       | 'apiTestsInstanceTypeCode' |
       | universitySecondInstanceTypeId | 'zzz'                      |
     * def v = call createInstanceType instanceTypes
 
-  Scenario: create instance statuses
+  Scenario: Create instance statuses
     * table instanceStatuses
       | id                               | code                         |
       | universityInstanceStatusId       | 'temp'                       |
       | universitySecondInstanceStatusId | 'apiTestsInstanceStatusCode' |
     * def v = call createInstanceStatus instanceStatuses
 
-  Scenario: create loan types
+  Scenario: Create loan types
     * table loanTypes
       | id                   | name            |
       | universityLoanTypeId | 'Can circulate' |
     * def v = call createLoanType loanTypes
 
-  Scenario: create material types
+  Scenario: Create material types
     * table materialTypes
       | id                           | name   |
       | universityMaterialTypeIdPhys | 'Phys' |
       | universityMaterialTypeIdElec | 'Elec' |
     * def v = call createMaterialType materialTypes
 
-  Scenario: create institutions
+  Scenario: Create institutions
     * table institutions
       | id                                    | name          | code |
       | universityLocationUnitsInstitutionsId | 'Universitet' | 'TU' |
     * def v = call createInstitution institutions
 
-  Scenario: create campus
+  Scenario: Create campus
     * table campuses
       | id                                | institutionId                         | name     | code |
       | universityLocationUnitsCampusesId | universityLocationUnitsInstitutionsId | 'Campus' | 'TC' |
     * def v = call createCampus campuses
 
-  Scenario: create libraries
+  Scenario: Create libraries
     * table libraries
       | id                                 | campusId                          | name      | code |
       | universityLocationUnitsLibrariesId | universityLocationUnitsCampusesId | 'Library' | 'TL' |
     * def v = call createLibrary libraries
 
-  Scenario: create service points
+  Scenario: Create service points
     * table servicePoints
       | id                        | name            | code  | discoveryDisplayName |
       | universityServicePointsId | 'Service point' | 'TPS' | 'Service point 1'    |
     * def v = call createServicePoint servicePoints
 
-  Scenario: create holdings sources
+  Scenario: Create holdings sources
     * table holdingSources
       | id                         | name    |
       | universityHoldingsSourceId | 'FOLIO' |
     * def v = call createHoldingSource holdingSources
 
-  Scenario: create locations
+  Scenario: Create locations
     * table locations
       | id                     | code   | institutionId                         | campusId                          | libraryId                          | servicePointId            |
       | universityLocationsId  | 'LOC1' | universityLocationUnitsInstitutionsId | universityLocationUnitsCampusesId | universityLocationUnitsLibrariesId | universityServicePointsId |

--- a/acquisitions/src/main/resources/thunderjet/consortia/order-utils/inventory.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/order-utils/inventory.feature
@@ -1,8 +1,9 @@
+@parallel=false
 Feature: Central inventory
 
   Background:
     * url baseUrl
-    * configure headers = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(token)', 'x-okapi-tenant': '#(tenant.name)', 'Accept': '*/*' }
+    * configure headers = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(centralTenantName)', 'Accept': '*/*' }
     * callonce variablesCentral
 
   Scenario: create instance types

--- a/acquisitions/src/main/resources/thunderjet/consortia/order-utils/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/order-utils/orders.feature
@@ -1,8 +1,8 @@
-Feature: global orders
+Feature: Global orders
 
   Background:
     * url baseUrl
-    * configure headers = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(token)', 'x-okapi-tenant': '#(tenant.name)', 'Accept': '*/*' }
+    * configure headers = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(centralTenantName)', 'Accept': '*/*' }
     * callonce variablesCentral
 
 

--- a/acquisitions/src/main/resources/thunderjet/consortia/order-utils/organizations.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/order-utils/organizations.feature
@@ -1,15 +1,14 @@
-Feature: global organizations
+Feature: Global organizations
 
   Background:
     * url baseUrl
+
+    * configure headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(centralTenantName)', 'Accept': 'application/json' }
+
     * callonce variablesCentral
 
-  Scenario: create vendor
-    Given path 'organizations-storage/organizations'
-    And header Accept = 'application/json'
-    And header Content-Type = 'application/json'
-    And header x-okapi-token = okapitoken
-    And header x-okapi-tenant = tenantName
+  Scenario: Create vendor
+    Given path 'organizations/organizations'
     And request
     """
     {
@@ -23,12 +22,8 @@ Feature: global organizations
     When method POST
     Then status 201
 
-  Scenario: create organization which is not a vendor
-    Given path 'organizations-storage/organizations'
-    And header Accept = 'application/json'
-    And header Content-Type = 'application/json'
-    And header x-okapi-token = okapitoken
-    And header x-okapi-tenant = tenantName
+  Scenario: Create organization which is not a vendor
+    Given path 'organizations/organizations'
     And request
     """
     {

--- a/acquisitions/src/main/resources/thunderjet/consortia/variables/variablesCentral.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/variables/variablesCentral.feature
@@ -51,4 +51,4 @@ Feature: Central variables
 
   Scenario: User IDs
     * def centralAdminId = '122b3d2b-4788-4f1e-9117-56daa91cb75c'
-    * def centralUser1Id = '6d27d190-b6e4-4075-b80f-01517bafb2d4'
+    * def centralUserId = '6d27d190-b6e4-4075-b80f-01517bafb2d4'

--- a/acquisitions/src/main/resources/thunderjet/mod-gobi/gobi-junit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-gobi/gobi-junit.feature
@@ -59,6 +59,7 @@ Feature: mod-gobi integration tests
       | 'inventory-storage.contributor-name-types.item.post'          |
       | 'inventory-storage.electronic-access-relationships.item.post' |
       | 'inventory-storage.holdings-sources.item.post'                |
+      | 'inventory-storage.holdings.collection.get'                   |
       | 'inventory-storage.holdings.item.post'                        |
       | 'inventory-storage.identifier-types.item.post'                |
       | 'inventory-storage.instance-statuses.item.post'               |

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/bind-piece.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/bind-piece.feature
@@ -12,8 +12,8 @@ Feature: Verify Bind Piece feature
     * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
     * configure headers = headersUser
 
-    * def tenantId1 = karate.get('tenantId1', testTenant);
-    * def tenantId2 = karate.get('tenantId2', testTenant);
+    * def tenantId1 = karate.get('tenantId1', testTenant)
+    * def tenantId2 = karate.get('tenantId2', testTenant)
 
     * configure retry = { count: 5, interval: 1000 }
 
@@ -28,9 +28,9 @@ Feature: Verify Bind Piece feature
 
     * callonce variables
 
-    * def holdingId1 = karate.get('holdingId1', globalHoldingId1);
-    * def holdingId2 = karate.get('holdingId2', globalHoldingId2);
-    * def holdingId3 = karate.get('holdingId3', globalHoldingId3);
+    * def holdingId1 = karate.get('holdingId1', globalHoldingId1)
+    * def holdingId2 = karate.get('holdingId2', globalHoldingId2)
+    * def holdingId3 = karate.get('holdingId3', globalHoldingId3)
 
     * def fromYear = callonce getCurrentYear
     * def toYear = parseInt(fromYear) + 1

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/user-init-data.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/user-init-data.feature
@@ -67,14 +67,12 @@ Feature:
     * set userData.type = 'patron'
     * set userData.patronGroup = groupId
 
-    * configure headers = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(tenant)', 'Accept': 'text/plain' }
     # update user
     Given path 'users', userId
     And header Accept = 'text/plain'
     And request userData
     When method PUT
     Then status 204
-    * configure headers = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(tenant)', 'Accept': 'application/json' }
 
     Given path 'users', userId
     When method GET


### PR DESCRIPTION
## Purpose
[MODORDERS-1272](https://folio-org.atlassian.net/browse/MODORDERS-1272) - Run ACQ Karate tests on Eureka platform

## Approach
- Cleaned up consortia-orders-junit.feature to make it easier to read
- Fixed the headers for all requests in consortia tests (note that "`And header`" does not work when `configure` is used)
- Removed unused permissions

### TODOS
- Continue fixing tests for Eureka
- Look at non-junit features
- Someone else should look at the remaining errors in `open-order-with-locations-from-different-tenants` and `reopen-and-change-instance-connection-order-with-locations-from-different-tenants`, they are probably caused by errors in the consortia tests (as multiple errors were cancelling each other and the user/permissions were fixed)
