### PR TITLE
Use latest application version param for entitelements

### DIFF
--- a/common/src/main/resources/common/eureka/application.feature
+++ b/common/src/main/resources/common/eureka/application.feature
@@ -13,14 +13,12 @@ Feature: Applications
     * def keycloakMasterToken = keycloakResponse.response.access_token
 
     Given path 'applications'
-    And param latest = 1
     And header Authorization = 'Bearer ' + keycloakMasterToken
     When method GET
     Then status 200
     * def totalAmount = response.totalRecords
 
     Given path 'applications'
-    And param latest = 1
     And param limit = totalAmount
     And header Authorization = 'Bearer ' + keycloakMasterToken
     When method GET
@@ -69,4 +67,27 @@ Feature: Applications
     # search application id by dependencies names, combine all ids together
     * karate.forEach(uniqueDependencyNames, dependencyName => dependencyIds = dependencyIds.concat(appDescriptions.filter(descriptor => descriptor.name == dependencyName).flatMap(x => x.id)))
     * def appIds = karate.distinct(appIds.concat(dependencyIds))
+
+    # When the registry holds multiple versions of the same application, keep only the highest SemVer per name —
+    # mgr-tenant-entitlements rejects payloads with duplicate application names.
+    * def descriptorById = {}
+    * karate.forEach(appDescriptions, d => descriptorById[d.id] = d)
+    * def Semver = Java.type('org.semver4j.Semver')
+    * def isNewer = (a, b) => new Semver(a).compareTo(new Semver(b)) > 0
+    * def pickLatestPerName =
+      """
+      ids => {
+        var latestByName = {};
+        ids.forEach(id => {
+          var descriptor = descriptorById[id];
+          if (!descriptor) return;
+          var current = latestByName[descriptor.name];
+          if (!current || isNewer(descriptor.version, current.version)) {
+            latestByName[descriptor.name] = descriptor;
+          }
+        });
+        return Object.keys(latestByName).map(name => latestByName[name].id);
+      }
+      """
+    * def appIds = pickLatestPerName(appIds)
     * karate.set('applicationIds', appIds)

--- a/common/src/main/resources/common/eureka/application.feature
+++ b/common/src/main/resources/common/eureka/application.feature
@@ -13,12 +13,14 @@ Feature: Applications
     * def keycloakMasterToken = keycloakResponse.response.access_token
 
     Given path 'applications'
+    And param latest = 1
     And header Authorization = 'Bearer ' + keycloakMasterToken
     When method GET
     Then status 200
     * def totalAmount = response.totalRecords
 
     Given path 'applications'
+    And param latest = 1
     And param limit = totalAmount
     And header Authorization = 'Bearer ' + keycloakMasterToken
     When method GET

--- a/pom.xml
+++ b/pom.xml
@@ -235,5 +235,10 @@
       <artifactId>logger-java-logback</artifactId>
       <version>5.2.2</version>
     </dependency>
+    <dependency>
+      <groupId>org.semver4j</groupId>
+      <artifactId>semver4j</artifactId>
+      <version>6.0.0</version>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
## Purpose
On sprint2 env we had situation where the same application was registered with different versions like this:
[2026-05-26T13:17:27.123Z]   "tenantId": "27856102-7e72-4afd-befe-fad913636a7e",
[2026-05-26T13:17:27.123Z]   "applications": [
[2026-05-26T13:17:27.123Z]     "app-platform-complete-3.3.0",
[2026-05-26T13:17:27.123Z]     "app-platform-complete-3.3.1",
[2026-05-26T13:17:27.123Z]     "app-platform-minimal-2.1.4",
[2026-05-26T13:17:27.123Z]     "app-acquisitions-2.0.5",
[2026-05-26T13:17:27.123Z]     "app-acquisitions-2.0.7",
[2026-05-26T13:17:27.123Z]     "app-acquisitions-2.0.9",
[2026-05-26T13:17:27.123Z]     "app-inventory-1.0.3",
[2026-05-26T13:17:27.123Z]     "app-inventory-1.0.4",
[2026-05-26T13:17:27.123Z]     "app-notification-1.0.0",
[2026-05-26T13:17:27.123Z]     "app-search-1.0.1",
[2026-05-26T13:17:27.123Z]     "app-search-1.0.2",
[2026-05-26T13:17:27.123Z]     "app-marc-storage-1.0.0"
[2026-05-26T13:17:27.123Z]   ]
[2026-05-26T13:17:27.123Z] }

As solution we use Semver to filter and use only the latest version.

## Approach
_How does this change fulfill the purpose?_

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
