### PR TITLE
FAT-22768: fix edge-rtac init fiscal-years order creation

### DIFF
--- a/edge-rtac/src/main/resources/core_platform/edge-rtac/features/rtac-from-order-piece.feature
+++ b/edge-rtac/src/main/resources/core_platform/edge-rtac/features/rtac-from-order-piece.feature
@@ -38,7 +38,7 @@ Feature: rtac from order piece tests
     * def fundId = callonce random_uuid
     * def budgetId = callonce random_uuid
     * call createFund { 'id': '#(fundId)'}
-    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)'}
+    * call createBudget { 'id': '#(budgetId)', 'allocated': 10000, 'fundId': '#(fundId)', 'fiscalYearId': 'ac2164c7-ba3d-1bc2-a12c-e35ceccbfaf2' }
 
     # create order
     * def orderId = callonce random_uuid

--- a/edge-rtac/src/main/resources/core_platform/edge-rtac/features/util/order/finances.feature
+++ b/edge-rtac/src/main/resources/core_platform/edge-rtac/features/util/order/finances.feature
@@ -10,11 +10,11 @@ Feature: global finances
       """
       {
         "id": "ac2164c7-ba3d-1bc2-a12c-e35ceccbfaf2",
-        "name": "TST-Fiscal Year 2024",
-        "code": "FY2024",
+        "name": "TST-Fiscal Year 2026",
+        "code": "FY2026",
         "description": "January 1 - December 30",
-        "periodStart": "2024-01-01T00:00:00Z",
-        "periodEnd": "2024-12-31T23:59:59Z",
+        "periodStart": "2026-01-01T00:00:00Z",
+        "periodEnd": "2026-12-31T23:59:59Z",
         "series": "FY"
       }
       """
@@ -43,11 +43,11 @@ Feature: global finances
       """
       {
         "id": "ac2164c7-ba3d-1bc2-a12c-e35ceccbfaf3",
-        "name": "TST-Fiscal Year 2025",
-        "code": "FY2025",
+        "name": "TST-Fiscal Year 2027",
+        "code": "FY2027",
         "description": "January 1 - December 30",
-        "periodStart": "2025-01-01T00:00:00Z",
-        "periodEnd": "2025-12-31T23:59:59Z",
+        "periodStart": "2027-01-01T00:00:00Z",
+        "periodEnd": "2027-12-31T23:59:59Z",
         "series": "FY"
       }
       """

--- a/edge-rtac/src/main/resources/karate-config.js
+++ b/edge-rtac/src/main/resources/karate-config.js
@@ -75,7 +75,6 @@ function fn() {
     config.edgeUrl = 'https://folio-edev-dreamliner-edge.ci.folio.org';
     config.baseKeycloakUrl = 'https://folio-edev-dreamliner-keycloak.ci.folio.org';
     config.apikey = 'eyJzIjoid2hhdHNpdCIsInQiOiJ0ZXN0cnRhYyIsInUiOiJ0ZXN0LXVzZXIifQ==';
-    config.prototypeTenant='diku'
  } else if (env == 'folio-testing-karate') {
     config.baseUrl = '${baseUrl}';
     config.edgeUrl = '${edgeUrl}';


### PR DESCRIPTION
## Purpose
Fix karate tests set up for edge-rtac related to fiscal-years order creation

## Approach
- Updated start and end period of fiscal year to year 2026 and 2027

<img width="1690" height="1023" alt="image" src="https://github.com/user-attachments/assets/57138488-ad51-4f45-8255-864a50eaacfe" />

## Linked issues

https://folio-org.atlassian.net/browse/FAT-22768
