### PR TITLE
FAT-25957 Add BORROWING-PICKUP self-borrowing integration test

### DIFF
--- a/mod-dcb/src/main/resources/volaris/mod-dcb/features/borrowing-pickup-self-borrowing.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/features/borrowing-pickup-self-borrowing.feature
@@ -1,0 +1,148 @@
+Feature: Testing Borrowing-Pickup Self-Borrowing Flow
+
+  Background:
+    * url baseUrl
+    * def proxyCall = karate.get('proxyCall', false)
+    * def user = proxyCall == true ? testUser : testAdmin
+    * print 'user  is', user
+    * callonce login user
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'x-okapi-tenant': '#(testTenant)', 'Accept': 'application/json'  }
+    * def key = ''
+    * configure headers = headersUser
+    * callonce variables
+    * def startDate = callonce getCurrentUtcDate
+    * configure retry = { count: 5, interval: 1000 }
+    * def sbTransactionId = call uuid1
+    * def sbItemId = call uuid1
+    * def sbItemBarcode = call random_string
+
+  @C773214
+  Scenario: Create BORROWING-PICKUP transaction with selfBorrowing and verify full status lifecycle
+
+    # Precondition: create an item in Available status in inventory
+    * def itemEntityRequest = read('classpath:volaris/mod-dcb/features/samples/item/item-entity-request.json')
+    * itemEntityRequest.id = sbItemId
+    * itemEntityRequest.barcode = sbItemBarcode
+    * itemEntityRequest.holdingsRecordId = holdingId
+    * itemEntityRequest.materialType.id = intMaterialTypeId
+    * itemEntityRequest.materialType.name = materialTypeName
+    * itemEntityRequest.status.name = 'Available'
+    Given path 'inventory', 'items'
+    And request itemEntityRequest
+    When method POST
+    Then status 201
+
+    # Step 1: Create DCB transaction with BORROWING-PICKUP role and selfBorrowing=true
+    * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
+    * url baseUrlNew
+    * def createDCBTransactionRequest = read('classpath:volaris/mod-dcb/features/samples/transaction/create-dcb-transaction.json')
+    * createDCBTransactionRequest.item.id = sbItemId
+    * createDCBTransactionRequest.item.barcode = sbItemBarcode
+    * createDCBTransactionRequest.patron.id = patronId31
+    * createDCBTransactionRequest.patron.group = patronGroupName
+    * createDCBTransactionRequest.patron.barcode = patronBarcode31
+    * createDCBTransactionRequest.pickup.servicePointId = servicePointId21
+    * createDCBTransactionRequest.role = 'BORROWING-PICKUP'
+    * createDCBTransactionRequest.selfBorrowing = true
+
+    * def orgPath = '/transactions/' + sbTransactionId
+    * def newPath = proxyCall == true ? proxyPath+orgPath : orgPath
+
+    Given path newPath
+    And param apikey = key
+    And request createDCBTransactionRequest
+    When method POST
+    Then status 201
+    And match $.status == 'CREATED'
+    And match $.item.barcode == sbItemBarcode
+    And match $.patron.id == patronId31
+
+    # Step 2: Verify transaction status is CREATED
+    * def orgPathStatus = '/transactions/' + sbTransactionId + '/status'
+    * def newPathStatus = proxyCall == true ? proxyPath+orgPathStatus : orgPathStatus
+    Given path newPathStatus
+    And param apikey = key
+    When method GET
+    Then status 200
+    And match $.status == 'CREATED'
+    And match $.role == 'BORROWING-PICKUP'
+
+    # Step 3: Check in item at pickup service point
+    * url baseUrl
+    * def intCheckInDate = call read('classpath:volaris/mod-dcb/features/util/get-time-now-function.js')
+    * def checkInRequest = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
+    * checkInRequest.servicePointId = servicePointId21
+    * checkInRequest.itemBarcode = sbItemBarcode
+    Given path 'circulation', 'check-in-by-barcode'
+    And request checkInRequest
+    When method POST
+    Then status 200
+    * call pause 5000
+
+    Given path 'inventory', 'items', sbItemId
+    When method GET
+    Then status 200
+    And match $.status.name == 'Awaiting pickup'
+
+    # Step 4: Verify transaction status is AWAITING_PICKUP
+    * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
+    * url baseUrlNew
+    Given path newPathStatus
+    And param apikey = key
+    And retry until response.status == 'AWAITING_PICKUP' && response.role == 'BORROWING-PICKUP'
+    When method GET
+    Then status 200
+
+    # Step 5: Check out item to patron
+    * url baseUrl
+    * def checkOutByBarcodeId = call uuid1
+    * def checkOutByBarcodeEntityRequest = read('classpath:volaris/mod-dcb/features/samples/check-out/check-out-by-barcode-entity-request.json')
+    * checkOutByBarcodeEntityRequest.itemBarcode = sbItemBarcode
+    * checkOutByBarcodeEntityRequest.userBarcode = patronBarcode31
+    * checkOutByBarcodeEntityRequest.servicePointId = servicePointId21
+    Given path 'circulation', 'check-out-by-barcode'
+    And request checkOutByBarcodeEntityRequest
+    When method POST
+    Then status 201
+    * call pause 5000
+
+    Given path 'inventory', 'items', sbItemId
+    When method GET
+    Then status 200
+    And match $.status.name == 'Checked out'
+
+    # Step 6: Verify transaction status is ITEM_CHECKED_OUT
+    * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
+    * url baseUrlNew
+    Given path newPathStatus
+    And param apikey = key
+    And retry until response.status == 'ITEM_CHECKED_OUT' && response.role == 'BORROWING-PICKUP'
+    When method GET
+    Then status 200
+
+    # Step 7: Check in item at home service point
+    * url baseUrl
+    * def intCheckInDate = call read('classpath:volaris/mod-dcb/features/util/get-time-now-function.js')
+    * def checkInRequest = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
+    * checkInRequest.servicePointId = servicePointId
+    * checkInRequest.itemBarcode = sbItemBarcode
+    Given path 'circulation', 'check-in-by-barcode'
+    And request checkInRequest
+    When method POST
+    Then status 200
+    * call pause 5000
+
+    Given path 'inventory', 'items', sbItemId
+    When method GET
+    Then status 200
+    And match $.status.name == 'Available'
+
+    # Step 8: Verify transaction status is CLOSED
+    * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
+    * url baseUrlNew
+    Given path newPathStatus
+    And param apikey = key
+    And retry until response.status == 'CLOSED' && response.role == 'BORROWING-PICKUP'
+    When method GET
+    Then status 200

--- a/mod-dcb/src/main/resources/volaris/mod-dcb/features/borrowing-pickup-self-borrowing.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/features/borrowing-pickup-self-borrowing.feature
@@ -20,7 +20,6 @@ Feature: Testing Borrowing-Pickup Self-Borrowing Flow
   @C773214
   Scenario: Create BORROWING-PICKUP transaction with selfBorrowing and verify full status lifecycle
 
-    # Precondition: create an item in Available status in inventory
     * def itemEntityRequest = read('classpath:volaris/mod-dcb/features/samples/item/item-entity-request.json')
     * itemEntityRequest.id = sbItemId
     * itemEntityRequest.barcode = sbItemBarcode
@@ -33,7 +32,6 @@ Feature: Testing Borrowing-Pickup Self-Borrowing Flow
     When method POST
     Then status 201
 
-    # Step 1: Create DCB transaction with BORROWING-PICKUP role and selfBorrowing=true
     * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
     * url baseUrlNew
     * def createDCBTransactionRequest = read('classpath:volaris/mod-dcb/features/samples/transaction/create-dcb-transaction.json')
@@ -58,7 +56,6 @@ Feature: Testing Borrowing-Pickup Self-Borrowing Flow
     And match $.item.barcode == sbItemBarcode
     And match $.patron.id == patronId31
 
-    # Step 2: Verify transaction status is CREATED
     * def orgPathStatus = '/transactions/' + sbTransactionId + '/status'
     * def newPathStatus = proxyCall == true ? proxyPath+orgPathStatus : orgPathStatus
     Given path newPathStatus
@@ -68,7 +65,6 @@ Feature: Testing Borrowing-Pickup Self-Borrowing Flow
     And match $.status == 'CREATED'
     And match $.role == 'BORROWING-PICKUP'
 
-    # Step 3: Check in item at pickup service point
     * url baseUrl
     * def intCheckInDate = call read('classpath:volaris/mod-dcb/features/util/get-time-now-function.js')
     * def checkInRequest = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
@@ -85,7 +81,6 @@ Feature: Testing Borrowing-Pickup Self-Borrowing Flow
     Then status 200
     And match $.status.name == 'Awaiting pickup'
 
-    # Step 4: Verify transaction status is AWAITING_PICKUP
     * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
     * url baseUrlNew
     Given path newPathStatus
@@ -94,7 +89,6 @@ Feature: Testing Borrowing-Pickup Self-Borrowing Flow
     When method GET
     Then status 200
 
-    # Step 5: Check out item to patron
     * url baseUrl
     * def checkOutByBarcodeId = call uuid1
     * def checkOutByBarcodeEntityRequest = read('classpath:volaris/mod-dcb/features/samples/check-out/check-out-by-barcode-entity-request.json')
@@ -112,7 +106,6 @@ Feature: Testing Borrowing-Pickup Self-Borrowing Flow
     Then status 200
     And match $.status.name == 'Checked out'
 
-    # Step 6: Verify transaction status is ITEM_CHECKED_OUT
     * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
     * url baseUrlNew
     Given path newPathStatus
@@ -121,7 +114,6 @@ Feature: Testing Borrowing-Pickup Self-Borrowing Flow
     When method GET
     Then status 200
 
-    # Step 7: Check in item at home service point
     * url baseUrl
     * def intCheckInDate = call read('classpath:volaris/mod-dcb/features/util/get-time-now-function.js')
     * def checkInRequest = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
@@ -138,7 +130,6 @@ Feature: Testing Borrowing-Pickup Self-Borrowing Flow
     Then status 200
     And match $.status.name == 'Available'
 
-    # Step 8: Verify transaction status is CLOSED
     * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
     * url baseUrlNew
     Given path newPathStatus

--- a/mod-dcb/src/main/resources/volaris/mod-dcb/mod-dcb-junit.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/mod-dcb-junit.feature
@@ -69,6 +69,7 @@ Feature: mod-dcb integration tests
       | 'inventory-storage.service-points.item.post'                      |
       | 'inventory-storage.service-points.item.put'                       |
       | 'inventory.instances.item.post'                                   |
+      | 'inventory.items.item.get'                                        |
       | 'inventory.items.item.post'                                       |
       | 'lost-item-fees-policies.item.post'                               |
       | 'overdue-fines-policies.item.post'                                |
@@ -94,6 +95,7 @@ Feature: mod-dcb integration tests
       | 'usergroups.item.post'                                            |
       | 'inventory-storage.service-points.item.post'                      |
       | 'inventory-storage.items.item.get'                                |
+      | 'inventory.items.item.get'                                        |
       | 'inventory.items.item.post'                                       |
       | 'inventory.instances.item.post'                                   |
       | 'inventory-storage.instance-types.item.post'                      |

--- a/mod-dcb/src/test/java/org/folio/ModDCBTest.java
+++ b/mod-dcb/src/test/java/org/folio/ModDCBTest.java
@@ -135,6 +135,11 @@ public class ModDCBTest extends TestBaseEureka {
     runFeatureTest("pickup-flow-update.feature");
   }
 
+  @Test
+  void testBorrowingPickupSelfBorrowing() {
+    runFeatureTest("borrowing-pickup-self-borrowing.feature");
+  }
+
   @BeforeAll
   public void setup() {
     runFeature("classpath:volaris/mod-dcb/mod-dcb-junit.feature");


### PR DESCRIPTION
## Purpose
Automate TestRail C773214 to verify that a BORROWING-PICKUP DCB transaction with selfBorrowing=true completes the full status lifecycle correctly.

## Approach
Create a real inventory item, POST the transaction with selfBorrowing=true, then drive it through check-in → check-out → check-in at home SP. Verify transaction status at each step via GET /transactions/{id}/status.  Item status checked via GET /inventory/items/{id} (real item, not virtual).  Added inventory.items.item.get permission to mod-dcb-junit.feature.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
[FAT-25957](https://folio-org.atlassian.net/browse/FAT-25957)

## Report
<img width="1536" height="797" alt="image" src="https://github.com/user-attachments/assets/5e7ce538-f63e-408c-80ea-61cd3e199c44" />

https://jenkins.ci.folio.org/job/folioTestingTools/job/runKarateTests/871/cucumber-html-reports/overview-features.html