### PR TITLE
FAT-20147 - Remove body from request to GET /data-import/fileExtensions to correct test

### DIFF
--- a/data-import/src/main/resources/folijet/data-import/features/file-extensions.feature
+++ b/data-import/src/main/resources/folijet/data-import/features/file-extensions.feature
@@ -132,18 +132,14 @@ Feature: File extensions
     Then status 200
 
   Scenario: Return a list of file extensions for which import is blocked
-
     * print 'Return a list of file extensions for which import is blocked'
 
     Given path '/data-import/fileExtensions'
-    And request
-    """
-    {
-      "importBlocked": true
-    }
-    """
+    And param query = 'importBlocked == true'
     When method GET
     Then status 200
+    And match each response.fileExtensions contains { "importBlocked": true }
+    And assert response.totalRecords == 6
 
   Scenario: Fail to delete non-existent extension
 


### PR DESCRIPTION
## Purpose
to correct the "Return a list of file extensions for which import is blocked" scenario according to GET /data-import/fileExtensions endpoint that expects query parameter instead of request body for file extensions search criteria


## Approach
* remove request body and specify search criteria through `query` parameter exposed by the endpoint


## Learning
[FAT-20147](https://issues.folio.org/browse/FAT-20147)
