### PR TITLE
FAT-22600: Update test to reflect latest profile count

### DIFF
--- a/mod-data-export/src/test/resources/firebird/dataexport/features/job-profiles.feature
+++ b/mod-data-export/src/test/resources/firebird/dataexport/features/job-profiles.feature
@@ -92,7 +92,7 @@ Feature: Test job profiles
     When method GET
     Then status 200
     #7 not used job profiles in total
-    And match  response.totalRecords == 7
+    And match  response.totalRecords == 8
 
   Scenario Outline: Test used job profiles
 
@@ -145,7 +145,7 @@ Feature: Test job profiles
     And param used = true
     When method GET
     Then status 200
-    #verify that among 5 job profiles 1 is used
+    #verify that among 6 job profiles 1 is used
     And match  response.totalRecords == 1
 
     Examples:


### PR DESCRIPTION
## Purpose

With the addition of a new data export job profile, update the profile count.

## Approach

Fixes the total count at the end of the test to 5 default profiles + 3 custom profiles, for a total of 8, up from 7.
