### PR TITLE
FAT-21570 Update FQM scenario for ET soft deletion

### DIFF
--- a/mod-fqm-manager/src/main/resources/corsair/mod-fqm-manager/features/custom-entity-types.feature
+++ b/mod-fqm-manager/src/main/resources/corsair/mod-fqm-manager/features/custom-entity-types.feature
@@ -91,7 +91,8 @@ Feature: Entity types
     # Verify the custom entity type has been deleted
     Given path 'entity-types/custom', customEntityTypeId
     When method GET
-    Then status 404
+    Then status 200
+    And match $.deleted == true
 
   Scenario: Create custom entity type and execute a query using it
     * def queryEntityTypeId = 'a1b2c3d4-e5f6-7890-abcd-ef0123456789'


### PR DESCRIPTION
## Purpose
Update the FQM scenarios to integrate the recent entity type soft deletion feature, where deleted ETs are not actually deleted, but are instead updated

## Approach
We no longer expect the GET API to return 404s for deleted entity types. Instead, the deleted ET is returned but with the `deleted` property set to `true`.
