### PR TITLE
Fix reference to class in TestBaseEureka for correct prefixing of team names

### DIFF
--- a/testrail-integration/src/main/java/org/folio/test/TestBaseEureka.java
+++ b/testrail-integration/src/main/java/org/folio/test/TestBaseEureka.java
@@ -204,8 +204,8 @@ public abstract class TestBaseEureka {
                         .concat(featurePath);
             }
 
-            AtomicInteger testCount = testCounts.computeIfAbsent(getClass(), key -> new AtomicInteger());
-            RuntimeHook hook = new FolioRuntimeHook(getClass(), testInfo, testCount.incrementAndGet());
+            AtomicInteger testCount = testCounts.computeIfAbsent(TestBaseEureka.this.getClass(), key -> new AtomicInteger());
+            RuntimeHook hook = new FolioRuntimeHook(TestBaseEureka.this.getClass(), testInfo, testCount.incrementAndGet());
 
             Runner.Builder builder = Runner.path(actualFeaturePath)
                     .outputCucumberJson(true)

--- a/testrail-integration/src/main/java/org/folio/test/TestBaseEureka.java
+++ b/testrail-integration/src/main/java/org/folio/test/TestBaseEureka.java
@@ -204,6 +204,8 @@ public abstract class TestBaseEureka {
                         .concat(featurePath);
             }
 
+            // Use TestBaseEureka.this.getClass() to get the actual test class (e.g., DataImportApiTest)
+            // instead of the inner FeatureRunner class, so FolioRuntimeHook can find the @FolioTest annotation
             AtomicInteger testCount = testCounts.computeIfAbsent(TestBaseEureka.this.getClass(), key -> new AtomicInteger());
             RuntimeHook hook = new FolioRuntimeHook(TestBaseEureka.this.getClass(), testInfo, testCount.incrementAndGet());
 


### PR DESCRIPTION
## Purpose
Fix reference to class in TestBaseEureka for correct prefixing of team names

## Approach
In the previous state, the class retrieved was the FeatureRunner class. This class does not have the annotation for the team names. The code now retrieves the TestBaseEureka class now.