### PR TITLE
[FAT-22677] Implement Karate test for the test case C353543 Update po lines when an order is closed with the "Cancelled" reason

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/update-po-lines-when-order-cancelled.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/update-po-lines-when-order-cancelled.feature
@@ -1,5 +1,4 @@
-# For MODORDERS-636
-# https://foliotest.testrail.io/index.php?/cases/view/353543
+# For MODORDERS-636, https://foliotest.testrail.io/index.php?/cases/view/353543
 Feature: Update PO Lines When Order Is Cancelled
 
   Background:

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/update-po-lines-when-order-cancelled.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/update-po-lines-when-order-cancelled.feature
@@ -1,0 +1,64 @@
+# For MODORDERS-636
+# https://foliotest.testrail.io/index.php?/cases/view/353543
+Feature: Update PO Lines When Order Is Cancelled
+
+  Background:
+    * print karate.info.scenarioName
+    * url baseUrl
+
+    * call login testAdmin
+    * def okapitokenAdmin = okapitoken
+    * call login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
+    * call variables
+
+    # Create fund and budget
+    * def fundId = call uuid
+    * def budgetId = call uuid
+    * configure headers = headersAdmin
+    * def v = call createFund { 'id': '#(fundId)' }
+    * def v = call createBudget { 'id': '#(budgetId)', 'allocated': 100000, 'fundId': '#(fundId)', 'status': 'Active' }
+    * configure headers = headersUser
+
+    * def createOrderUpdateStatusesAndCancel = read('classpath:thunderjet/mod-orders/helpers/helper-update-po-lines-when-order-cancelled.feature@CreateOrderUpdateStatusesAndCancel')
+
+  @C353543
+  @Positive
+  Scenario: Update PO Lines When An Order Is Closed With The Cancelled Reason
+    * table orderCancelTests
+      | initialPaymentStatus   | initialReceiptStatus   | expectedPaymentStatus  | expectedReceiptStatus  | expectedCloseReason | isAutoClosed | checkinItems | fundId   |
+      | 'Payment Not Required' | 'Receipt Not Required' | 'Payment Not Required' | 'Receipt Not Required' | 'Complete'          | true         | true         | fundId   |
+      | 'Payment Not Required' | 'Fully Received'       | 'Payment Not Required' | 'Fully Received'       | 'Complete'          | true         | false        | fundId   |
+      | 'Payment Not Required' | 'Awaiting Receipt'     | 'Payment Not Required' | 'Cancelled'            | 'Cancelled'         | false        | false        | fundId   |
+      | 'Payment Not Required' | 'Partially Received'   | 'Payment Not Required' | 'Cancelled'            | 'Cancelled'         | false        | false        | fundId   |
+      | 'Payment Not Required' | 'Cancelled'            | 'Payment Not Required' | 'Cancelled'            | 'Complete'          | true         | false        | fundId   |
+      | 'Payment Not Required' | null                   | 'Payment Not Required' | 'Cancelled'            | 'Cancelled'         | false        | false        | fundId   |
+      | 'Fully Paid'           | 'Fully Received'       | 'Fully Paid'           | 'Fully Received'       | 'Complete'          | true         | false        | fundId   |
+      | 'Fully Paid'           | 'Awaiting Receipt'     | 'Fully Paid'           | 'Cancelled'            | 'Cancelled'         | false        | false        | fundId   |
+      | 'Fully Paid'           | 'Partially Received'   | 'Fully Paid'           | 'Cancelled'            | 'Cancelled'         | false        | false        | fundId   |
+      | 'Fully Paid'           | 'Cancelled'            | 'Fully Paid'           | 'Cancelled'            | 'Complete'          | true         | false        | fundId   |
+      | 'Fully Paid'           | null                   | 'Fully Paid'           | 'Cancelled'            | 'Cancelled'         | false        | false        | fundId   |
+      | 'Fully Paid'           | 'Receipt Not Required' | 'Fully Paid'           | 'Receipt Not Required' | 'Complete'          | true         | true         | fundId   |
+      | 'Partially Paid'       | 'Awaiting Receipt'     | 'Cancelled'            | 'Cancelled'            | 'Cancelled'         | false        | false        | fundId   |
+      | 'Partially Paid'       | 'Partially Received'   | 'Cancelled'            | 'Cancelled'            | 'Cancelled'         | false        | false        | fundId   |
+      | 'Partially Paid'       | 'Cancelled'            | 'Cancelled'            | 'Cancelled'            | 'Cancelled'         | false        | false        | fundId   |
+      | 'Partially Paid'       | null                   | 'Cancelled'            | 'Cancelled'            | 'Cancelled'         | false        | false        | fundId   |
+      | 'Partially Paid'       | 'Receipt Not Required' | 'Cancelled'            | 'Receipt Not Required' | 'Cancelled'         | false        | true         | fundId   |
+      | 'Partially Paid'       | 'Fully Received'       | 'Cancelled'            | 'Fully Received'       | 'Cancelled'         | false        | false        | fundId   |
+      | 'Cancelled'            | 'Partially Received'   | 'Cancelled'            | 'Cancelled'            | 'Cancelled'         | false        | false        | fundId   |
+      | 'Cancelled'            | 'Cancelled'            | 'Cancelled'            | 'Cancelled'            | 'Cancelled'         | true         | false        | fundId   |
+      | 'Cancelled'            | null                   | 'Cancelled'            | 'Cancelled'            | 'Cancelled'         | false        | false        | fundId   |
+      | 'Cancelled'            | 'Receipt Not Required' | 'Cancelled'            | 'Receipt Not Required' | 'Complete'          | true         | true         | fundId   |
+      | 'Cancelled'            | 'Fully Received'       | 'Cancelled'            | 'Fully Received'       | 'Complete'          | true         | false        | fundId   |
+      | 'Cancelled'            | 'Awaiting Receipt'     | 'Cancelled'            | 'Cancelled'            | 'Cancelled'         | false        | false        | fundId   |
+      | null                   | 'Cancelled'            | 'Cancelled'            | 'Cancelled'            | 'Cancelled'         | false        | false        | fundId   |
+      | null                   | null                   | 'Cancelled'            | 'Cancelled'            | 'Cancelled'         | false        | false        | fundId   |
+      | null                   | 'Receipt Not Required' | 'Cancelled'            | 'Receipt Not Required' | 'Cancelled'         | false        | true         | fundId   |
+      | null                   | 'Fully Received'       | 'Cancelled'            | 'Fully Received'       | 'Cancelled'         | false        | false        | fundId   |
+      | null                   | 'Awaiting Receipt'     | 'Cancelled'            | 'Cancelled'            | 'Cancelled'         | false        | false        | fundId   |
+      | null                   | 'Partially Received'   | 'Cancelled'            | 'Cancelled'            | 'Cancelled'         | false        | false        | fundId   |
+    * def v = call createOrderUpdateStatusesAndCancel orderCancelTests

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/helpers/helper-update-po-lines-when-order-cancelled.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/helpers/helper-update-po-lines-when-order-cancelled.feature
@@ -1,0 +1,56 @@
+@ignore
+Feature: Helper for "update-po-lines-when-order-cancelled"
+
+  Background:
+    * url baseUrl
+
+  @CreateOrderUpdateStatusesAndCancel
+  Scenario: Create open order, set PO line statuses, cancel order, and verify final statuses
+    * def initialPaymentStatus = karate.get('initialPaymentStatus', null)
+    * def initialReceiptStatus = karate.get('initialReceiptStatus', null)
+
+    # 1. Create order and order line
+    * def orderId = call uuid
+    * def poLineId = call uuid
+    * def v = call createOrder { id: '#(orderId)' }
+    * def v = call createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', fundId: '#(fundId)', checkinItems: '#(checkinItems)' }
+
+    # 2. Open the order
+    * def v = call openOrder { orderId: '#(orderId)' }
+
+    # 3. Update PO line to the desired payment/receipt statuses
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+    * def poLine = response
+    * set poLine.paymentStatus = initialPaymentStatus
+    * set poLine.receiptStatus = initialReceiptStatus
+    * set poLine.checkinItems = checkinItems
+
+    Given path 'orders/order-lines', poLineId
+    And request poLine
+    When method PUT
+    Then status 204
+
+    # 4. Verify order status after POL update and cancel if not auto-closed
+    Given path 'orders/composite-orders', orderId
+    When method GET
+    Then status 200
+    * def expectedStatusAfterUpdate = isAutoClosed ? 'Closed' : 'Open'
+    And match response.workflowStatus == expectedStatusAfterUpdate
+
+    * if (!isAutoClosed) karate.call('classpath:thunderjet/mod-orders/reusable/cancel-order.feature', { orderId: orderId })
+
+    # 5. Verify the resulting PO line statuses
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+    And match response.paymentStatus == expectedPaymentStatus
+    And match response.receiptStatus == expectedReceiptStatus
+
+    # 6. Verify the order close reason
+    Given path 'orders/composite-orders', orderId
+    When method GET
+    Then status 200
+    And match response.workflowStatus == 'Closed'
+    And match response.closeReason.reason == expectedCloseReason

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
@@ -315,5 +315,8 @@ Feature: mod-orders integration tests
   Scenario: Unopen order with synchronized and independent POLs deletes only empty holding
     * call read('features/unopen-order-delete-empty-holding-mixed-pols.feature')
 
+  Scenario: Update PO lines when an order is cancelled
+    * call read('features/update-po-lines-when-order-cancelled.feature')
+
   Scenario: Add piece to cancelled ongoing order
     * call read('features/add-piece-to-cancelled-ongoing-order.feature')

--- a/acquisitions/src/test/java/org/folio/OrdersExtendedApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersExtendedApiTest.java
@@ -80,7 +80,7 @@ class OrdersExtendedApiTest extends TestBaseEureka {
   }
 
   @Test
-  @DisplayName("(Thunderjet) (@C353543) Update po lines when an order is closed with the 'Cancelled' reason")
+  @DisplayName("(Thunderjet) (C353543) Update po lines when an order is closed with the 'Cancelled' reason")
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void updatePoLinesWhenOrderCancelled() {
     runFeatureTest(Feature.FEATURE_3.getFileName());

--- a/acquisitions/src/test/java/org/folio/OrdersExtendedApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersExtendedApiTest.java
@@ -24,7 +24,8 @@ class OrdersExtendedApiTest extends TestBaseEureka {
 
   private enum Feature implements org.folio.test.config.CommonFeature {
     FEATURE_1("piece-status-transitions-claiming", true),
-    FEATURE_2("add-piece-to-cancelled-ongoing-order", true);
+    FEATURE_2("add-piece-to-cancelled-ongoing-order", true),
+    FEATURE_3("update-po-lines-when-order-cancelled", true);
 
     private final String fileName;
     private final boolean isEnabled;
@@ -76,5 +77,12 @@ class OrdersExtendedApiTest extends TestBaseEureka {
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void addPieceToCancelledOngoingOrder() {
     runFeatureTest(Feature.FEATURE_2.getFileName());
+  }
+
+  @Test
+  @DisplayName("(Thunderjet) (@C353543) Update po lines when an order is closed with the 'Cancelled' reason")
+  @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
+  void updatePoLinesWhenOrderCancelled() {
+    runFeatureTest(Feature.FEATURE_3.getFileName());
   }
 }


### PR DESCRIPTION
## Purpose
[[FAT-22677] Implement Karate test for the test case C353543 Update po lines when an order is closed with the "Cancelled" reason](https://folio-org.atlassian.net/browse/FAT-22677)

<img width="877" height="369" alt="image" src="https://github.com/user-attachments/assets/bc5f1f9c-7795-4a07-a91c-dfb207294a9f" />
