### PR TITLE
MODCONSKC-107. Add retries in case when system user not yet created

### DIFF
--- a/edge-patron/src/main/resources/utils/tenant.feature
+++ b/edge-patron/src/main/resources/utils/tenant.feature
@@ -106,7 +106,7 @@ Feature: Tenant object in mod-consortia api tests
     * def result = call read('classpath:common-consortia/eureka/initData.feature@Login') { username: '#(universityUser.username)', password: '#(universityUser.password)', tenant: '#(uniTenant.name)'}
     Given path 'user-tenants'
     And param query = 'username=dummy_user'
-    And headers { 'Content-Type': 'application/json', 'x-okapi-token': '#(result.token)', 'x-okapi-tenant': '#(uniTenant.name)', 'Accept': 'application/json' }
+    And headers { 'Content-Type': 'application/json', 'x-okapi-token': '#(result.okapitoken)', 'x-okapi-tenant': '#(uniTenant.name)', 'Accept': 'application/json' }
     When method GET
     Then status 200
     And match response.totalRecords == 1

--- a/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/tenant.feature
+++ b/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/tenant.feature
@@ -245,8 +245,11 @@ Feature: Tenant object in mod-consortia api tests
     And match response.totalRecords == 0
 
     # post 'centralTenant' (isCentral = true)
+    # retry on transient 5xx — env-side system-user provisioning can lag briefly after entitlement
+    # (custom field needs system user be created before adding tenant)
     Given path 'consortia', consortiumId, 'tenants'
     And request { id: '#(centralTenant)', code: 'ABC', name: 'Central tenants name', isCentral: true }
+    And retry until responseStatus == 201
     When method POST
     Then status 201
     And match response == { id: '#(centralTenant)', code: 'ABC', name: 'Central tenants name', isCentral: true, isDeleted: false }
@@ -477,9 +480,12 @@ Feature: Tenant object in mod-consortia api tests
   # This is for registering 'universityTenant'
   Scenario: Do POST a non-central tenant (isCentral = false), GET list of tenant(s), check value of 'setupStatus'
     # post 'universityTenant' (isCentral = false)
+    # retry on transient 5xx — env-side system-user provisioning can lag briefly after entitlement
+    # (custom field needs system user be created before adding tenant)
     Given path 'consortia', consortiumId, 'tenants'
     And param adminUserId = consortiaAdmin.id
     And request { id: '#(universityTenant)', code: 'XYZ', name: 'University tenants name', isCentral: false }
+    And retry until responseStatus == 201
     When method POST
     Then status 201
     And match response == { id: '#(universityTenant)', code: 'XYZ', name: 'University tenants name', isCentral: false, isDeleted: false }
@@ -531,9 +537,12 @@ Feature: Tenant object in mod-consortia api tests
   # This is for registering 'collegeTenant'
   Scenario: Do POST a non-central tenant (isCentral = false), GET list of tenant(s), check value of 'setupStatus'
     # post 'collegeTenant' (isCentral = false)
+    # retry on transient 5xx — env-side system-user provisioning can lag briefly after entitlement
+    # (custom field needs system user be created before adding tenant)
     Given path 'consortia', consortiumId, 'tenants'
     And param adminUserId = consortiaAdmin.id
     And request { id: '#(collegeTenant)', code: 'QWE', name: 'College tenants name', isCentral: false }
+    And retry until responseStatus == 201
     When method POST
     Then status 201
     And match response == { id: '#(collegeTenant)', code: 'QWE', name: 'College tenants name', isCentral: false, isDeleted: false }
@@ -664,9 +673,12 @@ Feature: Tenant object in mod-consortia api tests
   Scenario: Re-Add soft deleted tenant.
     # 1.  re-post 'universityTenant' (isCentral = false) it should be re-enabled
     #     previous code or name can be used to re-add tenant (code 'XYZ' is already used by itself as soft deleted tenant)
+    # retry on transient 5xx — env-side system-user provisioning can lag briefly after entitlement
+    # (custom field needs system user be created before adding tenant)
     Given path 'consortia', consortiumId, 'tenants'
     And param adminUserId = consortiaAdmin.id
     And request { id: '#(universityTenant)', code: 'XYZ', name: 'University tenants name 2', isCentral: false }
+    And retry until responseStatus == 201
     When method POST
     Then status 201
     And match response == { id: '#(universityTenant)', code: 'XYZ', name: 'University tenants name 2', isCentral: false, isDeleted:false }

--- a/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/user-tenant-associations.feature
+++ b/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/user-tenant-associations.feature
@@ -525,10 +525,13 @@ Feature: Consortia User Tenant associations api tests
   Scenario: Verify that after re-adding soft deleted tenant, user tenant associations must be shown
     # 1.  re-post 'universityTenant' (isCentral = false) it should be re-enabled
     #     previous code or name can be used to re-add tenant (name 'University tenants name 2' is already used by itself as soft deleted tenant)
+    # retry on transient 5xx — env-side system-user provisioning can lag briefly after entitlement
+    # (custom field needs system user be created before adding tenant)
     Given path 'consortia', consortiumId, 'tenants'
     And param adminUserId = consortiaAdmin.id
     And headers {'x-okapi-tenant':'#(centralTenant)', 'x-okapi-token':'#(okapitoken)'}
     And request { id: '#(universityTenant)', code: 'FOL', name: 'University tenants name 2', isCentral: false }
+    And retry until responseStatus == 201
     When method POST
     Then status 201
     And match response == { id: '#(universityTenant)', code: 'FOL', name: 'University tenants name 2', isCentral: false, isDeleted:false }


### PR DESCRIPTION
## Purpose
In logs there is error when creating custom field
<img width="991" height="561" alt="image" src="https://github.com/user-attachments/assets/40856e18-c5d8-4c25-91ad-3ac3e75c7ba3" />
Here is code taht uses system user to create custom field:
https://github.com/folio-org/mod-consortia-keycloak/blob/master/src/main/java/org/folio/consortia/service/impl/TenantManagerImpl.java#L187

Also additionally change token to okapitoken to fix Vega's edge-patron https://jenkins.ci.folio.org/job/folioScheduledTesting/job/runNightlyKarateEurekaTests/795/testReport/junit/consortia/init-consortia/Prepare_data/

<img width="1031" height="338" alt="image" src="https://github.com/user-attachments/assets/b3e84668-5075-4382-99b9-6826b8aa38ea" />

## Approach
_How does this change fulfill the purpose?_

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
