### PR TITLE
FAT-21678 - Karate test fail: [firebird/data-export] ModDataExportApiTest {16} firebird/dataexport/features/export-deleted-authorities.feature

### DIFF
--- a/mod-data-export/src/test/resources/firebird/dataexport/features/export-deleted-authorities.feature
+++ b/mod-data-export/src/test/resources/firebird/dataexport/features/export-deleted-authorities.feature
@@ -36,6 +36,8 @@ Feature: Test export authority deleted
     * call read('classpath:global/inventory_data_setup_util.feature@PostAuthority') {authorityId:'#(authorityId)'}
     * call read('classpath:global/mod_srs_init_data.feature@PostMarcAuthorityRecord') {recordId:'#(authorityRecordId)', snapshotId:'#(snapshotId)', authorityId:'#(authorityId)'}
 
+    * pause(5000)
+
     # delete authority
     * call login testUser
     * configure headers = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapiUserToken)', 'x-okapi-tenant': '#(testTenant)', 'Accept': 'application/json'  }
@@ -43,6 +45,8 @@ Feature: Test export authority deleted
     When method DELETE
     Then status 204
     And def authorityDeletedId = response.id
+
+    * pause(5000)
 
     # get total number of job executions before export
     Given path 'data-export/job-executions'


### PR DESCRIPTION
[FAT-21678](https://folio-org.atlassian.net/browse/FAT-21678) - Karate test fail: [firebird/data-export] ModDataExportApiTest {16} firebird/dataexport/features/export-deleted-authorities.feature

## Purpose
Fix data-export authority deleted

## Approach
Add pauses before and after authority deletion.

### TODOS and Open Questions

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
