### PR TITLE
Add order data cleanup to mod-gobi scenarios

### DIFF
--- a/acquisitions/src/main/resources/karate-config.js
+++ b/acquisitions/src/main/resources/karate-config.js
@@ -100,6 +100,7 @@ function fn() {
     unopenOrder: read('classpath:thunderjet/mod-orders/reusable/unopen-order.feature'),
     closeOrder: read('classpath:thunderjet/mod-orders/reusable/close-order.feature'),
     cancelOrder: read('classpath:thunderjet/mod-orders/reusable/cancel-order.feature'),
+    deleteOrder: read('classpath:thunderjet/mod-orders/reusable/delete-order.feature'),
     getOrderLine: karate.read('classpath:thunderjet/mod-orders/reusable/get-order-line.feature'),
     createOrderLine: karate.read('classpath:thunderjet/mod-orders/reusable/create-order-line.feature'),
     createOrderLineWithInstance: karate.read('classpath:thunderjet/mod-orders/reusable/create-order-line-with-instance.feature'),
@@ -141,6 +142,9 @@ function fn() {
 
     // edge-orders
     checkEndpoint: karate.read('classpath:thunderjet/edge-orders/reusable/check-endpoint.feature'),
+    
+    // gobi
+    cleanupOrderData: karate.read('classpath:thunderjet/mod-gobi/reusable/cleanup-order-data.feature'),
 
     // define global functions
     uuid: function () {

--- a/acquisitions/src/main/resources/thunderjet/mod-gobi/features/find-holdings-by-location-and-instance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-gobi/features/find-holdings-by-location-and-instance.feature
@@ -4,6 +4,9 @@ Feature: Find holdings by location and instance
     * print karate.info.scenarioName
     * url baseUrl
 
+    * callonce login testAdmin
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
+
     * callonce login testUser
     * def headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
 
@@ -26,6 +29,10 @@ Feature: Find holdings by location and instance
     When method GET
     Then status 200
     And match response.purchaseOrders[0].approved == true
+    * def orderId = response.purchaseOrders[0].id
+
+    # Cleanup order data
+    * def v = call cleanupOrderData { orderId: "#(orderId)" }
 
   Scenario: Create second order
     * def sample_po_2 = read('classpath:samples/mod-gobi/po-physical-annex-holding-2.xml')
@@ -44,6 +51,7 @@ Feature: Find holdings by location and instance
     When method GET
     Then status 200
     And match response.purchaseOrders[0].approved == true
+    * def orderId = response.purchaseOrders[0].id
 
     # matched order lines requested and stored information
     Given path '/orders/order-lines'
@@ -61,3 +69,6 @@ Feature: Find holdings by location and instance
     When method GET
     Then status 200
     And match $.totalRecords == 1
+
+    # Cleanup order data
+    * def v = call cleanupOrderData { orderId: "#(orderId)" }

--- a/acquisitions/src/main/resources/thunderjet/mod-gobi/features/gobi-api-tests.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-gobi/features/gobi-api-tests.feature
@@ -4,6 +4,9 @@ Feature: GOBI api tests
     * print karate.info.scenarioName
     * url baseUrl
 
+    * callonce login testAdmin
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
+
     * callonce login testUser
     * def headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json, application/xml', 'x-okapi-tenant': '#(testTenant)' }
 
@@ -42,6 +45,7 @@ Feature: GOBI api tests
     When method GET
     Then status 200
     And match response.purchaseOrders[0].approved == true
+    * def orderId = response.purchaseOrders[0].id
 
     # matched order lines requested and stored information
     Given path '/orders/order-lines'
@@ -65,6 +69,9 @@ Feature: GOBI api tests
     And match $.poLines[0].titleOrPackage == 'LIVING WITH THE UN[electronic resource] :AMERICAN RESPONSIBILITIES AND INTERNATIONAL ORDER.'
     And match $.poLines[0].vendorDetail.referenceNumbers[0].refNumber == '99952919209'
 
+    # Cleanup order data
+    * def v = call cleanupOrderData { orderId: "#(orderId)" }
+
   # Created for https://issues.folio.org/browse/MODGOBI-195
   Scenario: Try to create an order with invalid custom mapping and check error response
     # post invalid UnlistedPrintMonograph
@@ -83,6 +90,7 @@ Feature: GOBI api tests
     When method POST
     Then status 500
     And match responseHeaders['Content-Type'][0] == 'application/xml'
+
     # delete old UnlistedPrintMonograph
     Given path '/gobi/orders/custom-mappings/UnlistedPrintMonograph'
     And headers { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)' }
@@ -227,6 +235,7 @@ Feature: GOBI api tests
     When method GET
     Then status 200
     And match response.purchaseOrders[0].approved == true
+    And def orderId1 = response.purchaseOrders[0].id
 
     # Verify order line data
     Given path '/orders/order-lines'
@@ -267,6 +276,7 @@ Feature: GOBI api tests
     When method GET
     Then status 200
     And match response.purchaseOrders[0].approved == false
+    * def orderId2 = response.purchaseOrders[0].id
 
     # Verify order line data
     Given path '/orders/order-lines'
@@ -281,6 +291,10 @@ Feature: GOBI api tests
     And headers { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)' }
     When method DELETE
     Then status 200
+
+    # Cleanup order data
+    * def v = call cleanupOrderData { orderId: "#(orderId1)" }
+    * def v = call cleanupOrderData { orderId: "#(orderId2)" }
 
   Scenario: Verify order fields after successful mapping update
     # Update mapping
@@ -307,6 +321,7 @@ Feature: GOBI api tests
     When method GET
     Then status 200
     And match response.purchaseOrders[0].approved == false
+    * def orderId = response.purchaseOrders[0].id
 
     # Verify order line data
     Given path '/orders/order-lines'
@@ -328,6 +343,9 @@ Feature: GOBI api tests
     And headers { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)' }
     When method DELETE
     Then status 200
+
+    # Cleanup order data
+    * def v = call cleanupOrderData { orderId: "#(orderId)" }
 
   Scenario: Verify the lookup service integration endpoints work correctly
     # Update mapping
@@ -354,6 +372,7 @@ Feature: GOBI api tests
     When method GET
     Then status 200
     And match response.purchaseOrders[0].approved == true
+    * def orderId = response.purchaseOrders[0].id
 
     # Verify order line data
     # New order is not created, as one already exists
@@ -384,6 +403,9 @@ Feature: GOBI api tests
     And headers { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)' }
     When method DELETE
     Then status 200
+
+    # Cleanup order data
+    * def v = call cleanupOrderData { orderId: "#(orderId)" }
 
   Scenario: Verify that fetching all mappings include custom ones
     # Verify all mappings are default at first

--- a/acquisitions/src/main/resources/thunderjet/mod-gobi/features/validate-pol-receipt-not-required-with-checkin-items.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-gobi/features/validate-pol-receipt-not-required-with-checkin-items.feature
@@ -4,6 +4,9 @@ Feature: Validate POL receipt status with checkin items
     * print karate.info.scenarioName
     * url baseUrl
 
+    * callonce login testAdmin
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
+
     * callonce login testUser
     * def headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
 
@@ -39,6 +42,10 @@ Feature: Validate POL receipt status with checkin items
     When method GET
     Then status 200
     And match $.poLines[0].checkinItems == true
+    * def orderId = $.poLines[0].purchaseOrderId
+
+    # Cleanup order data
+    * def v = call cleanupOrderData { orderId: "#(orderId)" }
 
   @Positive
   Scenario: Send order with receipt not required and checkin items true
@@ -65,9 +72,13 @@ Feature: Validate POL receipt status with checkin items
     When method GET
     Then status 200
     And match $.poLines[0].checkinItems == true
+    * def orderId = $.poLines[0].purchaseOrderId
 
     # Delete custom mapping
     Given path '/gobi/orders/custom-mappings/UnlistedPrintMonograph'
     And headers { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)' }
     When method DELETE
     Then status 200
+
+    # Cleanup order data
+    * def v = call cleanupOrderData { orderId: "#(orderId)" }

--- a/acquisitions/src/main/resources/thunderjet/mod-gobi/gobi.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-gobi/gobi.feature
@@ -22,3 +22,7 @@ Feature: mod-gobi integration tests
 
   Scenario: Find holdings by location and instance
     * call read('features/find-holdings-by-location-and-instance.feature')
+
+  Scenario: Validate POL receipt not required with checkin items
+    * call read('features/validate-pol-receipt-not-required-with-checkin-items.feature')
+

--- a/acquisitions/src/main/resources/thunderjet/mod-gobi/init-gobi.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-gobi/init-gobi.feature
@@ -68,6 +68,7 @@ Feature: Initialize mod-gobi integration tests
       | 'inventory-storage.service-points.item.post'                  |
       | 'inventory.instances.item.post'                               |
       | 'organizations.organizations.item.post'                       |
+      | 'orders.item.delete'                                          |
 
 
   Scenario: Create tenant and test user

--- a/acquisitions/src/main/resources/thunderjet/mod-gobi/reusable/cleanup-order-data.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-gobi/reusable/cleanup-order-data.feature
@@ -1,0 +1,10 @@
+Feature: Cleanup Order Data
+  # parameters: orderId
+
+  Background:
+    * url baseUrl
+
+  Scenario: cleanupOrderData
+    * configure headers = headersAdmin
+    * def v = call deleteOrder { orderId: "#(orderId)" }
+    * configure headers = {}

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/delete-order.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/delete-order.feature
@@ -1,0 +1,10 @@
+Feature: Delete order
+  # parameters: orderId
+
+  Background:
+    * url baseUrl
+
+  Scenario: deleteOrder
+    Given path '/orders/composite-orders', orderId
+    When method DELETE
+    Then status 204


### PR DESCRIPTION
## Purpose
Add order data cleanup to mod-gobi scenarios

## Approach
Running tests directly and with JUnit gives different results, as GOBI tests fail if run in a certain order. To fix this, its necessary to delete any created orders before running next tests 

## Screenshots
![image](https://github.com/user-attachments/assets/6c51a8e4-cea4-48df-946e-a9967934fbd9)
![image](https://github.com/user-attachments/assets/5f0812d9-eaf5-4515-8efe-e4e12b4e7aca)
