### PR TITLE
FAT-25969: Enhance lending flow tests with item status transitions and new transaction completion feature

### DIFF
--- a/mod-dcb/src/main/resources/volaris/mod-dcb/features/lending-flow-various-statuses.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/features/lending-flow-various-statuses.feature
@@ -14,6 +14,7 @@ Feature: Lending transactions for items in various statuses
     * def startDate = callonce getCurrentUtcDate
     * configure retry = { count: 5, interval: 1000 }
 
+    # Items — each starts in Available; will be transitioned to the required status via valid FOLIO flows
     * def itemId630_1 = 'f6304901-4f30-4901-8abc-000000000001'
     * def itemBarcode630_1 = 'FAT-630490-I01'
     * def itemId630_2 = 'f6304902-4f30-4901-8abc-000000000002'
@@ -25,6 +26,11 @@ Feature: Lending transactions for items in various statuses
     * def itemId630_5 = 'f6304905-4f30-4901-8abc-000000000005'
     * def itemBarcode630_5 = 'FAT-630490-I05'
 
+    # Local FOLIO requester/borrower — a real user needed for creating circulation requests
+    * def localUserId630 = 'f6304930-4f30-4901-8abc-000000000030'
+    * def localUserBarcode630 = 'FAT-630490-U30'
+
+    # DCB patron IDs — non-existing users; DCB will create shadow patrons for these
     * def patronId630_1 = 'f6304911-4f30-4901-8abc-000000000001'
     * def patronBarcode630_1 = 'FAT-630490-P01'
     * def patronId630_2 = 'f6304912-4f30-4901-8abc-000000000002'
@@ -42,67 +48,205 @@ Feature: Lending transactions for items in various statuses
     * def txnId630_4 = '630490-04'
     * def txnId630_5 = '630490-05'
 
+    # Static ID for the checkout request body (must be unique per tenant run; ephemeral tenants prevent collisions)
+    * def checkOutByBarcodeId630 = 'f6304920-4f30-4901-8abc-000000000020'
+
+    # Address type for delivery request (must be created at runtime; not pre-seeded in ephemeral tenants)
+    * def addressTypeId630 = 'f6304940-4f30-4901-8abc-000000000040'
+
   @C630490
   Scenario: Create LENDER transactions for items in various statuses and verify full lending flow
-    # Precondition #1: item in "Checked out" status (check out an item in Available status)
+    # Create 5 items in Available status
     * def item1 = read('classpath:volaris/mod-dcb/features/samples/item/item-entity-request.json')
     * item1.id = itemId630_1
     * item1.barcode = itemBarcode630_1
+    * item1.holdingsRecordId = holdingId
     * item1.materialType.id = intMaterialTypeId
-    * item1.status.name = 'Checked out'
+    * item1.status.name = 'Available'
     Given path 'inventory', 'items'
     And request item1
     When method POST
     Then status 201
 
-    # Precondition #2: item in "Paged" status (create a Page request for an Available item)
     * def item2 = read('classpath:volaris/mod-dcb/features/samples/item/item-entity-request.json')
     * item2.id = itemId630_2
     * item2.barcode = itemBarcode630_2
+    * item2.holdingsRecordId = holdingId
     * item2.materialType.id = intMaterialTypeId
-    * item2.status.name = 'Paged'
+    * item2.status.name = 'Available'
     Given path 'inventory', 'items'
     And request item2
     When method POST
     Then status 201
 
-    # Precondition #3: item in "In transit" status (check in an Available item at a non-home service point)
     * def item3 = read('classpath:volaris/mod-dcb/features/samples/item/item-entity-request.json')
     * item3.id = itemId630_3
     * item3.barcode = itemBarcode630_3
+    * item3.holdingsRecordId = holdingId
     * item3.materialType.id = intMaterialTypeId
-    * item3.status.name = 'In transit'
+    * item3.status.name = 'Available'
     Given path 'inventory', 'items'
     And request item3
     When method POST
     Then status 201
 
-    # Precondition #4: item in "Awaiting pickup" status (Page request + check in at pickup service point)
     * def item4 = read('classpath:volaris/mod-dcb/features/samples/item/item-entity-request.json')
     * item4.id = itemId630_4
     * item4.barcode = itemBarcode630_4
+    * item4.holdingsRecordId = holdingId
     * item4.materialType.id = intMaterialTypeId
-    * item4.status.name = 'Awaiting pickup'
+    * item4.status.name = 'Available'
     Given path 'inventory', 'items'
     And request item4
     When method POST
     Then status 201
 
-    # Precondition #5: item in "Awaiting delivery" status (Page delivery request + check in at home service point)
     * def item5 = read('classpath:volaris/mod-dcb/features/samples/item/item-entity-request.json')
     * item5.id = itemId630_5
     * item5.barcode = itemBarcode630_5
+    * item5.holdingsRecordId = holdingId
     * item5.materialType.id = intMaterialTypeId
-    * item5.status.name = 'Awaiting delivery'
+    * item5.status.name = 'Available'
     Given path 'inventory', 'items'
     And request item5
     When method POST
     Then status 201
 
+    # Create address type at runtime (not pre-seeded in ephemeral tenants)
+    Given path 'addresstypes'
+    And request { id: '#(addressTypeId630)', addressType: 'DCB Home', desc: 'Address type for DCB delivery test' }
+    When method POST
+    Then status 201
+
+    # Create a local FOLIO user needed for checkout and circulation requests
+    * def localUser630 = read('classpath:volaris/mod-dcb/features/samples/user/user-entity-request.json')
+    * localUser630.id = localUserId630
+    * localUser630.barcode = localUserBarcode630
+    * localUser630.patronGroup = patronGroupId
+    * localUser630.personal.addresses = [{ addressLine1: '123 Main St', addressTypeId: addressTypeId630, primaryAddress: true }]
+    Given path 'users'
+    And request localUser630
+    When method POST
+    Then status 201
+
+    # Precondition #1: item in "Checked out" status — check out item1
+    * def intLoanDate = '2021-10-27T13:25:46.000Z'
+    * def checkOutReq1 = read('classpath:volaris/mod-dcb/features/samples/check-out/check-out-by-barcode-entity-request.json')
+    * checkOutReq1.id = checkOutByBarcodeId630
+    * checkOutReq1.itemBarcode = itemBarcode630_1
+    * checkOutReq1.userBarcode = localUserBarcode630
+    * checkOutReq1.servicePointId = servicePointId
+    * checkOutReq1.loanDate = intLoanDate
+    Given path 'circulation', 'check-out-by-barcode'
+    And request checkOutReq1
+    When method POST
+    Then status 201
+
+    Given path 'inventory', 'items', itemId630_1
+    When method GET
+    Then status 200
+    And match $.status.name == 'Checked out'
+
+    # Precondition #2: item in "Paged" status — create a Page request for item2
+    # Use servicePointId21 as pickup SP so DCB's own request (pickup = servicePointId)
+    # can be distinguished; this request will be cancelled in step 6.
+    Given path 'circulation', 'requests'
+    And request
+      """
+      {
+        "requestType": "Page",
+        "fulfillmentPreference": "Hold Shelf",
+        "requestLevel": "Item",
+        "requestDate": "2021-10-27T15:51:02Z",
+        "itemId": "#(itemId630_2)",
+        "holdingsRecordId": "#(holdingId)",
+        "instanceId": "#(instanceId)",
+        "requesterId": "#(localUserId630)",
+        "pickupServicePointId": "#(servicePointId21)"
+      }
+      """
+    When method POST
+    Then status 201
+    * def preconReqId2 = $.id
+
+    Given path 'inventory', 'items', itemId630_2
+    When method GET
+    Then status 200
+    And match $.status.name == 'Paged'
+
+    # Precondition #3: item in "In transit" status — check in at non-home SP
     * def intCheckInDate = call read('classpath:volaris/mod-dcb/features/util/get-time-now-function.js')
-    * def updateToAwaitingPickup = read('classpath:volaris/mod-dcb/features/samples/transaction/update-dcb-transaction-to-awaiting-pickup.json')
-    * def updateToItemCheckOut = read('classpath:volaris/mod-dcb/features/samples/transaction/update-dcb-transaction-to-item-check-out.json')
-    * def updateToItemCheckIn = read('classpath:volaris/mod-dcb/features/samples/transaction/update-dcb-transaction-to-item-check-in.json')
+    * def checkInReq3 = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
+    * checkInReq3.servicePointId = servicePointId11
+    * checkInReq3.itemBarcode = itemBarcode630_3
+    Given path 'circulation', 'check-in-by-barcode'
+    And request checkInReq3
+    When method POST
+    Then status 200
+    And match $.item.status.name == 'In transit'
+
+    # Precondition #4: item in "Awaiting pickup" status
+    # Create a Page request for item4 (Hold Shelf)
+    Given path 'circulation', 'requests'
+    And request
+      """
+      {
+        "requestType": "Page",
+        "fulfillmentPreference": "Hold Shelf",
+        "requestLevel": "Item",
+        "requestDate": "2021-10-27T15:51:02Z",
+        "itemId": "#(itemId630_4)",
+        "holdingsRecordId": "#(holdingId)",
+        "instanceId": "#(instanceId)",
+        "requesterId": "#(localUserId630)",
+        "pickupServicePointId": "#(servicePointId11)"
+      }
+      """
+    When method POST
+    Then status 201
+    * def preconReqId4 = $.id
+
+    # Check in at the pickup service point so item becomes Awaiting pickup
+    * def checkInReq4pre = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
+    * checkInReq4pre.servicePointId = servicePointId11
+    * checkInReq4pre.itemBarcode = itemBarcode630_4
+    Given path 'circulation', 'check-in-by-barcode'
+    And request checkInReq4pre
+    When method POST
+    Then status 200
+    And match $.item.status.name == 'Awaiting pickup'
+
+    # Precondition #5: item in "Awaiting delivery" status
+    # Create a Page delivery request for item5
+    Given path 'circulation', 'requests'
+    And request
+      """
+      {
+        "requestType": "Page",
+        "fulfillmentPreference": "Delivery",
+        "requestLevel": "Item",
+        "requestDate": "2021-10-27T15:51:02Z",
+        "itemId": "#(itemId630_5)",
+        "holdingsRecordId": "#(holdingId)",
+        "instanceId": "#(instanceId)",
+        "requesterId": "#(localUserId630)",
+        "deliveryAddressTypeId": "#(addressTypeId630)",
+        "pickupServicePointId": "#(servicePointId)"
+      }
+      """
+    When method POST
+    Then status 201
+    * def preconReqId5 = $.id
+
+    # Check in at the home service point so item becomes Awaiting delivery
+    * def checkInReq5pre = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
+    * checkInReq5pre.servicePointId = servicePointId
+    * checkInReq5pre.itemBarcode = itemBarcode630_5
+    Given path 'circulation', 'check-in-by-barcode'
+    And request checkInReq5pre
+    When method POST
+    Then status 200
+    And match $.item.status.name == 'Awaiting delivery'
 
     # Step 1: Create DCB LENDER transaction for "Checked out" item
     * def txnReq1 = read('classpath:volaris/mod-dcb/features/samples/transaction/create-dcb-transaction.json')
@@ -123,6 +267,8 @@ Feature: Lending transactions for items in various statuses
     And match $.patron.id == patronId630_1
 
     # Step 2: Create DCB LENDER transaction for "Paged" item
+    # Item2 is already Paged (due to preconReqId2). DCB creates the transaction
+    # and queues its own Page request behind the existing one.
     * def txnReq2 = read('classpath:volaris/mod-dcb/features/samples/transaction/create-dcb-transaction.json')
     * txnReq2.item.id = itemId630_2
     * txnReq2.item.barcode = itemBarcode630_2
@@ -139,6 +285,11 @@ Feature: Lending transactions for items in various statuses
     And match $.status == 'CREATED'
     And match $.item.id == itemId630_2
     And match $.patron.id == patronId630_2
+
+    Given path 'inventory', 'items', itemId630_2
+    When method GET
+    Then status 200
+    And match $.status.name == 'Paged'
 
     # Step 3: Create DCB LENDER transaction for "In transit" item
     * def txnReq3 = read('classpath:volaris/mod-dcb/features/samples/transaction/create-dcb-transaction.json')
@@ -194,11 +345,13 @@ Feature: Lending transactions for items in various statuses
     And match $.item.id == itemId630_5
     And match $.patron.id == patronId630_5
 
-    # Step 6: Finish each transaction flow
-    # After check-in, items are sent in transit to the DCB service points;
-    # each transaction moves through statuses according to flow without errors
+    # Step 6: Finish all outstanding requests/loans and drive each transaction
+    # to CLOSED.  For items with an open pre-condition request (Paged/Awaiting
+    # pickup/Awaiting delivery) we cancel that request first, then check in so
+    # the item goes In transit toward the DCB service point.
 
     # Transaction 1 flow (item was "Checked out")
+    # Return the item from the patron so the DCB check-in can move it In transit
     * def checkIn1 = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
     * checkIn1.servicePointId = servicePointId11
     * checkIn1.itemBarcode = itemBarcode630_1
@@ -209,42 +362,26 @@ Feature: Lending transactions for items in various statuses
     And match $.item.status.name == 'In transit'
     * call pause 5000
 
-    Given path 'transactions', txnId630_1, 'status'
-    And retry until response.status == 'OPEN'
-    When method GET
-    Then status 200
-
-    Given path 'transactions', txnId630_1, 'status'
-    And request updateToAwaitingPickup
-    When method PUT
-    Then status 200
-    * call pause 5000
-
-    Given path 'transactions', txnId630_1, 'status'
-    And request updateToItemCheckOut
-    When method PUT
-    Then status 200
-
-    Given path 'transactions', txnId630_1, 'status'
-    And request updateToItemCheckIn
-    When method PUT
-    Then status 200
-
-    * def checkIn1b = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
-    * checkIn1b.servicePointId = servicePointId11
-    * checkIn1b.itemBarcode = itemBarcode630_1
-    Given path 'circulation', 'check-in-by-barcode'
-    And request checkIn1b
-    When method POST
-    Then status 200
-    * call pause 5000
-
-    Given path 'transactions', txnId630_1, 'status'
-    And retry until response.status == 'CLOSED'
-    When method GET
-    Then status 200
+    * call read('classpath:volaris/mod-dcb/reusable/complete-lender-transaction.feature') { txnId: '#(txnId630_1)', itemBarcode: '#(itemBarcode630_1)', checkInServicePointId: '#(servicePointId11)' }
 
     # Transaction 2 flow (item was "Paged")
+    # Cancel the pre-condition Page request (by localUser630) so DCB's own request
+    # becomes the active one, then check in to send the item In transit.
+    * def cancelReq2 = read('classpath:volaris/mod-dcb/features/samples/request/cancel-request-entity-request.json')
+    * cancelReq2.cancellationReasonId = cancellationReasonId
+    * cancelReq2.cancelledByUserId = localUserId630
+    * cancelReq2.requesterId = localUserId630
+    * cancelReq2.requestLevel = 'Item'
+    * cancelReq2.holdingsRecordId = holdingId
+    * cancelReq2.requestType = 'Page'
+    * cancelReq2.itemId = itemId630_2
+    * cancelReq2.pickupServicePointId = servicePointId21
+    Given path 'circulation', 'requests', preconReqId2
+    And request cancelReq2
+    When method PUT
+    Then status 204
+    * call pause 2000
+
     * def checkIn2 = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
     * checkIn2.servicePointId = servicePointId11
     * checkIn2.itemBarcode = itemBarcode630_2
@@ -255,88 +392,42 @@ Feature: Lending transactions for items in various statuses
     And match $.item.status.name == 'In transit'
     * call pause 5000
 
-    Given path 'transactions', txnId630_2, 'status'
-    And retry until response.status == 'OPEN'
-    When method GET
-    Then status 200
-
-    Given path 'transactions', txnId630_2, 'status'
-    And request updateToAwaitingPickup
-    When method PUT
-    Then status 200
-    * call pause 5000
-
-    Given path 'transactions', txnId630_2, 'status'
-    And request updateToItemCheckOut
-    When method PUT
-    Then status 200
-
-    Given path 'transactions', txnId630_2, 'status'
-    And request updateToItemCheckIn
-    When method PUT
-    Then status 200
-
-    * def checkIn2b = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
-    * checkIn2b.servicePointId = servicePointId11
-    * checkIn2b.itemBarcode = itemBarcode630_2
-    Given path 'circulation', 'check-in-by-barcode'
-    And request checkIn2b
-    When method POST
-    Then status 200
-    * call pause 5000
-
-    Given path 'transactions', txnId630_2, 'status'
-    And retry until response.status == 'CLOSED'
-    When method GET
-    Then status 200
+    * call read('classpath:volaris/mod-dcb/reusable/complete-lender-transaction.feature') { txnId: '#(txnId630_2)', itemBarcode: '#(itemBarcode630_2)', checkInServicePointId: '#(servicePointId11)' }
 
     # Transaction 3 flow (item was "In transit")
-    * def checkIn3 = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
-    * checkIn3.servicePointId = servicePointId11
-    * checkIn3.itemBarcode = itemBarcode630_3
+    # Item is In transit to its home SP.  Checking in at the home SP resolves that
+    # in-transit; because DCB's Hold request is now active (pickup SP ≠ home SP),
+    # FOLIO immediately routes the item In transit to the DCB pickup SP, which
+    # is what triggers CREATED → OPEN.
+    * def checkIn3a = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
+    * checkIn3a.servicePointId = servicePointId
+    * checkIn3a.itemBarcode = itemBarcode630_3
     Given path 'circulation', 'check-in-by-barcode'
-    And request checkIn3
+    And request checkIn3a
     When method POST
     Then status 200
     And match $.item.status.name == 'In transit'
     * call pause 5000
 
-    Given path 'transactions', txnId630_3, 'status'
-    And retry until response.status == 'OPEN'
-    When method GET
-    Then status 200
-
-    Given path 'transactions', txnId630_3, 'status'
-    And request updateToAwaitingPickup
-    When method PUT
-    Then status 200
-    * call pause 5000
-
-    Given path 'transactions', txnId630_3, 'status'
-    And request updateToItemCheckOut
-    When method PUT
-    Then status 200
-
-    Given path 'transactions', txnId630_3, 'status'
-    And request updateToItemCheckIn
-    When method PUT
-    Then status 200
-
-    * def checkIn3b = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
-    * checkIn3b.servicePointId = servicePointId11
-    * checkIn3b.itemBarcode = itemBarcode630_3
-    Given path 'circulation', 'check-in-by-barcode'
-    And request checkIn3b
-    When method POST
-    Then status 200
-    * call pause 5000
-
-    Given path 'transactions', txnId630_3, 'status'
-    And retry until response.status == 'CLOSED'
-    When method GET
-    Then status 200
+    * call read('classpath:volaris/mod-dcb/reusable/complete-lender-transaction.feature') { txnId: '#(txnId630_3)', itemBarcode: '#(itemBarcode630_3)', checkInServicePointId: '#(servicePointId11)' }
 
     # Transaction 4 flow (item was "Awaiting pickup")
+    # Cancel the pre-condition request so the item is freed, then check in at sp11.
+    * def cancelReq4 = read('classpath:volaris/mod-dcb/features/samples/request/cancel-request-entity-request.json')
+    * cancelReq4.cancellationReasonId = cancellationReasonId
+    * cancelReq4.cancelledByUserId = localUserId630
+    * cancelReq4.requesterId = localUserId630
+    * cancelReq4.requestLevel = 'Item'
+    * cancelReq4.holdingsRecordId = holdingId
+    * cancelReq4.requestType = 'Page'
+    * cancelReq4.itemId = itemId630_4
+    * cancelReq4.pickupServicePointId = servicePointId11
+    Given path 'circulation', 'requests', preconReqId4
+    And request cancelReq4
+    When method PUT
+    Then status 204
+    * call pause 5000
+
     * def checkIn4 = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
     * checkIn4.servicePointId = servicePointId11
     * checkIn4.itemBarcode = itemBarcode630_4
@@ -347,42 +438,25 @@ Feature: Lending transactions for items in various statuses
     And match $.item.status.name == 'In transit'
     * call pause 5000
 
-    Given path 'transactions', txnId630_4, 'status'
-    And retry until response.status == 'OPEN'
-    When method GET
-    Then status 200
-
-    Given path 'transactions', txnId630_4, 'status'
-    And request updateToAwaitingPickup
-    When method PUT
-    Then status 200
-    * call pause 5000
-
-    Given path 'transactions', txnId630_4, 'status'
-    And request updateToItemCheckOut
-    When method PUT
-    Then status 200
-
-    Given path 'transactions', txnId630_4, 'status'
-    And request updateToItemCheckIn
-    When method PUT
-    Then status 200
-
-    * def checkIn4b = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
-    * checkIn4b.servicePointId = servicePointId11
-    * checkIn4b.itemBarcode = itemBarcode630_4
-    Given path 'circulation', 'check-in-by-barcode'
-    And request checkIn4b
-    When method POST
-    Then status 200
-    * call pause 5000
-
-    Given path 'transactions', txnId630_4, 'status'
-    And retry until response.status == 'CLOSED'
-    When method GET
-    Then status 200
+    * call read('classpath:volaris/mod-dcb/reusable/complete-lender-transaction.feature') { txnId: '#(txnId630_4)', itemBarcode: '#(itemBarcode630_4)', checkInServicePointId: '#(servicePointId11)' }
 
     # Transaction 5 flow (item was "Awaiting delivery")
+    # Cancel the pre-condition delivery request, then check in at sp11.
+    * def cancelReq5 = read('classpath:volaris/mod-dcb/features/samples/request/cancel-request-entity-request.json')
+    * cancelReq5.cancellationReasonId = cancellationReasonId
+    * cancelReq5.cancelledByUserId = localUserId630
+    * cancelReq5.requesterId = localUserId630
+    * cancelReq5.requestLevel = 'Item'
+    * cancelReq5.holdingsRecordId = holdingId
+    * cancelReq5.requestType = 'Page'
+    * cancelReq5.itemId = itemId630_5
+    * cancelReq5.pickupServicePointId = servicePointId
+    Given path 'circulation', 'requests', preconReqId5
+    And request cancelReq5
+    When method PUT
+    Then status 204
+    * call pause 5000
+
     * def checkIn5 = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
     * checkIn5.servicePointId = servicePointId11
     * checkIn5.itemBarcode = itemBarcode630_5
@@ -393,37 +467,4 @@ Feature: Lending transactions for items in various statuses
     And match $.item.status.name == 'In transit'
     * call pause 5000
 
-    Given path 'transactions', txnId630_5, 'status'
-    And retry until response.status == 'OPEN'
-    When method GET
-    Then status 200
-
-    Given path 'transactions', txnId630_5, 'status'
-    And request updateToAwaitingPickup
-    When method PUT
-    Then status 200
-    * call pause 5000
-
-    Given path 'transactions', txnId630_5, 'status'
-    And request updateToItemCheckOut
-    When method PUT
-    Then status 200
-
-    Given path 'transactions', txnId630_5, 'status'
-    And request updateToItemCheckIn
-    When method PUT
-    Then status 200
-
-    * def checkIn5b = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
-    * checkIn5b.servicePointId = servicePointId11
-    * checkIn5b.itemBarcode = itemBarcode630_5
-    Given path 'circulation', 'check-in-by-barcode'
-    And request checkIn5b
-    When method POST
-    Then status 200
-    * call pause 5000
-
-    Given path 'transactions', txnId630_5, 'status'
-    And retry until response.status == 'CLOSED'
-    When method GET
-    Then status 200
+    * call read('classpath:volaris/mod-dcb/reusable/complete-lender-transaction.feature') { txnId: '#(txnId630_5)', itemBarcode: '#(itemBarcode630_5)', checkInServicePointId: '#(servicePointId11)' }

--- a/mod-dcb/src/main/resources/volaris/mod-dcb/mod-dcb-junit.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/mod-dcb-junit.feature
@@ -37,6 +37,8 @@ Feature: mod-dcb integration tests
       | 'circulation.check-in-by-barcode.post'                            |
       | 'circulation.check-out-by-barcode.post'                           |
       | 'circulation.requests.item.get'                                   |
+      | 'circulation.requests.item.post'                                  |
+      | 'addresstypes.item.post'                                          |
       | 'circulation.requests.item.put'                                   |
       | 'circulation.rules.put'                                           |
       | 'dcb.transactions.collection.get'                                 |
@@ -140,6 +142,8 @@ Feature: mod-dcb integration tests
       | 'patron-blocks.automated-patron-blocks.collection.get'            |
       | 'dcb.shadow_locations.refresh.post'                               |
       | 'circulation-item.item.get'                                       |
+      | 'circulation.requests.item.post'                                  |
+      | 'addresstypes.item.post'                                          |
 
 
   Scenario: create tenant and users for testing for mod-dcb

--- a/mod-dcb/src/main/resources/volaris/mod-dcb/reusable/complete-lender-transaction.feature
+++ b/mod-dcb/src/main/resources/volaris/mod-dcb/reusable/complete-lender-transaction.feature
@@ -1,0 +1,44 @@
+Feature: Complete DCB lender transaction flow from OPEN to CLOSED
+
+  Scenario: Drive lender transaction through OPEN -> AWAITING_PICKUP -> ITEM_CHECKED_OUT -> ITEM_CHECKED_IN -> CLOSED
+    * url baseUrl
+    * configure retry = { count: 10, interval: 2000 }
+    * def intCheckInDate = call read('classpath:volaris/mod-dcb/features/util/get-time-now-function.js')
+    * def updateToAwaitingPickup = read('classpath:volaris/mod-dcb/features/samples/transaction/update-dcb-transaction-to-awaiting-pickup.json')
+    * def updateToItemCheckOut = read('classpath:volaris/mod-dcb/features/samples/transaction/update-dcb-transaction-to-item-check-out.json')
+    * def updateToItemCheckIn = read('classpath:volaris/mod-dcb/features/samples/transaction/update-dcb-transaction-to-item-check-in.json')
+
+    Given path 'transactions', txnId, 'status'
+    And retry until response.status == 'OPEN'
+    When method GET
+    Then status 200
+
+    Given path 'transactions', txnId, 'status'
+    And request updateToAwaitingPickup
+    When method PUT
+    Then status 200
+    * call pause 5000
+
+    Given path 'transactions', txnId, 'status'
+    And request updateToItemCheckOut
+    When method PUT
+    Then status 200
+
+    Given path 'transactions', txnId, 'status'
+    And request updateToItemCheckIn
+    When method PUT
+    Then status 200
+
+    * def finalCheckIn = read('classpath:volaris/mod-dcb/features/samples/check-in/check-in-by-barcode-entity-request.json')
+    * finalCheckIn.servicePointId = checkInServicePointId
+    * finalCheckIn.itemBarcode = itemBarcode
+    Given path 'circulation', 'check-in-by-barcode'
+    And request finalCheckIn
+    When method POST
+    Then status 200
+    * call pause 5000
+
+    Given path 'transactions', txnId, 'status'
+    And retry until response.status == 'CLOSED'
+    When method GET
+    Then status 200


### PR DESCRIPTION
## Purpose
Verify that a DCB LENDER transaction can be created for items already in Checked out / Paged / In transit / Awaiting pickup / Awaiting delivery status, and that each transaction completes the full flow to CLOSED.

## Approach
   1. Create 5 items as Available, then transition each to the required status via real FOLIO circulation actions (checkout, page request, check-in at wrong SP, etc.)
   2. POST one DCB LENDER transaction per item → assert 201
   3. Drive each transaction through OPEN → AWAITING_PICKUP → ITEM_CHECKED_OUT → ITEM_CHECKED_IN → CLOSED via the DCB status PUT API and circulation check-ins
   4. All IDs are static (per system prompt), reusable features are called where applicable, permissions added to both tables in mod-dcb-junit.feature

### TODOS and Open Questions
- [x] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
[FAT-25969](https://folio-org.atlassian.net/browse/FAT-25969)

## Report
<img width="1585" height="557" alt="image" src="https://github.com/user-attachments/assets/5f83d7a5-374d-49d6-926a-c5db2a22e0db" />
