### PR TITLE
FAT-26227 - Provide permissions to call `GET /contributor-name-types` and `GET /contributor-types` APIs

### DIFF
--- a/data-import/src/main/resources/folijet/data-import/data-import-junit.feature
+++ b/data-import/src/main/resources/folijet/data-import/data-import-junit.feature
@@ -35,6 +35,8 @@ Feature: mod-data-import integration tests
       | 'inventory.instances.collection.get'                                  |
       | 'inventory.instances.item.put'                                        |
       | 'inventory.instances.item.get'                                        |
+      | 'inventory-storage.contributor-name-types.collection.get'             |
+      | 'inventory-storage.contributor-types.collection.get'                  |
       | 'inventory-storage.instances.collection.get'                          |
       | 'inventory-storage.instance-types.item.post'                          |
       | 'inventory-storage.holdings-types.item.post'                          |


### PR DESCRIPTION
## Purpose
To provide "inventory-storage.contributor-name-types.collection.get", "inventory-storage.contributor-types.collection.get"
permissions required by `GET /contributor-name-types` and `GET /contributor-types` APIs in the "FAT-21038 Verify mapping of contributors from MARC 1xx/7xx fields (Personal/Corporate/Meeting names with relator terms and codes)" scenario.


## Learning
[FAT-26227](https://issues.folio.org/browse/FAT-26227)