### PR TITLE
FAT-26305: Fix tenant conflict between DataImportApiTest and DataImportExtendedApiTest (#2369)

### DIFF
--- a/data-import/src/test/java/org/folio/DataImportApiTest.java
+++ b/data-import/src/test/java/org/folio/DataImportApiTest.java
@@ -10,6 +10,9 @@ import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import static org.folio.test.config.TestParam.TEST_TENANT;
+import static org.folio.test.config.TestParam.TEST_TENANT_ID;
+
 @FolioTest(team = "folijet", module = "data-import")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class DataImportApiTest extends TestBaseEureka {
@@ -54,9 +57,14 @@ class DataImportApiTest extends TestBaseEureka {
     @AfterAll
     public void teardown() {
         if (shouldCreateTenant()) {
-            feature("classpath:common/eureka/destroy-data.feature")
-                    .reportDir(timestampedReportDir())
-                    .run();
+            try {
+                feature("classpath:common/eureka/destroy-data.feature")
+                        .reportDir(timestampedReportDir())
+                        .run();
+            } finally {
+                System.clearProperty(TEST_TENANT.getValue());
+                System.clearProperty(TEST_TENANT_ID.getValue());
+            }
         }
     }
 }

--- a/data-import/src/test/java/org/folio/DataImportExtendedApiTest.java
+++ b/data-import/src/test/java/org/folio/DataImportExtendedApiTest.java
@@ -7,6 +7,9 @@ import org.folio.test.services.TestIntegrationService;
 import org.folio.test.services.TestRailService;
 import org.junit.jupiter.api.*;
 
+import static org.folio.test.config.TestParam.TEST_TENANT;
+import static org.folio.test.config.TestParam.TEST_TENANT_ID;
+
 @FolioTest(team = "folijet", module = "data-import")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 public class DataImportExtendedApiTest extends TestBaseEureka {
@@ -35,9 +38,14 @@ public class DataImportExtendedApiTest extends TestBaseEureka {
     @AfterAll
     public void teardown() {
         if (shouldCreateTenant()) {
-            feature("classpath:common/eureka/destroy-data.feature")
-                    .reportDir(timestampedReportDir())
-                    .run();
+            try {
+                feature("classpath:common/eureka/destroy-data.feature")
+                        .reportDir(timestampedReportDir())
+                        .run();
+            } finally {
+                System.clearProperty(TEST_TENANT.getValue());
+                System.clearProperty(TEST_TENANT_ID.getValue());
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose
DataImportApiTest and DataImportExtendedApiTest share the same tenant configuration, causing test failures when run sequentially. The first test deletes the tenant in its @AfterAll cleanup phase, causing the second test to fail because it attempts to reuse the already-deleted tenant.

## Approach
Change in approach using finally.

### Learning
[FAT-26305](https://folio-org.atlassian.net/browse/FAT-26305)