### PR TITLE
[MODORDERS-1308] Test order totals with different invoice currency

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
@@ -56,6 +56,9 @@ Feature: cross-module integration tests
   Scenario: Check order re-encumber after preview rollover
     * call read('features/check-order-re-encumber-after-preview-rollover.feature')
 
+  Scenario: Check that order total fields are calculated correctly
+    * call read('features/check-order-total-fields-calculated-correctly.feature')
+
   Scenario: Check payment status after cancelling paid invoice
     * call read('features/check-payment-status-after-cancelling-paid-invoice.feature')
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
@@ -54,9 +54,6 @@ Feature: mod-orders integration tests
   Scenario: Check order re-encumber works correctly
     * call read('features/check-order-re-encumber-work-correctly.feature')
 
-  Scenario: Check that order total fields are calculated correctly
-    * call read('features/check-order-total-fields-calculated-correctly.feature')
-
   Scenario: Check needReEncumber flag populated correctly
     * call read('features/check-re-encumber-property.feature')
 

--- a/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
+++ b/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
@@ -101,6 +101,11 @@ public class CrossModulesApiTest extends TestBaseEureka {
   }
 
   @Test
+  void checkOrderTotalFieldsCalculatedCorrectly() {
+    runFeatureTest("check-order-total-fields-calculated-correctly");
+  }
+
+  @Test
   void checkPaymentStatusAfterCancellingPaidInvoice() {
     runFeatureTest("check-payment-status-after-cancelling-paid-invoice");
   }

--- a/acquisitions/src/test/java/org/folio/OrdersApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersApiTest.java
@@ -99,11 +99,6 @@ public class OrdersApiTest extends TestBaseEureka {
   }
 
   @Test
-  void checkOrderTotalFieldsCalculatedCorrectly() {
-    runFeatureTest("check-order-total-fields-calculated-correctly");
-  }
-
-  @Test
   void checkOrderNeedReEncumber() {
     runFeatureTest("check-re-encumber-property");
   }


### PR DESCRIPTION
## Purpose
[MODORDERS-1308](https://folio-org.atlassian.net/browse/MODORDERS-1308) - Order expended amount is not converting the invoice currency

## Approach
- Moved `check-order-total-fields-calculated-correctly.feature` from mod-orders to cross-module tests.
- Adjusted user/header usage
- Added a test to check order totals when an invoice uses a different currency than the system currency

## Related PR
[mod-orders PR](https://github.com/folio-org/mod-orders/pull/1130)

