### PR TITLE
Load capability sets using paging approach

### DIFF
--- a/common/src/main/resources/common/eureka/setup-users.feature
+++ b/common/src/main/resources/common/eureka/setup-users.feature
@@ -180,7 +180,21 @@ Feature: prepare data for api test
     Then status 201
 
     * print "---add capability sets for test user---"
-    * def capabilitySets = call read('classpath:common/eureka/capabilities.feature@getCapabilitySets')
-    * def capabilitySetIds = capabilitySets.response.capabilitySets.map(x => x.id)
+    * def loadCapabilitySetIds =
+    """
+      function() {
+        var capabilitySetIds = []
+        var chunkSize = 100;
+        for (let i = 0; i < permissions.length; i += chunkSize) {
+          var permissionsBatch = userPermissions.slice(i, i + chunkSize);
+          var result = karate.call('classpath:common/eureka/capabilities.feature@getCapabilitySets', {userPermissions: permissionsBatch});
+          var foundCapabilitySets = result.response.capabilitySets;
+          capabilitySetIds = capabilitySetIds.concat(foundCapabilitySets.map(x => x.id));
+        }
+
+        return capabilitySetIds;
+      }
+    """
+    * def capabilitySetIds = call loadCapabilitySetIds
     * if (capabilitySetIds.length == 0) karate.log('No capability sets found for the user');
     * if (capabilitySetIds.length > 0) karate.call('classpath:common/eureka/capabilities.feature@postCapabilitySets', {capabilitySetIds: capabilitySetIds});


### PR DESCRIPTION
## Purpose
Load capability sets using a paging approach to avoid issue: 414 Request-URI Too Long

## Approach
- Refactor load capability sets action to avoid `Request-URI Too Long`

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
