### PR TITLE
Fix Edge-Orders GOBI Tests

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/edge-orders/features/gobi.feature
+++ b/acquisitions/src/main/resources/thunderjet/edge-orders/features/gobi.feature
@@ -73,6 +73,7 @@ Feature: Edge Orders GOBI
     And match responseHeaders['content-type'][0] == 'application/xml'
     * def poLineNumber = /Response/PoLineNumber
 
+    Given url baseUrl
     Given path 'orders/order-lines'
     And param query = 'poLineNumber==' + poLineNumber
     And headers folioHeaders


### PR DESCRIPTION
## Purpose

- Fix broken Edge-orders GOBI tests

## Approach

- Change base URL from Edge (external) to Kong (internal)
- Test on Rancher edev cluster (thunderjet-2nd namespace):

![image](https://github.com/user-attachments/assets/889d9b6e-d325-4b8f-9c47-4c8629fc2c4c)
