### PR TITLE
FAT-26305: Fix tenant conflict between DataImportApiTest and DataImportExtendedApiTest

### DIFF
--- a/data-import/src/test/java/org/folio/DataImportApiTest.java
+++ b/data-import/src/test/java/org/folio/DataImportApiTest.java
@@ -57,11 +57,14 @@ class DataImportApiTest extends TestBaseEureka {
     @AfterAll
     public void teardown() {
         if (shouldCreateTenant()) {
-            System.clearProperty(TEST_TENANT.getValue());
-            System.clearProperty(TEST_TENANT_ID.getValue());
-            feature("classpath:common/eureka/destroy-data.feature")
-                    .reportDir(timestampedReportDir())
-                    .run();
+            try {
+                feature("classpath:common/eureka/destroy-data.feature")
+                        .reportDir(timestampedReportDir())
+                        .run();
+            } finally {
+                System.clearProperty(TEST_TENANT.getValue());
+                System.clearProperty(TEST_TENANT_ID.getValue());
+            }
         }
     }
 }

--- a/data-import/src/test/java/org/folio/DataImportExtendedApiTest.java
+++ b/data-import/src/test/java/org/folio/DataImportExtendedApiTest.java
@@ -38,11 +38,14 @@ public class DataImportExtendedApiTest extends TestBaseEureka {
     @AfterAll
     public void teardown() {
         if (shouldCreateTenant()) {
-            System.clearProperty(TEST_TENANT.getValue());
-            System.clearProperty(TEST_TENANT_ID.getValue());
-            feature("classpath:common/eureka/destroy-data.feature")
-                    .reportDir(timestampedReportDir())
-                    .run();
+            try {
+                feature("classpath:common/eureka/destroy-data.feature")
+                        .reportDir(timestampedReportDir())
+                        .run();
+            } finally {
+                System.clearProperty(TEST_TENANT.getValue());
+                System.clearProperty(TEST_TENANT_ID.getValue());
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose
DataImportApiTest and DataImportExtendedApiTest share the same tenant configuration, causing test failures when run sequentially. The first test deletes the tenant in its @AfterAll cleanup phase, causing the second test to fail because it attempts to reuse the already-deleted tenant.

## Approach
Change in approach using finally.

### Learning
[FAT-26305](https://folio-org.atlassian.net/browse/FAT-26305)
