### PR TITLE
[MODORDERS-1214-2]. Add missing settings permissions

### DIFF
--- a/acquisitions/src/main/resources/global/configuration.feature
+++ b/acquisitions/src/main/resources/global/configuration.feature
@@ -12,6 +12,21 @@ Feature: global finances
     When method POST
     Then status 201
 
+  # Bring back temporarily so that modules that haven't been migrated yet can still be using mod-configuration in the tests
+  Scenario: update configuration poline limit
+    Given path 'configurations/entries'
+    And request
+      """
+      {
+        "module": "ORDERS",
+        "configName": "poLines-limit",
+        "enabled": true,
+        "value": "999"
+      }
+      """
+    When method POST
+    Then status 201
+
   Scenario: Create configuration with UTC timezone
     Given path 'configurations/entries'
     And request

--- a/acquisitions/src/main/resources/thunderjet/consortia/features/open-orders-in-member-tenant.feature
+++ b/acquisitions/src/main/resources/thunderjet/consortia/features/open-orders-in-member-tenant.feature
@@ -7,9 +7,9 @@ Feature: Open orders in member tenant, share instance in one case
     * url baseUrl
 
     * call eurekaLogin { username: '#(consortiaAdmin.username)', password: '#(consortiaAdmin.password)', tenant: '#(centralTenantName)' }
-    * def headersCentral = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(centralTenantName)', 'Accept': 'application/json' }
+    * def headersCentral = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(centralTenantName)', 'Accept': '*/*' }
     * call eurekaLogin { username: '#(universityUser.username)', password: '#(universityUser.password)', tenant: '#(universityTenantName)' }
-    * def headersUni = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(universityTenantName)', 'Accept': 'application/json' }
+    * def headersUni = { 'Content-Type': 'application/json', 'Authtoken-Refresh-Cache': 'true', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(universityTenantName)', 'Accept': '*/*' }
     * configure headers = headersUni
 
     * configure retry = { interval: 5000, count: 5 }

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/init-cross-modules.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/init-cross-modules.feature
@@ -10,7 +10,6 @@ Feature: Cross-module integration tests
       | name                        |
       | 'mod-permissions'           |
       | 'mod-configuration'         |
-      | 'mod-settings'              |
       | 'mod-login'                 |
       | 'mod-users'                 |
       | 'mod-pubsub'                |

--- a/acquisitions/src/main/resources/thunderjet/edge-orders/init-edge-orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/edge-orders/init-edge-orders.feature
@@ -9,7 +9,6 @@ Feature: Initialize edge-orders integration tests
       | name                        |
       | "mod-audit"                 |
       | "mod-configuration"         |
-      | 'mod-settings'              |
       | "mod-ebsconet"              |
       | "mod-finance"               |
       | "mod-finance-storage"       |

--- a/acquisitions/src/main/resources/thunderjet/edge-orders/init-edge-orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/edge-orders/init-edge-orders.feature
@@ -9,6 +9,7 @@ Feature: Initialize edge-orders integration tests
       | name                        |
       | "mod-audit"                 |
       | "mod-configuration"         |
+      | 'mod-settings'              |
       | "mod-ebsconet"              |
       | "mod-finance"               |
       | "mod-finance-storage"       |
@@ -64,6 +65,7 @@ Feature: Initialize edge-orders integration tests
       | "acquisitions-units.memberships.item.post"                    |
       | "acquisitions-units.units.item.post"                          |
       | "configuration.entries.item.post"                             |
+      | 'orders-storage.settings.item.post'                           |
       | "finance.budgets.collection.get"                              |
       | "finance.budgets.item.get"                                    |
       | "finance.budgets.item.post"                                   |

--- a/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/init-data-export-spring.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/init-data-export-spring.feature
@@ -11,7 +11,6 @@ Feature: Initialize mod-data-export-spring integration tests
       | name                        |
       | 'mod-permissions'           |
       | 'mod-configuration'         |
-      | 'mod-settings'              |
       | 'mod-login'                 |
       | 'mod-users'                 |
       | 'mod-orders-storage'        |

--- a/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/init-data-export-spring.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/init-data-export-spring.feature
@@ -11,6 +11,7 @@ Feature: Initialize mod-data-export-spring integration tests
       | name                        |
       | 'mod-permissions'           |
       | 'mod-configuration'         |
+      | 'mod-settings'              |
       | 'mod-login'                 |
       | 'mod-users'                 |
       | 'mod-orders-storage'        |
@@ -27,6 +28,7 @@ Feature: Initialize mod-data-export-spring integration tests
     * table userPermissions
       | name                                                          |
       | 'configuration.entries.item.post'                             |
+      | 'orders-storage.settings.item.post'                           |
       | 'finance.budgets.item.post'                                   |
       | 'finance.funds.item.post'                                     |
       | 'data-export.config.collection.get'                           |
@@ -60,6 +62,7 @@ Feature: Initialize mod-data-export-spring integration tests
     * table adminPermissions
       | name                                                          |
       | 'configuration.entries.item.post'                             |
+      | 'orders-storage.settings.item.post'                           |
       | 'finance.budgets.item.post'                                   |
       | 'finance.expense-classes.item.post'                           |
       | 'finance.fiscal-years.item.post'                              |

--- a/acquisitions/src/main/resources/thunderjet/mod-ebsconet/init-ebsconet.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-ebsconet/init-ebsconet.feature
@@ -11,7 +11,6 @@ Feature: Initialize mod-ebsconet integration tests
       | 'mod-permissions'           |
       | 'mod-users'                 |
       | 'mod-configuration'         |
-      | 'mod-settings'              |
       | 'mod-ebsconet'              |
       | 'mod-orders-storage'        |
       | 'mod-orders'                |

--- a/acquisitions/src/main/resources/thunderjet/mod-ebsconet/init-ebsconet.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-ebsconet/init-ebsconet.feature
@@ -11,6 +11,7 @@ Feature: Initialize mod-ebsconet integration tests
       | 'mod-permissions'           |
       | 'mod-users'                 |
       | 'mod-configuration'         |
+      | 'mod-settings'              |
       | 'mod-ebsconet'              |
       | 'mod-orders-storage'        |
       | 'mod-orders'                |
@@ -38,6 +39,7 @@ Feature: Initialize mod-ebsconet integration tests
     * table adminPermissions
       | name                                                          |
       | 'configuration.entries.item.post'                             |
+      | 'orders-storage.settings.item.post'                           |
       | 'finance.budgets.item.post'                                   |
       | 'finance.expense-classes.item.post'                           |
       | 'finance.fiscal-years.item.post'                              |
@@ -60,7 +62,6 @@ Feature: Initialize mod-ebsconet integration tests
       | 'inventory-storage.service-points.item.post'                  |
       | 'inventory.instances.item.post'                               |
       | 'organizations.organizations.item.post'                       |
-
 
   Scenario: Create tenant and test user
     * call read('classpath:common/eureka/setup-users.feature')

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/init-finance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/init-finance.feature
@@ -9,6 +9,7 @@ Feature: Initialize mod-finance integration tests
       | name                        |
       | 'mod-permissions'           |
       | 'mod-configuration'         |
+      | 'mod-settings'              |
       | 'mod-login'                 |
       | 'mod-users'                 |
       | 'mod-finance-storage'       |
@@ -85,9 +86,11 @@ Feature: Initialize mod-finance integration tests
       | 'acquisitions-units.units.item.delete'                        |
       | 'acquisitions-units.units.item.post'                          |
       | 'configuration.entries.collection.get'                        |
-      | 'configuration.entries.item.delete'                           |
       | 'configuration.entries.item.post'                             |
       | 'configuration.entries.item.put'                              |
+      | 'orders-storage.settings.collection.get'                      |
+      | 'orders-storage.settings.item.post'                           |
+      | 'orders-storage.settings.item.put'                            |
       | 'inventory-storage.contributor-name-types.item.post'          |
       | 'inventory-storage.electronic-access-relationships.item.post' |
       | 'inventory-storage.holdings-sources.item.post'                |

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/init-finance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/init-finance.feature
@@ -9,7 +9,6 @@ Feature: Initialize mod-finance integration tests
       | name                        |
       | 'mod-permissions'           |
       | 'mod-configuration'         |
-      | 'mod-settings'              |
       | 'mod-login'                 |
       | 'mod-users'                 |
       | 'mod-finance-storage'       |

--- a/acquisitions/src/main/resources/thunderjet/mod-mosaic/init-mosaic.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-mosaic/init-mosaic.feature
@@ -9,7 +9,6 @@ Feature: Initialize mod-mosaic integration tests
       | name                        |
       | "mod-audit"                 |
       | "mod-configuration"         |
-      | 'mod-settings'              |
       | "mod-finance"               |
       | "mod-finance-storage"       |
       | "mod-inventory"             |

--- a/acquisitions/src/main/resources/thunderjet/mod-mosaic/init-mosaic.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-mosaic/init-mosaic.feature
@@ -9,6 +9,7 @@ Feature: Initialize mod-mosaic integration tests
       | name                        |
       | "mod-audit"                 |
       | "mod-configuration"         |
+      | 'mod-settings'              |
       | "mod-finance"               |
       | "mod-finance-storage"       |
       | "mod-inventory"             |
@@ -33,6 +34,7 @@ Feature: Initialize mod-mosaic integration tests
       | "acquisitions-units.memberships.item.post"                    |
       | "acquisitions-units.units.item.post"                          |
       | "configuration.entries.item.post"                             |
+      | 'orders-storage.settings.item.post'                           |
       | "finance.budgets.collection.get"                              |
       | "finance.budgets.item.get"                                    |
       | "finance.budgets.item.post"                                   |

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/init-orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/init-orders.feature
@@ -10,7 +10,6 @@ Feature: Initialize mod-orders integration tests
       | name                        |
       | 'mod-audit'                 |
       | 'mod-configuration'         |
-      | 'mod-settings'              |
       | 'mod-feesfines'             |
       | 'mod-finance'               |
       | 'mod-finance-storage'       |


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/MODORDERS-1214>

## Approach

- Add missing permissions
  - `init-edge-orders.feature`
  - `init-data-export-spring.feature`
  - `init-ebsconet.feature`
  - `init-finance.feature`
  - `init-mosaic.feature`
- Change Accept header in `open-orders-in-member-tenant.feature` from `application/json` to `*/*`