### PR TITLE
FAT-19900: Fix GET /material-types query in validation test cases

### DIFF
--- a/mod-dcb/src/main/resources/volaris/mod-dcb/features/borrowing-flow.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/features/borrowing-flow.feature
@@ -216,12 +216,13 @@ Feature: Borrowing Flow Scenarios
     And match $.errors[0].message == 'Cannot set item.materialtypeid = ' + intMaterialTypeIdNonExisting + ' because it does not exist in material_type.id.'
 
     # If the material type is not given in the request, then we check for default material type as book in inventory, if it doesn't exist, we throw the error.
-    * def materialTypeEntityRequest = read('classpath:volaris/mod-dcb/features/samples/item/material-type-entity-request.json')
-    * materialTypeEntityRequest.name = 'book'
     Given path 'material-types'
-    And request materialTypeEntityRequest
+    Given param query = '(name= ' + materialTypeName + ')'
     When method GET
     Then status 200
+    And match $.totalRecords == 1
+    And match $.mtypes[0].name == materialTypeName
+    And match $.mtypes[0].id == intMaterialTypeId
 
   Scenario: Validation. If the user exist but the type is DCB, error will be thrown
 

--- a/mod-dcb/src/main/resources/volaris/mod-dcb/features/pickup-flow.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/features/pickup-flow.feature
@@ -202,12 +202,13 @@ Feature: Pickup Flow Scenarios
     And match $.errors[0].message == 'Cannot set item.materialtypeid = ' + intMaterialTypeIdNonExisting + ' because it does not exist in material_type.id.'
 
     # If the material type is not given in the request, then we check for default material type as book in inventory, if it doesn't exist, we throw the error.
-    * def materialTypeEntityRequest = read('classpath:volaris/mod-dcb/features/samples/item/material-type-entity-request.json')
-    * materialTypeEntityRequest.name = 'book'
     Given path 'material-types'
-    And request materialTypeEntityRequest
+    Given param query = '(name= ' + materialTypeName + ')'
     When method GET
     Then status 200
+    And match $.totalRecords == 1
+    And match $.mtypes[0].name == materialTypeName
+    And match $.mtypes[0].id == intMaterialTypeId
 
   @CreateDCBTransaction
   Scenario: Create DCB Transaction


### PR DESCRIPTION
## Purpose
Fix failing validation test cases for pickup and borrowing flows

## Approach
- no request body is needed for `GET /material-types`
- use `query` param to fetch material-type by name

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
[FAT-19900](https://folio-org.atlassian.net/browse/FAT-19900)


<img width="1416" alt="image" src="https://github.com/user-attachments/assets/c5500a25-d6a5-4766-bd22-167854ba865d" />

<img width="1416" alt="image" src="https://github.com/user-attachments/assets/f6a09664-c0c6-4611-a57a-49842a24c5d1" />


