### PR TITLE
FAT-21705: Remove empty arrays from the expected search response

### DIFF
--- a/mod-linked-data/src/main/resources/citation/mod-linked-data/features/import-bib/samples/expected-search-response.json
+++ b/mod-linked-data/src/main/resources/citation/mod-linked-data/features/import-bib/samples/expected-search-response.json
@@ -50,19 +50,12 @@
           "type": "LCCN"
         }
       ],
-      "contributors": [
-      ],
       "publications": [
         {
           "name": "The Macmillan Company",
           "date":"1927"
         }
-      ],
-      "editionStatements": [
-      ],
-      "notes": [
       ]
     }
-  ],
-  "notes":[]
+  ]
 }


### PR DESCRIPTION
`mod-search` no longer returns empty arrays in the response. I think some framework level changes were made in `mod-search` to not return empty arrays.

This PR updates the test accordingly