### PR TITLE
[FAT-22058] Fix unstable tests in mod-search

### DIFF
--- a/mod-search/src/test/resources/spitfire/mod-search/search/resource-job-ids-search.feature
+++ b/mod-search/src/test/resources/spitfire/mod-search/search/resource-job-ids-search.feature
@@ -117,9 +117,9 @@ Feature: Tests for streaming resource ids by cql query
     * def jobId = response.id
 
     Given path '/search/resources/jobs', jobId
+    And retry until response.status == 'ERROR'
     When method GET
     Then status 200
-    Then match response.status == 'ERROR'
 
   @Negative
   Scenario: Job should failed with ERROR if query is blank
@@ -132,7 +132,7 @@ Feature: Tests for streaming resource ids by cql query
     * def jobId = response.id
 
     Given path '/search/resources/jobs', jobId
+    And retry until response.status == 'ERROR'
     When method GET
     Then status 200
-    Then match response.status == 'ERROR'
 


### PR DESCRIPTION
## Purpose
[FAT-22058](https://folio-org.atlassian.net/browse/FAT-22058)
Karate test fail: SearchApiTest

## Approach
Add retry logic until `response.status == 'ERROR'`

### Screenshots

