### PR TITLE
FAT-25972: Add borrower service point hold shelf feature test

### DIFF
--- a/mod-dcb/src/main/resources/volaris/mod-dcb/features/borrower-service-point-hold-shelf.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/features/borrower-service-point-hold-shelf.feature
@@ -1,0 +1,63 @@
+Feature: Borrower Transaction Service Point Hold Shelf
+
+  Background:
+    * url baseUrl
+    * def proxyCall = karate.get('proxyCall', false)
+    * def user = proxyCall == true ? testUser : testAdmin
+    * print 'user  is', user
+    * callonce login user
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'x-okapi-tenant': '#(testTenant)', 'Accept': 'application/json'  }
+    * def key = ''
+    * configure headers = headersUser
+    * callonce variables
+    * def startDate = callonce getCurrentUtcDate
+    * configure retry = { count: 5, interval: 1000 }
+    * def txnId = '648504'
+    * def itemTitle648504 = 'DCB Item Title C648504'
+    * def itemBarcode648504 = '648504bc'
+    * def pickupSpName = 'borrower_sp_648504'
+    * def pickupLibCode = 'lib648504'
+
+  @C648504
+  Scenario: Create BORROWER DCB transaction and verify DCB service point is created with 10-day hold shelf expiry period
+
+    # Step 1: Create DCB transaction with role = BORROWER using existing patron
+    * def baseUrlNew = proxyCall == true ? edgeUrl : baseUrl
+    * url baseUrlNew
+    * def createReq = read('classpath:volaris/mod-dcb/features/samples/transaction/create-dcb-transaction.json')
+    * createReq.item.title = itemTitle648504
+    * createReq.item.barcode = itemBarcode648504
+    * createReq.item.materialType = materialTypeName
+    * createReq.patron.id = patronId31
+    * createReq.patron.barcode = patronBarcode31
+    * createReq.pickup.servicePointName = pickupSpName
+    * createReq.pickup.libraryCode = pickupLibCode
+    * createReq.role = 'BORROWER'
+
+    * def orgPath = '/transactions/' + txnId
+    * def newPath = proxyCall == true ? proxyPath + orgPath : orgPath
+
+    Given path newPath
+    And param apikey = key
+    And request createReq
+    When method POST
+    Then status 201
+    And match $.status == 'CREATED'
+    And match $.item.barcode == itemBarcode648504
+    And match $.patron.id == patronId31
+
+    # Step 2: Verify DCB service point was auto-created with name "DCB_<libraryCode>_<servicePointName>"
+    * def dcbSpName = 'DCB_' + pickupLibCode + '_' + pickupSpName
+    * url baseUrl
+
+    Given path 'service-points'
+    And param query = '(name= ' + dcbSpName + ')'
+    When method GET
+    Then status 200
+    And match $.totalRecords == 1
+    And match $.servicepoints[0].name == dcbSpName
+
+    # Step 3: Verify "Hold shelf expiration period" is set to 10 days by default
+    And match $.servicepoints[0].holdShelfExpiryPeriod.duration == 10
+    And match $.servicepoints[0].holdShelfExpiryPeriod.intervalId == 'Days'

--- a/mod-dcb/src/test/java/org/folio/ModDCBTest.java
+++ b/mod-dcb/src/test/java/org/folio/ModDCBTest.java
@@ -160,6 +160,11 @@ public class ModDCBTest extends TestBaseEureka {
     runFeatureTest("lending-flow-various-statuses.feature");
   }
 
+  @Test
+  void testBorrowerServicePointHoldShelf() {
+    runFeatureTest("borrower-service-point-hold-shelf.feature");
+  }
+
   @BeforeAll
   public void setup() {
     runFeature("classpath:volaris/mod-dcb/mod-dcb-junit.feature");


### PR DESCRIPTION
## Purpose
Implement TestRail case C648504 as a Karate integration test for the mod-dcb FOLIO module. When a DCB BORROWER transaction is created with a non-existing pickup service point name and library code, DCB auto-creates a service point named DCB_<libraryCode>_<servicePointName> with a 10-day hold shelf expiry period.

## Approach
   1. Created borrower-service-point-hold-shelf.feature — mirrors the existing lender-service-point-hold-shelf.feature (C430227) but for the BORROWER role (no inventory item
  pre-creation needed; uses pre-existing patron patronId31/patronBarcode31)
   2. Registered the feature in ModDCBTest.java (appended only)
   3. No changes to variables.feature (IDs are feature-local) or mod-dcb-junit.feature (all required permissions already present)

### TODOS and Open Questions
- [x] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
[FAT-25972](https://folio-org.atlassian.net/browse/FAT-25972)

## Report
<img width="1578" height="759" alt="image" src="https://github.com/user-attachments/assets/c675e77d-8e61-4930-a476-2806d6ed0c57" />

https://jenkins.ci.folio.org/job/folioTestingTools/job/runKarateTests/922/cucumber-html-reports/overview-features.html