### PR TITLE
[MODORDERS-1449] Pay, unopen, open

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
@@ -331,3 +331,6 @@ Feature: cross-module integration tests
 
   Scenario: Over Encumbrance Is Calculated Correctly For Fiscal Year Ledger And Group
     * call read('features/over-encumbrance-for-fy-ledger-and-group.feature')
+
+  Scenario: Pay, unopen, open
+    * call read('features/pay-unopen-open.feature')

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/pay-unopen-open.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/pay-unopen-open.feature
@@ -1,0 +1,69 @@
+# For MODORDERS-1449
+Feature: Pay, unopen, open
+
+Background:
+  * print karate.info.scenarioName
+  * url baseUrl
+
+  * callonce login testAdmin
+  * def okapitokenAdmin = okapitoken
+  * callonce login testUser
+  * def okapitokenUser = okapitoken
+  * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+  * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
+  * configure headers = headersUser
+
+  * callonce variables
+
+
+@Positive
+Scenario: Pay, unopen, open
+  * def fundId = call uuid
+  * def budgetId = call uuid
+  * def orderId = call uuid
+  * def poLineId = call uuid
+  * def invoiceId = call uuid
+  * def invoiceLineId = call uuid
+
+  # 1. Create a fund and budget
+  * def v = call createFund { id: '#(fundId)' }
+  * def v = call createBudget { id: '#(budgetId)', allocated: 1000, fundId: '#(fundId)' }
+
+  # 2. Create an order and line
+  * def v = call createOrder { id: '#(orderId)' }
+  * def v = call createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', fundId: '#(fundId)', listUnitPrice: 11 }
+
+  # 3. Open the order
+  * def v = call openOrder { orderId: '#(orderId)' }
+
+  # 4. Get the encumbrance id
+  Given path 'orders/order-lines', poLineId
+  When method GET
+  Then status 200
+  * def encumbranceId = $.fundDistribution[0].encumbrance
+
+  # 5. Create an invoice
+  * def v = call createInvoice { id: '#(invoiceId)' }
+
+  # 6. Add an invoice line linked to the po line, releaseEncumbrance=false
+  * def v = call createInvoiceLine { invoiceLineId: '#(invoiceLineId)', invoiceId: '#(invoiceId)', poLineId: '#(poLineId)', fundId: '#(fundId)', encumbranceId: '#(encumbranceId)', releaseEncumbrance: false, total: 4.0 }
+
+  # 7. Approve and pay the invoice
+  * def v = call approveInvoice { invoiceId: '#(invoiceId)' }
+  * def v = call payInvoice { invoiceId: '#(invoiceId)' }
+
+  # 8. Unopen the order
+  * def v = call unopenOrder { orderId: '#(orderId)' }
+
+  # 9. Reopen the order
+  * def v = call openOrder { orderId: '#(orderId)' }
+
+  # 10. Check the encumbrance is unreleased
+  Given path 'finance/transactions', encumbranceId
+  When method GET
+  Then status 200
+  And match $.encumbrance.status == 'Unreleased'
+  And match $.amount == 7.0
+  And match $.encumbrance.initialAmountEncumbered == 11.0
+  And match $.encumbrance.amountAwaitingPayment == 0
+  And match $.encumbrance.amountExpended == 4.0

--- a/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
+++ b/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
@@ -82,7 +82,8 @@ public class CrossModulesApiTest extends TestBaseEureka implements AcquisitionsT
     FEATURE_56("update_fund_in_poline_when_invoice_approved", true),
     FEATURE_57("rollover-multi-ledger", true),
     FEATURE_58("rollover-many-orders-and-lines", false),
-    FEATURE_59("approve-invoice-with-different-fund-than-order", false);
+    FEATURE_59("approve-invoice-with-different-fund-than-order", false),
+    FEATURE_60("pay-unopen-open", false);
 
     private final String fileName;
     private final boolean isEnabled;
@@ -481,4 +482,9 @@ public class CrossModulesApiTest extends TestBaseEureka implements AcquisitionsT
     runFeatureTest(Feature.FEATURE_59.getFileName());
   }
 
+  @Test
+  @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
+  void payUnopenOpen() {
+    runFeatureTest(Feature.FEATURE_60.getFileName());
+  }
 }


### PR DESCRIPTION
## Purpose
[MODORDERS-1449](https://folio-org.atlassian.net/browse/MODORDERS-1449) - Encumbrance is released after un-opening the order with related Paid invoice (release encumbrance = false)

## Approach
Added a new test case matching the JIRA description.

## Related PR
- [mod-orders](https://github.com/folio-org/mod-orders/pull/1324)
