### PR TITLE
[MODINVOICE-647] Delete invoice line and check next line number

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/features/delete-line-check-next-line-number.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/features/delete-line-check-next-line-number.feature
@@ -1,0 +1,58 @@
+# For MODINVOICE-647
+Feature: Delete line and check next line number
+
+  Background:
+    * print karate.info.scenarioName
+    * url baseUrl
+
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
+    * call variables
+
+
+  Scenario: Delete line and check next line number
+    * def fundId = call uuid
+    * def budgetId = call uuid
+    * def invoiceId = call uuid
+    * def invoiceLineId1 = call uuid
+    * def invoiceLineId2 = call uuid
+    * def invoiceLineId3 = call uuid
+
+    # 1. Create finances
+    * print "1. Create finances"
+    * configure headers = headersAdmin
+    * def v = call createFund { id: '#(fundId)' }
+    * def v = call createBudget { id: '#(budgetId)', allocated: 1000, fundId: '#(fundId)', status: 'Active' }
+
+    # 2. Create an invoice
+    * print "2. Create an invoice"
+    * configure headers = headersUser
+    * def v = call createInvoice { id: '#(invoiceId)' }
+
+    # 3. Add two invoice lines
+    * print "3. Add two invoice lines"
+    * def v = call createInvoiceLine { invoiceLineId: '#(invoiceLineId1)', invoiceId: '#(invoiceId)', fundId: '#(fundId)', total: 10 }
+    * def v = call createInvoiceLine { invoiceLineId: '#(invoiceLineId2)', invoiceId: '#(invoiceId)', fundId: '#(fundId)', total: 10 }
+
+    # 4. Delete invoice line 2
+    * print "4. Delete invoice line 2"
+    Given path 'invoice/invoice-lines', invoiceLineId2
+    When method DELETE
+    Then status 204
+
+    # 5. Create invoice line 3
+    * print "5. Create invoice line 3"
+    * def v = call createInvoiceLine { invoiceLineId: '#(invoiceLineId3)', invoiceId: '#(invoiceId)', fundId: '#(fundId)', total: 10 }
+
+    # 6. Check invoice line 3 number
+    * print "6. Check invoice line 3 number"
+    Given path 'invoice/invoice-lines', invoiceLineId3
+    When method GET
+    Then status 200
+    And match $.invoiceLineNumber == '3'

--- a/acquisitions/src/main/resources/thunderjet/mod-invoice/invoice.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-invoice/invoice.feature
@@ -80,6 +80,9 @@ Feature: mod-invoice integration tests
   Scenario: Checking that voucher lines are created taking into account the expense classes
     * call read('features/create-voucher-lines-honor-expense-classes.feature')
 
+  Scenario: Delete line and check next line number
+    * call read('features/delete-line-check-next-line-number.feature')
+
   Scenario: Edit subscription dates after invoice is paid
     * call read('features/edit-subscription-dates-after-invoice-paid.feature')
 

--- a/acquisitions/src/test/java/org/folio/InvoicesApiTest.java
+++ b/acquisitions/src/test/java/org/folio/InvoicesApiTest.java
@@ -56,7 +56,8 @@ public class InvoicesApiTest extends TestBaseEureka implements AcquisitionsTest 
     FEATURE_31("should_populate_vendor_address_on_get_voucher_by_id", true),
     FEATURE_32("voucher-numbers", true),
     FEATURE_33("voucher-with-lines-using-same-external-account", true),
-    FEATURE_34("fund-code-auto-populate-invoice-lines", true);
+    FEATURE_34("fund-code-auto-populate-invoice-lines", true),
+    FEATURE_35("delete-line-check-next-line-number", true);
 
     private final String fileName;
     private final boolean isEnabled;
@@ -301,5 +302,11 @@ public class InvoicesApiTest extends TestBaseEureka implements AcquisitionsTest 
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void fundCodeAutoPopulateInvoiceLines() {
     runFeatureTest(Feature.FEATURE_34.getFileName());
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
+  void deleteLineCheckNextLineNumber() {
+    runFeatureTest(Feature.FEATURE_35.getFileName());
   }
 }


### PR DESCRIPTION
## Purpose
[MODINVOICE-647](https://folio-org.atlassian.net/browse/MODINVOICE-647) - Invoice line number is reused after deletion

## Approach
Added a new test matching the ticket description.

## Related PRs
- [acq-models 1](https://github.com/folio-org/acq-models/pull/567), [acq-models 2](https://github.com/folio-org/acq-models/pull/568)
- [mod-invoice-storage](https://github.com/folio-org/mod-invoice-storage/pull/259)
- [mod-orders-storage](https://github.com/folio-org/mod-orders-storage/pull/623)
- [mod-invoice](https://github.com/folio-org/mod-invoice/pull/622)
- [mod-orders](https://github.com/folio-org/mod-orders/pull/1307)
