### PR TITLE
[FAT-21344]. Thunderjet - Create Karate test - Change instance connection for P/E mix order with independent workflow (""Create new"") when piece is received in existing and new locations (""Delete holdings"")

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/pe-mix-change-instance-connection-create-new-delete-holdings.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/pe-mix-change-instance-connection-create-new-delete-holdings.feature
@@ -1,0 +1,181 @@
+# For MODORDERS-1297, MODORDERS-1300, https://foliotest.testrail.io/index.php?/cases/view/784423
+Feature: P/E Mix Change Instance Connection Create New Delete Holdings
+
+  Background:
+    * print karate.info.scenarioName
+    * url baseUrl
+
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+    * configure retry = { count: 10, interval: 10000 }
+
+    * callonce variables
+
+  @C784423
+  @Positive
+  Scenario: P/E Mix Order Change Instance To Existing With Create New Holdings And Delete Abandoned Holdings
+    * def instanceId = call uuid
+    * def orderId = call uuid
+    * def poLineId = call uuid
+    * def preconditionHoldingId = call uuid
+
+    # 1. Create Instance #1 With One Holding In Loc1 (Precondition)
+    * print '1. Create Instance #1 With One Holding In Loc1 (Precondition)'
+    * configure headers = headersAdmin
+    * def v = call createInstance { id: '#(instanceId)', title: 'Instance C784423', instanceTypeId: '#(globalInstanceTypeId)' }
+
+    Given path 'holdings-storage/holdings'
+    And request
+    """
+    {
+      "id": "#(preconditionHoldingId)",
+      "instanceId": "#(instanceId)",
+      "permanentLocationId": "#(globalLocationsId)",
+      "sourceId": "#(globalHoldingsSourceId)"
+    }
+    """
+    When method POST
+    Then status 201
+
+    # 2. Create P/E Mix Order And Open It
+    * print '2. Create P/E Mix Order And Open It'
+    * configure headers = headersUser
+    * def v = call createOrder { id: '#(orderId)' }
+    * def locations =
+    """
+    [
+      { locationId: '#(globalLocationsId)', quantity: 1, quantityPhysical: 1 },
+      { locationId: '#(globalLocationsId2)', quantity: 1, quantityElectronic: 1 }
+    ]
+    """
+
+    * def orderLineRequest =
+    """
+    {
+      id: '#(poLineId)',
+      orderId: '#(orderId)',
+      titleOrPackage: 'Title C784423',
+      orderFormat: 'P/E Mix',
+      checkinItems: true,
+      quantity: 1,
+      quantityElectronic: 1,
+      listUnitPriceElectronic: 1.0,
+      createInventory: 'Instance, Holding, Item',
+      eresourceCreateInventory: 'Instance, Holding, Item',
+      eresourceMaterialType: '#(globalMaterialTypeIdElec)',
+      fundDistribution: [],
+      locations: '#(locations)'
+    }
+    """
+    * def v = call createOrderLine orderLineRequest
+    * def v = call openOrder { orderId: '#(orderId)' }
+
+    # 3.1 Get POL Holding IDs
+    * print '3.1 Get POL Holding IDs'
+    Given path 'orders/order-lines', poLineId
+    And retry until response.locations[0].holdingId != null && response.locations[1].holdingId != null
+    When method GET
+    Then status 200
+    * def holdingId1 = response.locations[0].holdingId
+    * def holdingId2 = response.locations[1].holdingId
+    * def instanceIdOld = response.instanceId
+
+    # 3.2 Get Title ID
+    * print '3.2 Get Title ID'
+    Given path 'orders/titles'
+    And param query = 'poLineId==' + poLineId
+    When method GET
+    Then status 200
+    And match response.totalRecords == 1
+    And match response.titles[0].poLineId == poLineId
+    * def titleId = response.titles[0].id
+
+    # 4.1 Create Pieces With Holding IDs
+    * print '4.1 Create Pieces With Holding IDs'
+    * def pieceId1 = call uuid
+    * def pieceId2 = call uuid
+    * table piecesData
+      | id       | poLineId | titleId | holdingId  | format       | createItem |
+      | pieceId1 | poLineId | titleId | holdingId1 | 'Physical'   | true       |
+      | pieceId2 | poLineId | titleId | holdingId2 | 'Electronic' | true       |
+    * def v = call createPieceWithHoldingOrLocation piecesData
+
+    # 4.2 Create Piece #3 In New Location Loc3
+    * print '4.2 Create Piece #3 In New Location Loc3'
+    * def pieceId3 = call uuid
+    * def pieceId3Data = { id: '#(pieceId3)', poLineId: '#(poLineId)', titleId: '#(titleId)', locationId: '#(globalLocationsId3)', useLocationId: true, format: 'Physical', createItem: true }
+    * def v = call createPieceWithHoldingOrLocation pieceId3Data
+
+    # 4.3 Get Holding ID Created For Piece #3
+    * print '4.3 Get Holding ID Created For Piece #3'
+    Given path 'orders/pieces', pieceId3
+    When method GET
+    Then status 200
+    * def holdingId3 = response.holdingId
+
+    # 4.4 Receive All Three Pieces
+    * print '4.4 Receive All Three Pieces'
+    * table receivePiecesData
+      | pieceId  | poLineId | holdingId  |
+      | pieceId1 | poLineId | holdingId1 |
+      | pieceId2 | poLineId | holdingId2 |
+      | pieceId3 | poLineId | holdingId3 |
+    * def v = call receivePieceWithHolding receivePiecesData
+
+    # 5. Change Instance Connection With "Create" Holdings Operation And Delete Abandoned Holdings
+    * print '5. Change Instance Connection With "Create" Holdings Operation And Delete Abandoned Holdings'
+    * table instanceChangeData
+      | poLineId | instanceId | holdingsOperation | deleteAbandonedHoldings |
+      | poLineId | instanceId | 'Create'          | true                    |
+    * def v = call changeOrderLineInstanceConnection instanceChangeData
+
+    # 6.1 Verify POL Instance ID And Holdings Updated
+    * print '6.1 Verify POL Instance ID And Holdings Updated'
+    * def isPoLineUpdated =
+    """
+    function(response) {
+      return response.instanceId == instanceId &&
+             response.instanceId != instanceIdOld &&
+             response.locations != null &&
+             response.locations.length == 2 &&
+             response.locations[0].holdingId != holdingId1 &&
+             response.locations[1].holdingId != holdingId2;
+    }
+    """
+    Given path 'orders/order-lines', poLineId
+    And retry until isPoLineUpdated(response)
+    When method GET
+    Then status 200
+    * def newHoldingId1 = response.locations[0].holdingId
+    * def newHoldingId2 = response.locations[1].holdingId
+
+    # 6.2 Verify Instance #1 Now Has Four Holdings
+    # (Precondition Holding In Loc1 + Three New Holdings Created For Loc1, Loc2, Loc3)
+    * print '6.2 Verify Instance #1 Now Has Four Holdings'
+    * configure headers = headersAdmin
+    * def isInstanceHoldingsCreated =
+    """
+    function(response) {
+      var ids = karate.jsonPath(response, '$.holdingsRecords[*].id');
+      return response.totalRecords == 4 &&
+             ids.indexOf(preconditionHoldingId) >= 0;
+    }
+    """
+    Given path 'holdings-storage/holdings'
+    And param query = 'instanceId==' + instanceId
+    And retry until isInstanceHoldingsCreated(response)
+    When method GET
+    Then status 200
+
+    # 6.3 Verify Old Instance No Longer Has Any Holdings
+    * print '6.3 Verify Old Instance No Longer Has Any Holdings'
+    Given path 'holdings-storage/holdings'
+    And param query = 'instanceId==' + instanceIdOld
+    And retry until response.totalRecords == 0
+    When method GET
+    Then status 200

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/pe-mix-synchronized-change-instance-connection-create-new-delete-holdings.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/pe-mix-synchronized-change-instance-connection-create-new-delete-holdings.feature
@@ -1,0 +1,177 @@
+# For MODORDERS-1297, MODORDERS-1300, https://foliotest.testrail.io/index.php?/cases/view/784425
+Feature: P/E Mix Synchronized Change Instance Connection Create New Delete Holdings
+
+  Background:
+    * print karate.info.scenarioName
+    * url baseUrl
+
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+    * configure retry = { count: 10, interval: 10000 }
+
+    * callonce variables
+
+  @C784425
+  @Positive
+  Scenario: P/E Mix Order Synchronized Change Instance To Existing With Create New Holdings And Delete Abandoned Holdings
+    * def instanceId = call uuid
+    * def orderId = call uuid
+    * def poLineId = call uuid
+    * def preconditionHoldingId = call uuid
+    * def pieceId3 = call uuid
+
+    # 1. Create Instance #1 With One Holding In Loc1 (Precondition)
+    * print '1. Create Instance #1 With One Holding In Loc1 (Precondition)'
+    * configure headers = headersAdmin
+    * def v = call createInstance { id: '#(instanceId)', title: 'Instance C784425', instanceTypeId: '#(globalInstanceTypeId)' }
+
+    Given path 'holdings-storage/holdings'
+    And request
+    """
+    {
+      "id": "#(preconditionHoldingId)",
+      "instanceId": "#(instanceId)",
+      "permanentLocationId": "#(globalLocationsId)",
+      "sourceId": "#(globalHoldingsSourceId)"
+    }
+    """
+    When method POST
+    Then status 201
+
+    # 2. Create P/E Mix Order With Synchronized Workflow And Open It
+    * print '2. Create P/E Mix Order With Synchronized Workflow And Open It'
+    * configure headers = headersUser
+    * def v = call createOrder { id: '#(orderId)' }
+    * def locations =
+    """
+    [
+      { locationId: '#(globalLocationsId)', quantity: 2, quantityPhysical: 1, quantityElectronic: 1 }
+    ]
+    """
+
+    * def orderLineRequest =
+    """
+    {
+      id: '#(poLineId)',
+      orderId: '#(orderId)',
+      titleOrPackage: 'Title C784425',
+      orderFormat: 'P/E Mix',
+      checkinItems: false,
+      quantity: 1,
+      quantityElectronic: 1,
+      listUnitPriceElectronic: 1.0,
+      createInventory: 'Instance, Holding, Item',
+      eresourceCreateInventory: 'Instance, Holding, Item',
+      eresourceMaterialType: '#(globalMaterialTypeIdElec)',
+      fundDistribution: [],
+      locations: '#(locations)'
+    }
+    """
+    * def v = call createOrderLine orderLineRequest
+    * def v = call openOrder { orderId: '#(orderId)' }
+
+    # 3.1 Get POL Instance ID And Auto-Created Holding ID In Loc1
+    * print '3.1 Get POL Instance ID And Auto-Created Holding ID In Loc1'
+    Given path 'orders/order-lines', poLineId
+    And retry until response.instanceId != null && response.locations[0].holdingId != null
+    When method GET
+    Then status 200
+    * def instanceIdOld = response.instanceId
+    * def holdingId1 = response.locations[0].holdingId
+
+    # 3.2 Get Title ID And Auto-Created Pieces
+    * print '3.2 Get Title ID And Auto-Created Pieces'
+    Given path 'orders/titles'
+    And param query = 'poLineId==' + poLineId
+    When method GET
+    Then status 200
+    And match $.totalRecords == 1
+    * def titleId = $.titles[0].id
+
+    Given path 'orders/pieces'
+    And param query = 'poLineId==' + poLineId
+    And retry until response.totalRecords == 2
+    When method GET
+    Then status 200
+    * def physicalPieceId = karate.filter(response.pieces, function(p) { return p.format == 'Physical' })[0].id
+    * def electronicPieceId = karate.filter(response.pieces, function(p) { return p.format == 'Electronic' })[0].id
+
+    # 4.1 Add Piece In New Location Loc2
+    * print '4.1 Add Piece In New Location Loc2'
+    * def pieceRequest =
+    """
+    { id: '#(pieceId3)', poLineId: '#(poLineId)', titleId: '#(titleId)', locationId: '#(globalLocationsId2)', useLocationId: true, format: 'Physical', createItem: true }
+    """
+    * def v = call createPieceWithHoldingOrLocation pieceRequest
+
+    # 4.2 Get Holding ID Created For Piece In Loc2
+    * print '4.2 Get Holding ID Created For Piece In Loc2'
+    Given path 'orders/pieces', pieceId3
+    When method GET
+    Then status 200
+    * def holdingId2 = response.holdingId
+
+    # 4.3 Receive All Pieces
+    * print '4.3 Receive All Pieces'
+    * table receivePiecesData
+      | pieceId          | poLineId | holdingId  |
+      | physicalPieceId  | poLineId | holdingId1 |
+      | electronicPieceId| poLineId | holdingId1 |
+      | pieceId3         | poLineId | holdingId2 |
+    * def v = call receivePieceWithHolding receivePiecesData
+
+    # 5. Change Instance Connection With "Create" Holdings Operation And Delete Abandoned Holdings
+    * print '5. Change Instance Connection With "Create" Holdings Operation And Delete Abandoned Holdings'
+    * table instanceChangeData
+      | poLineId | instanceId | holdingsOperation | deleteAbandonedHoldings |
+      | poLineId | instanceId | 'Create'          | true                    |
+    * def v = call changeOrderLineInstanceConnection instanceChangeData
+
+    # 6.1 Verify POL Instance ID And Locations Updated
+    * print '6.1 Verify POL Instance ID And Locations Updated'
+    * def isPoLineUpdated =
+    """
+    function(response) {
+      return response.instanceId == instanceId &&
+             response.instanceId != instanceIdOld &&
+             response.locations != null &&
+             response.locations.length == 2 &&
+             response.locations[0].holdingId != holdingId1 &&
+             response.locations[1].holdingId != holdingId1;
+    }
+    """
+    Given path 'orders/order-lines', poLineId
+    And retry until isPoLineUpdated(response)
+    When method GET
+    Then status 200
+
+    # 6.2 Verify Instance #1 Now Has Three Holdings
+    # (Precondition Holding In Loc1 + New Loc1 With Two Items + New Loc2 With One Item)
+    * print '6.2 Verify Instance #1 Now Has Three Holdings'
+    * configure headers = headersAdmin
+    * def isInstanceHoldingsCreated =
+    """
+    function(response) {
+      var ids = karate.jsonPath(response, '$.holdingsRecords[*].id');
+      return response.totalRecords == 3 &&
+             ids.indexOf(preconditionHoldingId) >= 0;
+    }
+    """
+    Given path 'holdings-storage/holdings'
+    And param query = 'instanceId==' + instanceId
+    And retry until isInstanceHoldingsCreated(response)
+    When method GET
+    Then status 200
+
+    # 6.3 Verify Old Instance No Longer Has Any Holdings
+    * print '6.3 Verify Old Instance No Longer Has Any Holdings'
+    Given path 'holdings-storage/holdings'
+    And param query = 'instanceId==' + instanceIdOld
+    And retry until response.totalRecords == 0
+    When method GET
+    Then status 200

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
@@ -326,3 +326,9 @@ Feature: mod-orders integration tests
 
   Scenario: Update PO lines when an order is cancelled
     * call read('features/update-po-lines-when-order-cancelled.feature')
+
+  Scenario: P/E Mix change instance connection create new holdings and delete abandoned holdings
+    * call read('features/pe-mix-change-instance-connection-create-new-delete-holdings.feature')
+
+  Scenario: P/E Mix synchronized change instance connection create new holdings and delete abandoned holdings
+    * call read('features/pe-mix-synchronized-change-instance-connection-create-new-delete-holdings.feature')

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/create-order-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/create-order-line.feature
@@ -2,7 +2,7 @@
 Feature: Create order line
   # parameters: id, orderId, fundId?, listUnitPrice?, listUnitPriceElectronic?, isPackage?, titleOrPackage?, paymentStatus?,
   # receiptStatus?, locations?, orderFormat?, quantity?, quantityElectronic?, checkinItems?, createInventory?, eresourceCreateInventory?,
-  # fundDistribution?, claimingActive?, claimingInterval?, suppressInstanceFromDiscovery?, productIds?, currency?, exchangeRate?
+  # eresourceMaterialType?, fundDistribution?, claimingActive?, claimingInterval?, suppressInstanceFromDiscovery?, productIds?, currency?, exchangeRate?
 
   Background:
     * print karate.info.scenarioName
@@ -37,6 +37,7 @@ Feature: Create order line
     * def productIds = karate.get("productIds", poLine.details.productIds)
     * def currency = karate.get("currency", null)
     * def exchangeRate = karate.get("exchangeRate", null)
+    * def eresourceMaterialType = karate.get("eresourceMaterialType", null)
 
     * set poLine.id = id
     * set poLine.purchaseOrderId = orderId
@@ -59,6 +60,7 @@ Feature: Create order line
     * set poLine.checkinItems = checkinItems
     * set poLine.physical.createInventory = createInventory
     * set poLine.eresource.createInventory = eresourceCreateInventory
+    * if (eresourceMaterialType != null) poLine.eresource.materialType = eresourceMaterialType
     * set poLine.fundDistribution = fundDistribution
     * set poLine.claimingActive = claimingActive
     * set poLine.claimingInterval = claimingInterval

--- a/acquisitions/src/test/java/org/folio/OrdersExtendedApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersExtendedApiTest.java
@@ -35,7 +35,9 @@ class OrdersExtendedApiTest extends TestBaseEureka implements AcquisitionsTest {
     // moved from OrdersCriticalPathApiTest (TestRail group = Extended)
     FEATURE_8("unopen-order-delete-empty-holding-two-locs", true),
     FEATURE_9("unopen-order-delete-empty-holding-two-pols", true),
-    FEATURE_10("unopen-order-delete-empty-holding-mixed-pols", true);
+    FEATURE_10("unopen-order-delete-empty-holding-mixed-pols", true),
+    FEATURE_11("pe-mix-change-instance-connection-create-new-delete-holdings", true),
+    FEATURE_12("pe-mix-synchronized-change-instance-connection-create-new-delete-holdings", true);
 
     private final String fileName;
     private final boolean isEnabled;
@@ -150,5 +152,19 @@ class OrdersExtendedApiTest extends TestBaseEureka implements AcquisitionsTest {
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void unopenOrderDeleteEmptyHoldingMixedPols() {
     runFeatureTest(Feature.FEATURE_10.getFileName());
+  }
+
+  @Test
+  @DisplayName("(Thunderjet) (C784423) P/E Mix Change Instance Connection Create New Holdings Delete Abandoned Holdings")
+  @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
+  void peMixChangeInstanceConnectionCreateNewDeleteHoldings() {
+    runFeatureTest(Feature.FEATURE_11.getFileName());
+  }
+
+  @Test
+  @DisplayName("(Thunderjet) (C784425) P/E Mix Synchronized Change Instance Connection Create New Holdings Delete Abandoned Holdings")
+  @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
+  void peMixSynchronizedChangeInstanceConnectionCreateNewDeleteHoldings() {
+    runFeatureTest(Feature.FEATURE_12.getFileName());
   }
 }


### PR DESCRIPTION
## Purpose

- <https://folio-org.atlassian.net/browse/FAT-21344>
- <https://folio-org.atlassian.net/browse/FAT-21345>

## Approach

- Implement C784423 and C784425