### PR TITLE
[MODFISTO-549] Multi-ledger rollover: check budgets

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/rollover-multi-ledger.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/rollover-multi-ledger.feature
@@ -1,4 +1,4 @@
-# For MODORDERS-1388
+# For MODORDERS-1388 and MODFISTO-549
 Feature: Rollover orders using different ledgers
 
   Background:
@@ -144,6 +144,18 @@ Feature: Rollover orders using different ledgers
     And match $.transactions[*].id contains only encumbrancesIds2
     And match each $.transactions[*].amount == 1
 
+    # 10. Check the budgets
+    * print '10. Check the budgets'
+    Given path 'finance/budgets', budgetId3
+    When method GET
+    Then status 200
+    And match $.encumbered == 1
+
+    Given path 'finance/budgets', budgetId4
+    When method GET
+    Then status 200
+    And match $.encumbered == 1
+
 
   @Positive
   Scenario: Rollover open orders with 2 lines, one using different ledgers
@@ -284,3 +296,15 @@ Feature: Rollover orders using different ledgers
     And match $.totalRecords == 3
     And match $.transactions[*].id contains only encumbrancesIds2
     And match $.transactions[*].amount contains only [0.5,0.5,1.0]
+
+    # 10. Check the budgets
+    * print '10. Check the budgets'
+    Given path 'finance/budgets', budgetId3
+    When method GET
+    Then status 200
+    And match $.encumbered == 1.5
+
+    Given path 'finance/budgets', budgetId4
+    When method GET
+    Then status 200
+    And match $.encumbered == 0.5


### PR DESCRIPTION
## Purpose
[MODFISTO-549](https://folio-org.atlassian.net/browse/MODFISTO-549) - Encumbered amount is not updated in budget details for multi-ledger PO lines after rollover until "Recalculate budget totals"

## Approach
Added budget checks to the existing rollover-multi-ledger test.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Related PR
[mod-finance-storage](https://github.com/folio-org/mod-finance-storage/pull/530)
