### PR TITLE
MODSOURCE-898 Update deleted instances with MARC-MARC matching

### DIFF
--- a/data-import/src/main/resources/folijet/data-import/features/marc-records/data-import-set-for-deletion.feature
+++ b/data-import/src/main/resources/folijet/data-import/features/marc-records/data-import-set-for-deletion.feature
@@ -2,15 +2,9 @@ Feature: Set for deletion logic
 
   Background:
     * url baseUrl
-    * call login testUser
-    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(testTenant)', 'Accept': '*/*' }
-    * def headersUserOctetStream = { 'Content-Type': 'application/octet-stream', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(testTenant)', 'Accept': '*/*'  }
-    * def utilFeature = 'classpath:folijet/data-import/global/import-record.feature'
-    * def commonImportFeature = 'classpath:folijet/data-import/global/common-data-import.feature'
-    * def completeExecutionFeature = 'classpath:folijet/data-import/global/get-completed-job-execution-for-key.feature@getJobWhenJobStatusCompleted'
-    * def samplePath = 'classpath:folijet/data-import/samples/'
+    * call read('classpath:folijet/data-import/global/auth.feature')
+    * call read('classpath:folijet/data-import/global/common-functions.feature')
 
-    * def javaDemo = Java.type('test.java.WriteData')
 
   @Ignore
   @SetupUpdateJobProfile
@@ -184,6 +178,7 @@ Feature: Set for deletion logic
   @Ignore
   @VerifyInstanceAndRecordMarkedAsDeleted
   Scenario: Verify instance and record are marked as deleted
+    # TODO: add explicit parameters for this scenario
     # Retrieve instance
     Given path 'inventory/instances'
     And headers headersUser
@@ -217,9 +212,9 @@ Feature: Set for deletion logic
     * def fileName = 'updateMarcBibDeletedLeader'
     * def filePathFromSourceRoot = 'file:target/' + fileName + '.mrc'
     * def marcRecord = read('classpath:folijet/data-import/samples/mrc-files/marcBibDeletedLeader.mrc')
-    * def updatedMarcRecord = javaDemo.modifyMarcRecord(marcRecord, '001', ' ', ' ', ' ', instanceHrid)
+    * def updatedMarcRecord = javaWriteData.modifyMarcRecord(marcRecord, '001', ' ', ' ', ' ', instanceHrid)
 
-    * javaDemo.writeByteArrayToFile(updatedMarcRecord, 'target/' + fileName + '.mrc')
+    * javaWriteData.writeByteArrayToFile(updatedMarcRecord, 'target/' + fileName + '.mrc')
 
     Given call read('@SetupUpdateJobProfile') { profileName: 'Update deleted' }
     * def jobProfileId = updateJobProfileId
@@ -233,9 +228,9 @@ Feature: Set for deletion logic
     * def fileName = 'unmarkDeleted'
     * def filePathFromSourceRoot = 'file:target/' + fileName + '.mrc'
     * def marcRecord = read('classpath:folijet/data-import/samples/mrc-files/marcBib.mrc')
-    * def updatedMarcRecord = javaDemo.modifyMarcRecord(marcRecord, '001', ' ', ' ', ' ', instanceHrid)
+    * def updatedMarcRecord = javaWriteData.modifyMarcRecord(marcRecord, '001', ' ', ' ', ' ', instanceHrid)
 
-    * javaDemo.writeByteArrayToFile(updatedMarcRecord, 'target/' + fileName + '.mrc')
+    * javaWriteData.writeByteArrayToFile(updatedMarcRecord, 'target/' + fileName + '.mrc')
 
     Given call read('@SetupUpdateJobProfile') { profileName: 'Unmark deleted' }
     * def jobProfileId = updateJobProfileId
@@ -264,3 +259,79 @@ Feature: Set for deletion logic
     And match response.additionalInfo.suppressDiscovery == true
     And match response.state == 'ACTUAL'
     And match response.leaderRecordStatus == 'c'
+
+  ### MODINV-1232
+  Scenario: MODSOURCE-898 - Update deleted instance using MARC-MARC matching
+    # Step 1: Create MARC instance using default job profile for creating instance
+    * def marcBibJson = read('classpath:folijet/data-import/samples/marcBib.mrc.json')
+    # Update 245$a with timestamp to make each test run unique
+    * def timestamp = '' + java.lang.System.currentTimeMillis()
+    * def field245 = marcBibJson.fields.find(field => field['245'])
+    * field245['245'].subfields.find(sf => sf.a).a = 'Summerland_MODSOURCE-898' + timestamp + ' /'
+    Given call read('classpath:folijet/data-import/global/import-marc-json-and-verify.feature') { marcJsonObject: '#(marcBibJson)', fileName: 'marcBib', jobName: 'createInstance', actionStatus: 'CREATED' }
+
+    # Step 2: Mark instance as deleted using DELETE /inventory/instances/{id}/mark-deleted
+    Given path 'inventory/instances', instanceId, 'mark-deleted'
+    And headers headersUser
+    When method DELETE
+    Then status 204
+
+    # Step 3: Export MARC instance using data export
+    # Create export mapping and job profiles for export
+    * def exportMappingProfileName = 'MODSOURCE-898 Export mapping profile'
+    * def dataExportMappingProfile = read('classpath:folijet/data-import/samples/profiles/data-export-mapping-profile.json')
+    * def result = call createExportMappingProfile { mappingProfile: "#(dataExportMappingProfile)" }
+    * def exportJobProfileName = 'MODSOURCE-898 Export job profile'
+    * def result = call createExportJobProfile { jobProfileName: "#(exportJobProfileName)", dataExportMappingProfileId: "#(result.dataExportMappingProfileId)" }
+    * def dataExportJobProfileId = result.dataExportJobProfileId
+
+    # Export MARC record by instance id
+    * def fileName = 'MODSOURCE-898-exported.mrc'
+    * def result = call read(exportRecordFeature) { instanceId: "#(instanceId)", dataExportJobProfileId: "#(dataExportJobProfileId)", fileName: "#(fileName)" }
+
+    # Step 4: Create MARC update job profile (MARC-MARC matching with 999ff$i)
+    Given call read('classpath:folijet/data-import/global/setup-marc-to-marc-update-profile.feature') { profileName: 'MODSOURCE-898 MARC-MARC Update deleted', actionType: 'UPDATE', mappingOption: 'UPDATE' }
+    * def jobProfileId = updateJobProfileId
+
+    # Step 5: Make changes in exported file (add "upd" in 245 field)
+    # Modify the exported MARC record using javaWriteData utility
+    * def modifiedFileName = 'MODSOURCE-898-modified.mrc'
+    * def modifiedMarcRecord = javaWriteData.modifyMarcRecord(result.exportedBinaryMarcRecord, '245', '1', '0', 'a', 'Summerland_MODSOURCE-898' + timestamp + ' upd /')
+    * javaWriteData.writeByteArrayToFile(modifiedMarcRecord, modifiedFileName)
+
+    # Step 6: Run import with created job profile and updated file
+    * def filePathFromSourceRoot = 'file:' + modifiedFileName
+    # Note: jobProfileId from Step 4 is used by customJob.json within the ImportRecord function
+    Given call read(utilFeature + '@ImportRecord') { fileName: '#(modifiedFileName)', jobName: 'customJob', filePathFromSourceRoot: '#(filePathFromSourceRoot)' }
+
+    # Verify job execution for update job execution
+    * call read(completeExecutionFeature) { key: '#(sourcePath)' }
+    * def jobExecution = response
+    And assert jobExecution.status == 'COMMITTED'
+
+    # Verify the record was successfully updated via MARC-MARC matching
+    Given path 'metadata-provider/jobLogEntries', jobExecutionId
+    And headers headersUser
+    When method GET
+    Then status 200
+    And match response.entries[0].sourceRecordActionStatus == "UPDATED"
+    And match response.entries[0].relatedInstanceInfo.actionStatus == "UPDATED"
+    * def instanceId = response.entries[0].relatedInstanceInfo.idList[0]
+
+    # Verify the source record content was properly updated
+    # Retrieving the source record by instanceId so that the latest generation of the instance is fetched
+    # There will be two source records for the same instanceId, one for the original import and one for the update
+    Given path 'source-storage/records', instanceId, 'formatted'
+    And param idType = 'INSTANCE'
+    And headers headersUser
+    When method GET
+    Then status 200
+    * def sourceRecordId = response.id
+    * def updatedParsedContent = response.parsedRecord.content
+    * def finalMarcJson = (typeof updatedParsedContent === 'string') ? JSON.parse(updatedParsedContent) : updatedParsedContent
+    # Verify the 245 field was updated with "upd"
+    * def field245Final = finalMarcJson.fields.find(field => field['245'])
+    And match field245Final['245'].subfields[0].a contains 'upd'
+
+    # Verify instance and record remain marked as deleted
+    Given call read('@VerifyInstanceAndRecordMarkedAsDeleted')

--- a/data-import/src/main/resources/folijet/data-import/features/marc-records/data-import-set-for-deletion.feature
+++ b/data-import/src/main/resources/folijet/data-import/features/marc-records/data-import-set-for-deletion.feature
@@ -260,7 +260,6 @@ Feature: Set for deletion logic
     And match response.state == 'ACTUAL'
     And match response.leaderRecordStatus == 'c'
 
-  ### MODINV-1232
   Scenario: MODSOURCE-898 - Update deleted instance using MARC-MARC matching
     # Step 1: Create MARC instance using default job profile for creating instance
     * def marcBibJson = read('classpath:folijet/data-import/samples/marcBib.mrc.json')
@@ -326,6 +325,11 @@ Feature: Set for deletion logic
     And headers headersUser
     When method GET
     Then status 200
+    ### MODINV-1232
+    # Verify the response contains parsedRecord with content and leader
+    Then match response.parsedRecord.content.fields == '#present'
+    And match response.parsedRecord.content.leader == '#present'
+    ### END
     * def sourceRecordId = response.id
     * def updatedParsedContent = response.parsedRecord.content
     * def finalMarcJson = (typeof updatedParsedContent === 'string') ? JSON.parse(updatedParsedContent) : updatedParsedContent

--- a/data-import/src/main/resources/folijet/data-import/features/marc-records/data-import-set-for-deletion.feature
+++ b/data-import/src/main/resources/folijet/data-import/features/marc-records/data-import-set-for-deletion.feature
@@ -256,6 +256,11 @@ Feature: Set for deletion logic
     When method GET
     Then status 200
     And match response.deleted == false
+    ### MODINV-1232
+    # Verify the response contains parsedRecord with content and leader
+    And match response.parsedRecord.content.fields == '#present'
+    And match response.parsedRecord.content.leader == '#present'
+    ### END
     And match response.additionalInfo.suppressDiscovery == true
     And match response.state == 'ACTUAL'
     And match response.leaderRecordStatus == 'c'
@@ -325,11 +330,6 @@ Feature: Set for deletion logic
     And headers headersUser
     When method GET
     Then status 200
-    ### MODINV-1232
-    # Verify the response contains parsedRecord with content and leader
-    Then match response.parsedRecord.content.fields == '#present'
-    And match response.parsedRecord.content.leader == '#present'
-    ### END
     * def sourceRecordId = response.id
     * def updatedParsedContent = response.parsedRecord.content
     * def finalMarcJson = (typeof updatedParsedContent === 'string') ? JSON.parse(updatedParsedContent) : updatedParsedContent

--- a/data-import/src/main/resources/folijet/data-import/global/import-marc-json-and-verify.feature
+++ b/data-import/src/main/resources/folijet/data-import/global/import-marc-json-and-verify.feature
@@ -1,0 +1,77 @@
+Feature: Import MARC JSON and Verify
+
+  Background:
+    * url baseUrl
+    * call read('classpath:folijet/data-import/global/auth.feature')
+    * call read('classpath:folijet/data-import/global/common-functions.feature')
+
+  @ImportMarcJsonAndVerify
+  Scenario: Import MARC JSON record and verify
+    # Handle parameters with defaults
+    * def passedParams = karate.get('__arg', {})
+    * def marcJsonObject = passedParams.marcJsonObject
+    * def jobName = passedParams.jobName
+    * def actionStatus = passedParams.actionStatus
+    * def fileName = passedParams.fileName || 'marcRecord_' + java.lang.System.currentTimeMillis()
+    * def filePathFromSourceRoot = passedParams.filePathFromSourceRoot
+
+    # Validate that jobProfileId is available (required for customJob.json and similar job files)
+    * if (jobName == 'customJob' && typeof jobProfileId == 'undefined') karate.fail('jobProfileId must be defined when using customJob - call @SetupUpdateJobProfile first')
+
+    # Initialize Java utilities
+    * def marcConverter = Java.type('test.java.MarcConverter')
+    * def javaWriteData = Java.type('test.java.WriteData')
+
+    # Generate file names
+    * def binaryFileName = fileName + '.mrc'
+    # Use custom path if provided, otherwise default to target directory
+    * def defaultFilePathFromSourceRoot = 'file:target/' + binaryFileName
+    * def finalFilePathFromSourceRoot = filePathFromSourceRoot || defaultFilePathFromSourceRoot
+
+    # Convert MARC JSON object to string and then to binary format
+    * def marcJsonString = JSON.stringify(marcJsonObject)
+    * def marcBinaryData = marcConverter.convertJsonStringToBinary(marcJsonString)
+
+    # Write binary data to appropriate directory
+    * def targetPath = filePathFromSourceRoot ? filePathFromSourceRoot.replace('file:', '') : 'target/' + binaryFileName
+    * javaWriteData.writeByteArrayToFile(marcBinaryData, targetPath)
+
+    # Import file using the job profile ID (jobProfileId must be available in scope)
+    # The jobName parameter should reference a job JSON file that uses #(jobProfileId)
+    Given call read(utilFeature + '@ImportRecord') { fileName: '#(fileName)', jobName: '#(jobName)', filePathFromSourceRoot: '#(finalFilePathFromSourceRoot)' }
+    Then match status != 'ERROR'
+
+    # Verify job execution
+    * call read(completeExecutionFeature) { key: '#(sourcePath)' }
+    * def jobExecution = response
+
+    # If job failed, get error details from job log entries
+    * if (jobExecution.status == 'ERROR') karate.call('classpath:folijet/data-import/global/check-job-log-entries.feature', { jobExecutionId: jobExecution.id, headersUser: headersUser })
+
+    And assert jobExecution.status == 'COMMITTED'
+    And assert jobExecution.uiStatus == 'RUNNING_COMPLETE'
+    And assert jobExecution.progress.current == 1
+    And assert jobExecution.progress.total == 1
+    And match jobExecution.runBy == '#present'
+    And match jobExecution.progress == '#present'
+
+    # Verify instance created
+    * call login testUser
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(testTenant)', 'Accept': '*/*' }
+    Given path 'metadata-provider/jobLogEntries', jobExecutionId
+    And headers headersUser
+    And retry until karate.get('response.entries[0].relatedInstanceInfo.actionStatus') != null
+    When method GET
+    Then status 200
+    And match response.entries[0].sourceRecordActionStatus == "#(actionStatus)"
+    And match response.entries[0].relatedInstanceInfo.actionStatus == "#(actionStatus)"
+    * def instanceId = response.entries[0].relatedInstanceInfo.idList[0]
+    * def instanceHrid = response.entries[0].relatedInstanceInfo.hridList[0]
+
+    # Retrieve instance hrid from record
+    Given path 'source-storage/records', instanceId, 'formatted'
+    And param idType = 'INSTANCE'
+    And headers headersUser
+    When method GET
+    Then status 200
+    * def sourceRecordId = response.id

--- a/data-import/src/main/resources/folijet/data-import/global/import-record.feature
+++ b/data-import/src/main/resources/folijet/data-import/global/import-record.feature
@@ -9,6 +9,7 @@ Feature: Util feature to import records
   ## Util scenario accept fileName and jobName
   @ImportRecord
   Scenario: Import record
+    # TODO: Add explicit parameters for jobProfileId
     * def fileName = fileName + '.mrc'
     * def jobName = jobName + '.json'
     # Use __arg to only get parameters explicitly passed to this feature call

--- a/data-import/src/main/resources/folijet/data-import/global/setup-marc-to-marc-update-profile.feature
+++ b/data-import/src/main/resources/folijet/data-import/global/setup-marc-to-marc-update-profile.feature
@@ -1,0 +1,154 @@
+Feature: Setup MARC-to-MARC Update Job Profile
+
+  Background:
+    * url baseUrl
+    * call read('classpath:folijet/data-import/global/auth.feature')
+    * call read('classpath:folijet/data-import/global/common-functions.feature')
+
+  Scenario: Create job profile for MARC-MARC record replacement/overlay
+    * def profileName = __arg.profileName
+
+    # Create MARC-to-MARC mapping profile with UPDATE action
+    Given path 'data-import-profiles/mappingProfiles'
+    And headers headersUser
+    And request
+      """
+      {
+        "profile": {
+          "name": "#(profileName)",
+          "incomingRecordType": "MARC_BIBLIOGRAPHIC",
+          "existingRecordType": "MARC_BIBLIOGRAPHIC",
+          "description": "MARC-to-MARC update mapping profile for record replacement/overlay",
+          "mappingDetails": {
+            "name": "marcBib",
+            "recordType": "MARC_BIBLIOGRAPHIC",
+            "marcMappingDetails": [],
+            "marcMappingOption": "UPDATE"
+          }
+        },
+        "addedRelations": [],
+        "deletedRelations": []
+      }
+      """
+    When method POST
+    Then status 201
+    * def mappingProfileId = $.id
+
+    # Create action profile with UPDATE action
+    Given path 'data-import-profiles/actionProfiles'
+    And headers headersUser
+    And request
+      """
+      {
+        "profile": {
+          "name": "#(profileName)",
+          "action": "UPDATE",
+          "folioRecord": "MARC_BIBLIOGRAPHIC",
+          "description": "Action profile for MARC-MARC update"
+        },
+        "addedRelations": [
+          {
+            "masterProfileId": null,
+            "masterProfileType": "ACTION_PROFILE",
+            "detailProfileId": "#(mappingProfileId)",
+            "detailProfileType": "MAPPING_PROFILE"
+          }
+        ],
+        "deletedRelations": []
+      }
+      """
+    When method POST
+    Then status 201
+    * def actionProfileId = $.id
+
+    # Create match profile for MARC-MARC matching
+    Given path 'data-import-profiles/matchProfiles'
+    And headers headersUser
+    And request
+      """
+      {
+        "profile": {
+          "name": "#(profileName)",
+          "description": "MARC-MARC match profile by 999ff$i",
+          "incomingRecordType": "MARC_BIBLIOGRAPHIC",
+          "existingRecordType": "MARC_BIBLIOGRAPHIC",
+          "matchDetails": [ {
+            "incomingRecordType" : "MARC_BIBLIOGRAPHIC",
+            "existingRecordType" : "MARC_BIBLIOGRAPHIC",
+            "incomingMatchExpression" : {
+              "dataValueType" : "VALUE_FROM_RECORD",
+              "fields" : [ {
+                "label" : "field",
+                "value" : "999"
+              }, {
+                "label" : "indicator1",
+                "value" : "f"
+              }, {
+                "label" : "indicator2",
+                "value" : "f"
+              }, {
+                "label" : "recordSubfield",
+                "value" : "i"
+              } ]
+            },
+            "existingMatchExpression" : {
+              "dataValueType" : "VALUE_FROM_RECORD",
+              "fields" : [ {
+                "label" : "field",
+                "value" : "999"
+              }, {
+                "label" : "indicator1",
+                "value" : "f"
+              }, {
+                "label" : "indicator2",
+                "value" : "f"
+              }, {
+                "label" : "recordSubfield",
+                "value" : "i"
+              } ]
+            },
+            "matchCriterion" : "EXACTLY_MATCHES"
+          } ]
+        },
+        "addedRelations": [],
+        "deletedRelations": []
+      }
+      """
+    When method POST
+    Then status 201
+    * def matchProfileId = $.id
+
+    # Create job profile
+    Given path 'data-import-profiles/jobProfiles'
+    And headers headersUser
+    And request
+      """
+      {
+        "profile": {
+          "name": "#(profileName)",
+          "description": "Job profile for MARC-MARC record replacement/overlay",
+          "dataType": "MARC"
+        },
+        "addedRelations": [
+          {
+            "masterProfileId": null,
+            "masterProfileType": "JOB_PROFILE",
+            "detailProfileId": "#(matchProfileId)",
+            "detailProfileType": "MATCH_PROFILE",
+            "order": 0
+          },
+          {
+            "masterProfileId": "#(matchProfileId)",
+            "masterProfileType": "MATCH_PROFILE",
+            "detailProfileId": "#(actionProfileId)",
+            "detailProfileType": "ACTION_PROFILE",
+            "order": 0,
+            "reactTo": "MATCH"
+          }
+        ],
+        "deletedRelations": []
+      }
+      """
+    When method POST
+    Then status 201
+    * def updateJobProfileId = $.id

--- a/data-import/src/main/resources/folijet/data-import/samples/marcBib.mrc.json
+++ b/data-import/src/main/resources/folijet/data-import/samples/marcBib.mrc.json
@@ -1,0 +1,181 @@
+{
+  "leader": "00738cam a2200217 a 4500",
+  "fields": [
+    {
+      "001": "12883376"
+    },
+    {
+      "005": "20030616111422.0"
+    },
+    {
+      "008": "020805s2002    nyu    j      000 1 eng  "
+    },
+    {
+      "020": {
+        "subfields": [
+          {
+            "a": "0786808772"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "020": {
+        "subfields": [
+          {
+            "a": "0786816155 (pbk.)"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "040": {
+        "subfields": [
+          {
+            "a": "DLC"
+          },
+          {
+            "c": "DLC"
+          },
+          {
+            "d": "DLC"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "100": {
+        "subfields": [
+          {
+            "a": "Chabon, Michael."
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "245": {
+        "subfields": [
+          {
+            "a": "Summerland /"
+          },
+          {
+            "c": "Michael Chabon."
+          }
+        ],
+        "ind1": "1",
+        "ind2": "0"
+      }
+    },
+    {
+      "250": {
+        "subfields": [
+          {
+            "a": "1st ed."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "250": {
+        "subfields": [
+          {
+            "a": "2st ed."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "260": {
+        "subfields": [
+          {
+            "a": "New York :"
+          },
+          {
+            "b": "Miramax Books/Hyperion Books for Children,"
+          },
+          {
+            "c": "c2002."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "300": {
+        "subfields": [
+          {
+            "a": "500 p. ;"
+          },
+          {
+            "c": "22 cm."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "520": {
+        "subfields": [
+          {
+            "a": "Ethan Feld, the worst baseball player in the history of the game, finds himself recruited by a 100-year-old scout to help a band of fairies triumph over an ancient enemy."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "650": {
+        "subfields": [
+          {
+            "a": "Fantasy."
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "650": {
+        "subfields": [
+          {
+            "a": "Baseball"
+          },
+          {
+            "v": "Fiction."
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "650": {
+        "subfields": [
+          {
+            "a": "Magic"
+          },
+          {
+            "v": "Fiction."
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    }
+  ]
+}

--- a/data-import/src/main/resources/folijet/data-import/samples/mrc-files/marcBibDeletedLeader.mrc.json
+++ b/data-import/src/main/resources/folijet/data-import/samples/mrc-files/marcBibDeletedLeader.mrc.json
@@ -1,0 +1,181 @@
+{
+  "leader": "00738dam a2200217 a 4500",
+  "fields": [
+    {
+      "001": "12883376"
+    },
+    {
+      "005": "20030616111422.0"
+    },
+    {
+      "008": "020805s2002    nyu    j      000 1 eng  "
+    },
+    {
+      "020": {
+        "subfields": [
+          {
+            "a": "0786808772"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "020": {
+        "subfields": [
+          {
+            "a": "0786816155 (pbk.)"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "040": {
+        "subfields": [
+          {
+            "a": "DLC"
+          },
+          {
+            "c": "DLC"
+          },
+          {
+            "d": "DLC"
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "100": {
+        "subfields": [
+          {
+            "a": "Chabon, Michael."
+          }
+        ],
+        "ind1": "1",
+        "ind2": " "
+      }
+    },
+    {
+      "245": {
+        "subfields": [
+          {
+            "a": "Summerland /"
+          },
+          {
+            "c": "Michael Chabon."
+          }
+        ],
+        "ind1": "1",
+        "ind2": "0"
+      }
+    },
+    {
+      "250": {
+        "subfields": [
+          {
+            "a": "1st ed."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "250": {
+        "subfields": [
+          {
+            "a": "2st ed."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "260": {
+        "subfields": [
+          {
+            "a": "New York :"
+          },
+          {
+            "b": "Miramax Books/Hyperion Books for Children,"
+          },
+          {
+            "c": "c2002."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "300": {
+        "subfields": [
+          {
+            "a": "500 p. ;"
+          },
+          {
+            "c": "22 cm."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "520": {
+        "subfields": [
+          {
+            "a": "Ethan Feld, the worst baseball player in the history of the game, finds himself recruited by a 100-year-old scout to help a band of fairies triumph over an ancient enemy."
+          }
+        ],
+        "ind1": " ",
+        "ind2": " "
+      }
+    },
+    {
+      "650": {
+        "subfields": [
+          {
+            "a": "Fantasy."
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "650": {
+        "subfields": [
+          {
+            "a": "Baseball"
+          },
+          {
+            "v": "Fiction."
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    },
+    {
+      "650": {
+        "subfields": [
+          {
+            "a": "Magic"
+          },
+          {
+            "v": "Fiction."
+          }
+        ],
+        "ind1": " ",
+        "ind2": "1"
+      }
+    }
+  ]
+}

--- a/data-import/src/test/java/test/java/WriteData.java
+++ b/data-import/src/test/java/test/java/WriteData.java
@@ -1,5 +1,6 @@
 package test.java;
 
+import com.intuit.karate.Logger;
 import org.marc4j.MarcReader;
 import org.marc4j.MarcStreamReader;
 import org.marc4j.MarcStreamWriter;
@@ -15,6 +16,8 @@ import java.io.FileOutputStream;
 import java.io.BufferedOutputStream;
 
 public class WriteData {
+    private static Logger LOGGER = new Logger();
+
     public static void writeByteArrayToFile(byte[] buffer, String fileName) {
         try (FileOutputStream fileOutputStream = new FileOutputStream(fileName);
              BufferedOutputStream bufferedOutputStream = new BufferedOutputStream(fileOutputStream)) {
@@ -67,6 +70,11 @@ public class WriteData {
                     subfield.setData(subfieldValue);
                     record.addVariableField(field);
                 }
+                else {
+                    LOGGER.info("modifyMarcRecord:: subfield " + subfieldCode + " not found in field " + fieldTag);
+                }
+            } else {
+                LOGGER.info("modifyMarcRecord:: Field " + fieldTag + " not found in the record.");
             }
         }
 


### PR DESCRIPTION
## Purpose
Covering test for MODSOURCE-898

## Approach
1. Create MARC instance using default job profile for creating instance
2. Mark instance as deleted using DELETE /inventory/instances/{id}/mark-deleted
3. Export MARC instance using data export
4. Create MARC update job profile (MARC-MARC matching with 999ff$i)
5. Update exported MARC file
6. Run import with created job profile and updated file
