### PR TITLE
fix(mod-quick-marc): Fix linking test cases

### DIFF
--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-linking-records.feature
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-linking-records.feature
@@ -61,7 +61,7 @@ Feature: linking-records tests
     * set record.relatedRecordVersion = 4
 
     * def field = karate.jsonPath(record, "$.fields[?(@.tag=='010')]")[0]
-    * set field.content = 'Updated010'
+    * set field.content = '$a n 00001265'
     * remove record.fields[?(@.tag=='010')]
     * record.fields.push(field)
     * set record._actionType = 'edit'
@@ -78,7 +78,7 @@ Feature: linking-records tests
     And retry until response.generation == 10
     When method GET
     Then status 200
-    And match response.parsedRecord.content.fields[*].100.subfields[*].a contains 'Updated010'
+    And match response.parsedRecord.content.fields[*].100.subfields[*].0 contains 'http://id.loc.gov/authorities/names/n00001265'
 
   @Positive
   Scenario: Delete linking authority - should remove $9 subfield from bib record

--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-linking-records.feature
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-linking-records.feature
@@ -35,12 +35,12 @@ Feature: linking-records tests
     * sleep(5000)
 
     # retrieve bib record
-    Given path '/source-storage/records'
-    And param state = 'ACTUAL'
+    Given path '/source-storage/records', instanceId, 'formatted'
+    And param idType = 'INSTANCE'
+    And retry until response.generation == 9
     When method GET
     Then status 200
-    And def bibRecord = response.records.find(x => x.externalIdsHolder.instanceId==instanceId)
-    And match bibRecord.parsedRecord.content.fields[*].100.subfields[*].a contains 'Updated'
+    And match response.parsedRecord.content.fields[*].100.subfields[*].a contains 'Updated'
 
     # retrieve instance record
     Given path '/instance-storage/instances', instanceId
@@ -61,7 +61,7 @@ Feature: linking-records tests
     * set record.relatedRecordVersion = 4
 
     * def field = karate.jsonPath(record, "$.fields[?(@.tag=='010')]")[0]
-    * set field.content = 'Updated'
+    * set field.content = 'Updated010'
     * remove record.fields[?(@.tag=='010')]
     * record.fields.push(field)
     * set record._actionType = 'edit'
@@ -73,24 +73,23 @@ Feature: linking-records tests
     Then status 202
 
     # retrieve bib srs record
-    Given path '/source-storage/records'
-    And param state = 'ACTUAL'
+    Given path '/source-storage/records', instanceId, 'formatted'
+    And param idType = 'INSTANCE'
+    And retry until response.generation == 10
     When method GET
     Then status 200
-    And def bibRecord = response.records.find(x => x.externalIdsHolder.instanceId==instanceId)
-    And match bibRecord.parsedRecord.content.fields[*].100.subfields[*].a contains 'Updated'
+    And match response.parsedRecord.content.fields[*].100.subfields[*].a contains 'Updated010'
 
   @Positive
   Scenario: Delete linking authority - should remove $9 subfield from bib record
     # retrieve bib srs record - should have authority link
-    Given path '/source-storage/records'
-    And param state = 'ACTUAL'
+    Given path '/source-storage/records', instanceId, 'formatted'
+    And param idType = 'INSTANCE'
     When method GET
     Then status 200
-    And def bibRecord = response.records.find(x => x.externalIdsHolder.instanceId==instanceId)
-    And match bibRecord.parsedRecord.content.fields[*].100 != null
-    And match bibRecord.parsedRecord.content.fields[*].100.subfields[*].0 != []
-    And match bibRecord.parsedRecord.content.fields[*].100.subfields[*].9 != []
+    And match response.parsedRecord.content.fields[*].100 != null
+    And match response.parsedRecord.content.fields[*].100.subfields[*].0 != []
+    And match response.parsedRecord.content.fields[*].100.subfields[*].9 != []
 
     # delete linking authority
     Given path 'authority-storage/authorities', authorityId
@@ -100,10 +99,10 @@ Feature: linking-records tests
     And eval if (responseStatus == 408) sleep(20000)
 
     # retrieve bib srs record - should delete authority link
-    Given path '/source-storage/records'
-    And param state = 'ACTUAL'
+    Given path '/source-storage/records', instanceId, 'formatted'
+    And param idType = 'INSTANCE'
+    And retry until response.generation == 11
     When method GET
     Then status 200
-    And def bibRecord = response.records.find(x => x.externalIdsHolder.instanceId==instanceId)
-    And match bibRecord.parsedRecord.content.fields[*].100 != []
-    And match bibRecord.parsedRecord.content.fields[*].100.subfields[*].9 == []
+    And match response.parsedRecord.content.fields[*].100 != []
+    And match response.parsedRecord.content.fields[*].100.subfields[*].9 == []

--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-update-linked-authority-records.feature
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/quick-marc-update-linked-authority-records.feature
@@ -14,13 +14,15 @@ Feature: update of two authorities records linked to one instance tests
 
   Scenario: Should unlink bib record on first authority field update making it unlinkable
     # retrieve marc bib record and check it contains a link
-    Given path '/source-storage/records'
-    And param state = 'ACTUAL'
+    Given path '/source-storage/records', instanceId, 'formatted'
+    And param idType = 'INSTANCE'
     When method GET
     Then status 200
-    And def srsBibRecord = response.records.find(x => x.externalIdsHolder.instanceId==instanceId)
-    And match srsBibRecord.parsedRecord.content.fields[*].100 != null
-    And match srsBibRecord.parsedRecord.content.fields[*].100.subfields[*].9 != []
+    And match response.parsedRecord.content.fields[*].100 != null
+    And match response.parsedRecord.content.fields[*].100.subfields[*].9 != []
+
+    # save bib snapshotId to use for retry later
+    * def bibSnapshotId = response.snapshotId
 
     # retrieve quick marc authority record
     Given path '/records-editor/records'
@@ -46,18 +48,19 @@ Feature: update of two authorities records linked to one instance tests
     # count links
     Given path '/links/authorities/bulk/count'
     And request {"ids": [#(authorityId1)]}
+    And retry until response.links[0].totalLinks == 0
     When method POST
     Then status 200
     Then match response.links[0].totalLinks == 0
 
     # retrieve marc bib record
-    Given path '/source-storage/records'
-    And param state = 'ACTUAL'
+    Given path '/source-storage/records', instanceId, 'formatted'
+    And param idType = 'INSTANCE'
+    And retry until response.snapshotId != bibSnapshotId
     When method GET
     Then status 200
-    And def srsBibRecord = response.records.find(x => x.externalIdsHolder.instanceId==instanceId)
-    And match srsBibRecord.parsedRecord.content.fields[*].100 != null
-    And match srsBibRecord.parsedRecord.content.fields[*].100.subfields[*].9 == []
+    And match response.parsedRecord.content.fields[*].100 != null
+    And match response.parsedRecord.content.fields[*].100.subfields[*].9 == []
 
     # retrieve quick marc authority record
     Given path '/records-editor/records'
@@ -93,13 +96,15 @@ Feature: update of two authorities records linked to one instance tests
 
   Scenario: Should unlink bib record on second authority field update making it unlinkable
     # retrieve marc bib record and check it contains a link
-    Given path '/source-storage/records'
-    And param state = 'ACTUAL'
+    Given path '/source-storage/records', instanceId, 'formatted'
+    And param idType = 'INSTANCE'
     When method GET
     Then status 200
-    And def srsBibRecord = response.records.find(x => x.externalIdsHolder.instanceId==instanceId)
-    And match srsBibRecord.parsedRecord.content.fields[*].240 != null
-    And match srsBibRecord.parsedRecord.content.fields[*].240.subfields[*].9 != []
+    And match response.parsedRecord.content.fields[*].240 != null
+    And match response.parsedRecord.content.fields[*].240.subfields[*].9 != []
+
+    # save bib snapshotId to use for retry later
+    * def bibSnapshotId = response.snapshotId
 
     # retrieve quick marc authority record
     Given path '/records-editor/records'
@@ -125,15 +130,16 @@ Feature: update of two authorities records linked to one instance tests
     # count links
     Given path '/links/authorities/bulk/count'
     And request {"ids": [#(authorityId2)]}
+    And retry until response.links[0].totalLinks == 0
     When method POST
     Then status 200
     Then match response.links[0].totalLinks == 0
 
     # retrieve marc bib record
-    Given path '/source-storage/records'
-    And param state = 'ACTUAL'
+    Given path '/source-storage/records', instanceId, 'formatted'
+    And param idType = 'INSTANCE'
+    And retry until response.snapshotId != bibSnapshotId
     When method GET
     Then status 200
-    And def srsBibRecord = response.records.find(x => x.externalIdsHolder.instanceId==instanceId)
-    And match srsBibRecord.parsedRecord.content.fields[*].240 != null
-    And match srsBibRecord.parsedRecord.content.fields[*].240.subfields[*].9 == []
+    And match response.parsedRecord.content.fields[*].240 != null
+    And match response.parsedRecord.content.fields[*].240.subfields[*].9 == []

--- a/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/samples/setup-records/authority-source-file.json
+++ b/mod-quick-marc/src/main/resources/spitfire/mod-quick-marc/features/setup/samples/setup-records/authority-source-file.json
@@ -1,7 +1,7 @@
 {
   "id": "af045f2f-e851-4613-984c-4bc13430454a",
   "name": "LC Name Authority file (LCNAF)",
-  "code": "abcdefghijklmnopqrstuvwxy",
+  "code": "n",
   "type": "Names",
   "baseUrl": "http://id.loc.gov/authorities/names/",
   "selectable": true,


### PR DESCRIPTION
## Purpose
Fix linking test cases

## Approach
Add retries after time consuming operations
Refactor source-storage calls to query only one record by externalId
Fix "Update linking authority 010 - should update $0 bib subfield" which wasn't verifying the supposed change
Fix source file code for source file setup

### Learning
[FAT-20110](https://folio-org.atlassian.net/browse/FAT-20110)