### PR TITLE
FAT-25845 Update expiration-lending-flow.feature

### DIFF
--- a/mod-dcb/src/main/resources/volaris/mod-dcb/features/expiration-lending-flow.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/features/expiration-lending-flow.feature
@@ -15,7 +15,7 @@ Feature: Testing Lending Flow Request Expiration
     * def expLenderItemBarcode = call random_string
 
   @C1046007
-  Scenario: Request expiration for LENDER role transitions transaction to EXPIRED, check-in at home service point closes transaction
+  Scenario: Request expiration for LENDER role transitions transaction to EXPIRED, check-in at any service point closes transaction
     * def newItemPayload = read('classpath:volaris/mod-dcb/features/samples/item/item-entity-request.json')
     * newItemPayload.id = expLenderItemId
     * newItemPayload.barcode = expLenderItemBarcode
@@ -116,7 +116,7 @@ Feature: Testing Lending Flow Request Expiration
 
     * def intCheckInDate2 = call read('classpath:volaris/mod-dcb/features/util/get-time-now-function.js')
     * def checkInRequest2 = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
-    * checkInRequest2.servicePointId = servicePointId21
+    * checkInRequest2.servicePointId = servicePointId11
     * checkInRequest2.itemBarcode = expLenderItemBarcode
 
     Given path 'circulation', 'check-in-by-barcode'
@@ -124,24 +124,6 @@ Feature: Testing Lending Flow Request Expiration
     When method POST
     Then status 200
     And match $.item.status.name == 'In transit'
-    * call pause 5000
-
-    Given path 'transactions', expLenderTransactionId, 'status'
-    When method GET
-    Then status 200
-    And match $.status == 'EXPIRED'
-    And match $.role == 'LENDER'
-
-    * def intCheckInDate3 = call read('classpath:volaris/mod-dcb/features/util/get-time-now-function.js')
-    * def checkInRequest3 = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
-    * checkInRequest3.servicePointId = servicePointId
-    * checkInRequest3.itemBarcode = expLenderItemBarcode
-
-    Given path 'circulation', 'check-in-by-barcode'
-    And request checkInRequest3
-    When method POST
-    Then status 200
-    And match $.item.status.name == 'Available'
     * call pause 5000
 
     Given path 'transactions', expLenderTransactionId, 'status'


### PR DESCRIPTION
## Purpose
Fix failing expiration-lending-flow Karate test caused by behavioral change introduced in MODDCB-267.

## Approach
MODDCB-267 simplified the LENDER expiration logic — removed the item status (Available) check before closing, so expired LENDER transactions now close on the first check-in at any service point (same as BORROWER/PICKUP/BORROWING-PICKUP).

Updated the test to reflect this: replaced the two-step post-expiration flow (intermediate SP + home SP check-in) with a single check-in, consistent with the other expiration flows.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Report
https://jenkins.ci.folio.org/job/folioTestingTools/job/runKarateTests/812/cucumber-html-reports/overview-features.html