### PR TITLE
Bump Netty from 4.1.127.Final to 4.1.132.Final fixing vulns

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.127.Final</version>
+        <version>4.1.132.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Fix https://www.cve.org/CVERecord?id=CVE-2026-33870 HTTP Request Smuggling
Fix https://www.cve.org/CVERecord?id=CVE-2026-33871 Allocation of Resources Without Limits or Throttling
Fix https://www.cve.org/CVERecord?id=CVE-2025-67735 CRLF Injection
