### PR TITLE
Bump Spring from 6.1.14 to 6.1.21, Netty from 4.1.119 to 4.1.127

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <karate.version>1.5.1</karate.version>
     <junit.version>5.10.1</junit.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <spring.version>6.1.14</spring.version>
+    <spring.version>6.1.21</spring.version>
     <jenkins.buildNumber>${env.BUILD_NUMBER}</jenkins.buildNumber>
   </properties>
 
@@ -153,7 +153,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.119.Final</version>
+        <version>4.1.127.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
This fixes
* https://www.cve.org/CVERecord?id=CVE-2025-41249
* https://www.cve.org/CVERecord?id=CVE-2025-41234
* https://www.cve.org/CVERecord?id=CVE-2025-58056
* https://www.cve.org/CVERecord?id=CVE-2025-58057
* https://www.cve.org/CVERecord?id=CVE-2025-55163

## Purpose
Fix security vulnerabilities in Spring and Netty dependencies.

## Approach
Bump patch version:
* Spring from 6.1.14 to 6.1.21
* Netty from 4.1.119 to 4.1.127