### PR TITLE
[FAT-21199] Move existing test to extended

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/invoice-encumbrance-update-without-acquisition-unit.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/invoice-encumbrance-update-without-acquisition-unit.feature
@@ -1,4 +1,4 @@
-# For MODORDERS-1073
+# For MODORDERS-1073, https://foliotest.testrail.io/index.php?/cases/view/451627
 Feature: Invoice encumbrance update without acquisition unit
 
   Background:

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/invoice-encumbrance-update-without-acquisition-unit.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/invoice-encumbrance-update-without-acquisition-unit.feature
@@ -16,6 +16,8 @@ Feature: Invoice encumbrance update without acquisition unit
     * callonce variables
 
 
+  @C451627
+  @Positive
   Scenario: Invoice encumbrance update without acquisition unit
     * def fundId = call uuid
     * def budgetId = call uuid

--- a/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
+++ b/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
@@ -51,7 +51,6 @@ public class CrossModulesApiTest extends TestBaseEureka implements AcquisitionsT
     FEATURE_25("create-order-and-invoice-with-odd-penny", true),
     FEATURE_26("create-order-with-invoice-that-has-enough-money", true),
     FEATURE_27("delete-encumbrance", true),
-    FEATURE_28("invoice-encumbrance-update-without-acquisition-unit", true),
     FEATURE_29("ledger-fiscal-year-rollover", true),
     FEATURE_30("ledger-fiscal-year-rollover-cash-balance", true),
     FEATURE_31("link-invoice-line-to-po-line", true),
@@ -285,12 +284,6 @@ public class CrossModulesApiTest extends TestBaseEureka implements AcquisitionsT
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void deleteEncumbrance() {
     runFeatureTest(Feature.FEATURE_27.getFileName());
-  }
-
-  @Test
-  @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void invoiceEncumbranceUpdateWithoutAcquisitionUnit() {
-    runFeatureTest(Feature.FEATURE_28.getFileName());
   }
 
   @Test

--- a/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
+++ b/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
@@ -51,37 +51,37 @@ public class CrossModulesApiTest extends TestBaseEureka implements AcquisitionsT
     FEATURE_25("create-order-and-invoice-with-odd-penny", true),
     FEATURE_26("create-order-with-invoice-that-has-enough-money", true),
     FEATURE_27("delete-encumbrance", true),
-    FEATURE_29("ledger-fiscal-year-rollover", true),
-    FEATURE_30("ledger-fiscal-year-rollover-cash-balance", true),
-    FEATURE_31("link-invoice-line-to-po-line", true),
-    FEATURE_32("MODFISTO-270-delete-planned-budget-without-transactions", true),
-    FEATURE_33("moving_encumbered_value_to_different_budget", true),
-    FEATURE_34("moving_expended_value_to_newly_created_encumbrance", true),
-    FEATURE_35("open-approve-and-pay-order-with-50-lines", true),
-    FEATURE_36("open-order-after-approving-invoice", true),
-    FEATURE_37("order-invoice-relation", true),
-    FEATURE_38("order-invoice-relation-can-be-changed", true),
-    FEATURE_39("order-invoice-relation-can-be-deleted", true),
-    FEATURE_40("order-invoice-relation-must-be-deleted-if-invoice-deleted", true),
-    FEATURE_41("partial-rollover", true),
-    FEATURE_42("pay-invoice-and-delete-piece", true),
-    FEATURE_43("pay-invoice-with-new-expense-class", true),
-    FEATURE_44("pay-invoice-without-order-acq-unit-permission", true),
-    FEATURE_45("pending-payment-update-after-encumbrance-deletion", true),
-    FEATURE_46("remove-fund-distribution-after-rollover-when-re-encumber-false", true),
-    FEATURE_47("remove_linked_invoice_lines_fund_distribution_encumbrance_reference", true),
-    FEATURE_48("rollover-and-pay-invoice-using-past-fiscal-year", true),
-    FEATURE_49("rollover-with-closed-order", true),
-    FEATURE_50("rollover-with-no-settings", true),
-    FEATURE_51("rollover-with-pending-order", true),
-    FEATURE_52("unopen-approve-invoice-reopen", true),
-    FEATURE_53("unopen-order-and-add-addition-pol-and-check-encumbrances", true),
-    FEATURE_54("unopen-order-simple-case", true),
-    FEATURE_55("update-encumbrance-links-with-fiscal-year", true),
-    FEATURE_56("update_fund_in_poline_when_invoice_approved", true),
-    FEATURE_57("rollover-multi-ledger", true),
-    FEATURE_58("rollover-many-orders-and-lines", false),
-    FEATURE_59("approve-invoice-with-different-fund-than-order", false);
+    FEATURE_28("ledger-fiscal-year-rollover", true),
+    FEATURE_29("ledger-fiscal-year-rollover-cash-balance", true),
+    FEATURE_30("link-invoice-line-to-po-line", true),
+    FEATURE_31("MODFISTO-270-delete-planned-budget-without-transactions", true),
+    FEATURE_32("moving_encumbered_value_to_different_budget", true),
+    FEATURE_33("moving_expended_value_to_newly_created_encumbrance", true),
+    FEATURE_34("open-approve-and-pay-order-with-50-lines", true),
+    FEATURE_35("open-order-after-approving-invoice", true),
+    FEATURE_36("order-invoice-relation", true),
+    FEATURE_37("order-invoice-relation-can-be-changed", true),
+    FEATURE_38("order-invoice-relation-can-be-deleted", true),
+    FEATURE_39("order-invoice-relation-must-be-deleted-if-invoice-deleted", true),
+    FEATURE_40("partial-rollover", true),
+    FEATURE_41("pay-invoice-and-delete-piece", true),
+    FEATURE_42("pay-invoice-with-new-expense-class", true),
+    FEATURE_43("pay-invoice-without-order-acq-unit-permission", true),
+    FEATURE_44("pending-payment-update-after-encumbrance-deletion", true),
+    FEATURE_45("remove-fund-distribution-after-rollover-when-re-encumber-false", true),
+    FEATURE_46("remove_linked_invoice_lines_fund_distribution_encumbrance_reference", true),
+    FEATURE_47("rollover-and-pay-invoice-using-past-fiscal-year", true),
+    FEATURE_48("rollover-with-closed-order", true),
+    FEATURE_49("rollover-with-no-settings", true),
+    FEATURE_50("rollover-with-pending-order", true),
+    FEATURE_51("unopen-approve-invoice-reopen", true),
+    FEATURE_52("unopen-order-and-add-addition-pol-and-check-encumbrances", true),
+    FEATURE_53("unopen-order-simple-case", true),
+    FEATURE_54("update-encumbrance-links-with-fiscal-year", true),
+    FEATURE_55("update_fund_in_poline_when_invoice_approved", true),
+    FEATURE_56("rollover-multi-ledger", true),
+    FEATURE_57("rollover-many-orders-and-lines", false),
+    FEATURE_58("approve-invoice-with-different-fund-than-order", false);
 
     private final String fileName;
     private final boolean isEnabled;
@@ -289,175 +289,175 @@ public class CrossModulesApiTest extends TestBaseEureka implements AcquisitionsT
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void ledgerRollover() {
-    runFeatureTest(Feature.FEATURE_29.getFileName());
+    runFeatureTest(Feature.FEATURE_28.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void ledgerFiscalYearRolloverCashBalance() {
-    runFeatureTest(Feature.FEATURE_30.getFileName());
+    runFeatureTest(Feature.FEATURE_29.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void linkInvoiceLineToPoLine() {
-    runFeatureTest(Feature.FEATURE_31.getFileName());
+    runFeatureTest(Feature.FEATURE_30.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void deletePlannedBudgetWithoutTransactions() {
-    runFeatureTest(Feature.FEATURE_32.getFileName());
+    runFeatureTest(Feature.FEATURE_31.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void movingEncumberedValueToDifferentBudget() {
-    runFeatureTest(Feature.FEATURE_33.getFileName());
+    runFeatureTest(Feature.FEATURE_32.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void movingExpendedValueToNewlyCreatedEncumbrance() {
-    runFeatureTest(Feature.FEATURE_34.getFileName());
+    runFeatureTest(Feature.FEATURE_33.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void openApproveAndPayOrderWith50Lines() {
-    runFeatureTest(Feature.FEATURE_35.getFileName());
+    runFeatureTest(Feature.FEATURE_34.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void openOrderAfterApprovingInvoice() {
-    runFeatureTest(Feature.FEATURE_36.getFileName());
+    runFeatureTest(Feature.FEATURE_35.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void orderInvoiceRelation() {
-    runFeatureTest(Feature.FEATURE_37.getFileName());
+    runFeatureTest(Feature.FEATURE_36.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void orderInvoiceRelationCanBeChanged() {
-    runFeatureTest(Feature.FEATURE_38.getFileName());
+    runFeatureTest(Feature.FEATURE_37.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void orderInvoiceRelationCanBeDeleted() {
-    runFeatureTest(Feature.FEATURE_39.getFileName());
+    runFeatureTest(Feature.FEATURE_38.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void order_invoice_relation_must_be_deleted_if_invoice_deleted() {
-    runFeatureTest(Feature.FEATURE_40.getFileName());
+    runFeatureTest(Feature.FEATURE_39.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void partialRollover() {
-    runFeatureTest(Feature.FEATURE_41.getFileName());
+    runFeatureTest(Feature.FEATURE_40.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void payInvoiceAndDeletePiece() {
-    runFeatureTest(Feature.FEATURE_42.getFileName());
+    runFeatureTest(Feature.FEATURE_41.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void payInvoiceWithNewExpenseClass() {
-    runFeatureTest(Feature.FEATURE_43.getFileName());
+    runFeatureTest(Feature.FEATURE_42.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void payInvoiceWithoutOrderAcqUnitPermission() {
-    runFeatureTest(Feature.FEATURE_44.getFileName());
+    runFeatureTest(Feature.FEATURE_43.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void pendingPaymentUpdateAfterEncumbranceDeletion() {
-    runFeatureTest(Feature.FEATURE_45.getFileName());
+    runFeatureTest(Feature.FEATURE_44.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void removeFundDistributionAfterRolloverWhenReEncumberFalse() {
-    runFeatureTest(Feature.FEATURE_46.getFileName());
+    runFeatureTest(Feature.FEATURE_45.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void removeLinkedInvoiceLinesFundDistributionEncumbranceReference() {
-    runFeatureTest(Feature.FEATURE_47.getFileName());
+    runFeatureTest(Feature.FEATURE_46.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void rolloverAndPayInvoiceUsingPastFiscalYear() {
-    runFeatureTest(Feature.FEATURE_48.getFileName());
+    runFeatureTest(Feature.FEATURE_47.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void rolloverWithClosedOrder() {
-    runFeatureTest(Feature.FEATURE_49.getFileName());
+    runFeatureTest(Feature.FEATURE_48.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void rolloverWithNoSettings() {
-    runFeatureTest(Feature.FEATURE_50.getFileName());
+    runFeatureTest(Feature.FEATURE_49.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void rolloverWithPendingOrder() {
-    runFeatureTest(Feature.FEATURE_51.getFileName());
+    runFeatureTest(Feature.FEATURE_50.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void unopenApproveInvoiceReopen() {
-    runFeatureTest(Feature.FEATURE_52.getFileName());
+    runFeatureTest(Feature.FEATURE_51.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void unopen_order_and_add_addition_pol_and_check_encumbrances() {
-    runFeatureTest(Feature.FEATURE_53.getFileName());
+    runFeatureTest(Feature.FEATURE_52.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void unopen_order_simple_case() {
-    runFeatureTest(Feature.FEATURE_54.getFileName());
+    runFeatureTest(Feature.FEATURE_53.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void updateEncumbranceLinksWithFiscalYear() {
-    runFeatureTest(Feature.FEATURE_55.getFileName());
+    runFeatureTest(Feature.FEATURE_54.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void updateFundInPoLineWhenInvoiceApproved() {
-    runFeatureTest(Feature.FEATURE_56.getFileName());
+    runFeatureTest(Feature.FEATURE_55.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void rolloverMultiLedger() {
-    runFeatureTest(Feature.FEATURE_57.getFileName());
+    runFeatureTest(Feature.FEATURE_56.getFileName());
   }
 
   @Test
@@ -465,13 +465,13 @@ public class CrossModulesApiTest extends TestBaseEureka implements AcquisitionsT
   @Disabled
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void rolloverManyOrdersAndLines() {
-    runFeatureTest(Feature.FEATURE_58.getFileName());
+    runFeatureTest(Feature.FEATURE_57.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void approveInvoiceWithDifferentFundThanOrder() {
-    runFeatureTest(Feature.FEATURE_59.getFileName());
+    runFeatureTest(Feature.FEATURE_58.getFileName());
   }
 
 }

--- a/acquisitions/src/test/java/org/folio/CrossModulesExtendedApiTest.java
+++ b/acquisitions/src/test/java/org/folio/CrossModulesExtendedApiTest.java
@@ -52,7 +52,8 @@ public class CrossModulesExtendedApiTest extends TestBaseEureka implements Acqui
     FEATURE_24("open-order-when-balance-close-to-encumbered-available", true),
     FEATURE_25("expense-class-percent-expended-when-budget-over-expended", true),
     FEATURE_26("rollover-settings-no-encumbrances", true),
-    FEATURE_27("unreleased-encumbrance-rolled-over-to-next-fiscal-year", true);
+    FEATURE_27("unreleased-encumbrance-rolled-over-to-next-fiscal-year", true),
+    FEATURE_28("invoice-encumbrance-update-without-acquisition-unit", true);
 
     private final String fileName;
     private final boolean isEnabled;
@@ -287,4 +288,12 @@ public class CrossModulesExtendedApiTest extends TestBaseEureka implements Acqui
   void unreleasedEncumbranceRolledOverToNextFiscalYear() {
     runFeatureTest(Feature.FEATURE_27.getFileName());
   }
+
+  @Test
+  @DisplayName("(Thunderjet) (C451627) Invoice encumbrance update without acquisition unit")
+  @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
+  void invoiceEncumbranceUpdateWithoutAcquisitionUnit() {
+    runFeatureTest(Feature.FEATURE_28.getFileName());
+  }
+
 }


### PR DESCRIPTION
## Purpose
[FAT-21199](https://folio-org.atlassian.net/browse/FAT-21199) - Thunderjet - Create Karate test - Link to encumbrance is removed from Invoice with Acq unit when Fund distribution is deleted from related POL

## Approach
Moved matching existing test to extended, with the Testrail tag.

### TODOS and Open Questions
Avoid numbering tests so we can remove them without leaving gaps or having to renumber everything.
