### PR TITLE
MODDCB-231: Make mockServerUrl optional with default value

### DIFF
--- a/mod-dcb/src/main/resources/karate-config.js
+++ b/mod-dcb/src/main/resources/karate-config.js
@@ -108,7 +108,7 @@ function fn() {
   } else if(env == 'folio-testing-karate') {
     config.baseUrl = '${baseUrl}';
     config.edgeUrl = '${edgeUrl}';
-    config.mockServerUrl = '${mockServerUrl}';
+    config.mockServerUrl = karate.properties['mockServerUrl'] || 'https://folio-etesting-cikarate-mockserver.ci.folio.org';
     config.admin = {
       tenant: '${admin.tenant}',
       name: '${admin.name}',


### PR DESCRIPTION
## Purpose
Fix the integration test startup issue using karate.properties instead of direct mapping

## Approach
- Fix configuration in `karate-config.js`

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
