### PR TITLE
MODLD-766: Remove obsolete permission linked-data.profiles.get

### DIFF
--- a/mod-linked-data/src/main/resources/citation/mod-linked-data/linked-data-junit.feature
+++ b/mod-linked-data/src/main/resources/citation/mod-linked-data/linked-data-junit.feature
@@ -31,7 +31,6 @@ Feature: mod-linked-data integration tests
       | 'linked-data.resources.support-check.get'                      |
       | 'linked-data.resources.preview.get'                            |
       | 'linked-data.resources.import.post'                            |
-      | 'linked-data.profiles.get'                                     |
       | 'search.linked-data.work.collection.get'                       |
       | 'search.linked-data.hub.collection.get'                        |
       | 'search.instances.collection.get'                              |


### PR DESCRIPTION
`GET linked-data/profile` and the associated permission `linked-data.profiles.get` is removed from the backend. This PR removes the permission from karate test codebase.

Depends on https://github.com/folio-org/mod-linked-data/pull/236