### PR TITLE
[FAT-21157] Recalculate budget

### DIFF
--- a/acquisitions/src/main/resources/karate-config.js
+++ b/acquisitions/src/main/resources/karate-config.js
@@ -65,6 +65,7 @@ function fn() {
     createTransaction: karate.read('classpath:thunderjet/mod-finance/reusable/createTransaction.feature'),
     createEncumbrance: karate.read('classpath:thunderjet/mod-finance/reusable/createEncumbrance.feature'),
     createPayment: karate.read('classpath:thunderjet/mod-finance/reusable/createPayment.feature'),
+    createCredit: karate.read('classpath:thunderjet/mod-finance/reusable/createCredit.feature'),
     createPendingPayment: karate.read('classpath:thunderjet/mod-finance/reusable/createPendingPayment.feature'),
     createLedger: karate.read('classpath:thunderjet/mod-finance/reusable/createLedger.feature'),
     createExpenseClass: karate.read('classpath:thunderjet/mod-finance/reusable/createExpenseClass.feature'),

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/features/recalculate-budget.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/features/recalculate-budget.feature
@@ -1,0 +1,101 @@
+# For MODFIN-394, FAT-21157
+Feature: Recalculate budget
+
+  Background:
+    * print karate.info.scenarioName
+    * url baseUrl
+
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+
+    * callonce variables
+
+  @Positive
+  Scenario: Recalculate budget
+    * def fundId1 = call uuid
+    * def fundId2 = call uuid
+    * def budgetId1 = call uuid
+    * def budgetId2 = call uuid
+    * def releasedEncumbranceId = call uuid
+    * def orderId = call uuid
+    * def poLineId = call uuid
+    * def invoiceId1 = call uuid
+    * def invoiceId2 = call uuid
+    * def invoiceId3 = call uuid
+    * def invoiceLineId1 = call uuid
+    * def invoiceLineId2 = call uuid
+    * def invoiceLineId3 = call uuid
+
+    # 1. Create funds and budgets
+    * def v = call createFund { id: '#(fundId1)' }
+    * def v = call createBudget { id: '#(budgetId1)', fundId: '#(fundId1)', allocated: 100 }
+    * def v = call createFund { id: '#(fundId2)' }
+    * def v = call createBudget { id: '#(budgetId2)', fundId: '#(fundId2)', allocated: 100 }
+
+    # 2. Create unreleased encumbrance
+    * def v = call createEncumbrance { amount: 2.0, fundId: '#(fundId1)', sourcePurchaseOrderId: '#(orderId)', sourcePoLineId: '#(poLineId)' }
+
+    # 3. Create released encumbrance
+    * def v = call createEncumbrance { id: '#(releasedEncumbranceId)', amount: 0.0, initialAmountEncumbered: 3.0, fundId: '#(fundId1)', status: 'Released', sourcePurchaseOrderId: '#(orderId)', sourcePoLineId: '#(poLineId)' }
+
+    # 4. Create pending payment
+    * def v = call createPendingPayment { amount: 5.0, fundId: '#(fundId1)', encumbranceId: '#(releasedEncumbranceId)', invoiceId: '#(invoiceId1)', invoiceLineId: '#(invoiceLineId1)', releaseEncumbrance: true }
+
+    # 5. Create payment
+    * def v = call createPayment { amount: 7.0, fundId: '#(fundId1)', invoiceId: '#(invoiceId2)', invoiceLineId: '#(invoiceLineId2)' }
+
+    # 6. Create credit
+    * def v = call createCredit { amount: 11.0, fundId: '#(fundId1)', invoiceId: '#(invoiceId3)', invoiceLineId: '#(invoiceLineId3)' }
+
+    # 7. Create allocation
+    * def v = call createTransaction { transactionType: 'Allocation', amount: 13.0, fundId: '#(fundId1)' }
+
+    # 8. Create transfer
+    * def v = call createTransaction { transactionType: 'Transfer', amount: 17.0, fromFundId: '#(fundId2)', toFundId: '#(fundId1)' }
+
+    # 9. Create rollover transfer
+    * def v = call createTransaction { transactionType: 'Rollover transfer', amount: 19.0, fundId: '#(fundId1)' }
+
+    # 10. Change budget amounts so it needs to be recalculated
+    Given path '/finance/budgets', budgetId1
+    When method GET
+    Then status 200
+    * def budget = $
+    * set budget.allocated = 0
+    * set budget.awaitingPayment = 0
+    * set budget.credits = 0
+    * set budget.encumbered = 0
+    * set budget.expenditures = 0
+    * set budget.netTransfers = 0
+    Given path '/finance/budgets', budgetId1
+    And request budget
+    When method PUT
+    Then status 204
+
+    # 11. Recalculate budget
+    Given path 'finance/budgets', budgetId1, 'recalculate'
+    When method POST
+    Then status 204
+
+    # 12. Check budget amounts
+    Given path '/finance/budgets', budgetId1
+    When method GET
+    Then status 200
+    And match $.initialAllocation == 100
+    And match $.allocationTo == 13
+    And match $.allocationFrom == 0
+    # allocated = initialAllocation + allocationTo - allocationFrom
+    And match $.allocated == 113
+    And match $.netTransfers == 36
+    # totalFunding = allocated + netTransfers
+    And match $.totalFunding == 149
+    And match $.encumbered == 2
+    And match $.awaitingPayment == 5
+    And match $.expenditures == 7
+    And match $.credits == 11
+    # unavailable = encumbered + awaitingPayment + expenditures - credits
+    And match $.unavailable == 3
+    # available = totalFunding - unavailable
+    And match $.available == 146

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/finance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/finance.feature
@@ -111,6 +111,9 @@ Feature: mod-finance integration tests
   Scenario: Budget's totals (available, unavailable, encumbered) is updated when encumbrance's amount is changed but status has not been changed
     * call read('features/update-encumbrance-transactions.feature')
 
+  Scenario: Recalculate budget
+    * call read('features/recalculate-budget.feature')
+
   Scenario: Get funds without providing filter query should take into account acquisition units
     * call read('features/acq-units/verify-get-funds-without-query-where-user-has-units-and-filter-only-by-units.feature')
 

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/init-finance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/init-finance.feature
@@ -36,6 +36,7 @@ Feature: Initialize mod-finance integration tests
       | 'finance-storage.transactions.batch.execute'                  |
       | 'finance-storage.transactions.collection.get'                 |
       | 'finance.budgets-expense-classes-totals.collection.get'       |
+      | 'finance.budgets-recalculate.item.post'                       |
       | 'finance.budgets.collection.get'                              |
       | 'finance.budgets.item.delete'                                 |
       | 'finance.budgets.item.get'                                    |

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createCredit.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createCredit.feature
@@ -1,0 +1,39 @@
+Feature: Create a credit
+
+  Background:
+    * print karate.info.scenarioName
+    * url baseUrl
+
+  Scenario: Create a credit
+    * def id = karate.get('id', uuid())
+    * def fiscalYearId = karate.get('fiscalYearId', globalFiscalYearId)
+    * def description = karate.get('description', null)
+    * def expenseClassId = karate.get('expenseClassId', null)
+    * def encumbranceId = karate.get('encumbranceId', null)
+    * def toFundId = karate.get('fundId', null)
+    * def sourceInvoiceId = karate.get('invoiceId', null)
+    * def sourceInvoiceLineId = karate.get('invoiceLineId', null)
+    * def expectedStatus = karate.get('expectedStatus', 204)
+
+    Given path 'finance/transactions/batch-all-or-nothing'
+    And request
+      """
+      {
+        "transactionsToCreate": [{
+          "id": "#(id)",
+          "amount": "#(amount)",
+          "currency": "USD",
+          "description": "#(description)",
+          "expenseClassId": "#(expenseClassId)",
+          "fiscalYearId": "#(fiscalYearId)",
+          "source": "User",
+          "toFundId": "#(fundId)",
+          "transactionType": "Credit",
+          "paymentEncumbranceId": "#(encumbranceId)",
+          "sourceInvoiceId": "#(sourceInvoiceId)",
+          "sourceInvoiceLineId": "#(sourceInvoiceLineId)"
+        }]
+      }
+      """
+    When method POST
+    Then assert responseStatus == expectedStatus

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createEncumbrance.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createEncumbrance.feature
@@ -11,7 +11,8 @@ Feature: Create an encumbrance
     * def sourcePurchaseOrderId = karate.get('orderId', null)
     * def sourcePoLineId = karate.get('poLineId', null)
     * def expenseClassId = karate.get('expenseClassId', null)
-    * def transactionEncumbrance = { initialAmountEncumbered: '#(amount)', status: 'Unreleased', sourcePurchaseOrderId: '#(sourcePurchaseOrderId)', sourcePoLineId: '#(sourcePoLineId)', orderType: 'One-Time', subscription: false, reEncumber: false }
+    * def initialAmountEncumbered = karate.get('initialAmountEncumbered', amount)
+    * def transactionEncumbrance = { initialAmountEncumbered: '#(initialAmountEncumbered)', status: 'Unreleased', sourcePurchaseOrderId: '#(sourcePurchaseOrderId)', sourcePoLineId: '#(sourcePoLineId)', orderType: 'One-Time', subscription: false, reEncumber: false }
     * def expectedStatus = karate.get('expectedStatus', 204)
 
     Given path 'finance/transactions/batch-all-or-nothing'

--- a/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createTransaction.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-finance/reusable/createTransaction.feature
@@ -11,8 +11,12 @@ Feature: Create transaction
     * def sourceInvoiceId = karate.get('invoiceId', null)
     * def sourcePurchaseOrderId = karate.get('orderId', null)
     * def expenseClassId = karate.get('expenseClassId', null)
-    * def transactionEncumbrance = { initialAmountEncumbered: #(amount), status: 'Unreleased', sourcePurchaseOrderId: #(sourcePurchaseOrderId), sourcePoLineId: #(poLineId), orderType: 'One-Time', subscription: false, reEncumber: false }
+    * def transactionEncumbrance = { initialAmountEncumbered: '#(amount)', status: 'Unreleased', sourcePurchaseOrderId: '#(sourcePurchaseOrderId)', sourcePoLineId: '#(poLineId)', orderType: 'One-Time', subscription: false, reEncumber: false }
     * def transactionEncumbrance = transactionType == 'Encumbrance' ? transactionEncumbrance : null
+    * def fundId = karate.get('fundId', null)
+    * def creditTransactions = ['Allocation', 'Credit', 'Rollover transfer']
+    * def fromFundId = karate.get('fromFundId', creditTransactions.includes(transactionType) ? null : fundId)
+    * def toFundId = karate.get('toFundId', creditTransactions.includes(transactionType) ? fundId : null)
 
     Given path 'finance/transactions/batch-all-or-nothing'
     And request
@@ -22,8 +26,8 @@ Feature: Create transaction
         "id": "#(id)",
         "amount": "#(amount)",
         "currency": "USD",
-        "fromFundId": "#(fundId)",
-        "toFundId": "#(fundId)",
+        "fromFundId": "#(fromFundId)",
+        "toFundId": "#(toFundId)",
         "fiscalYearId": "#(fiscalYearId)",
         "transactionType": "#(transactionType)",
         "source": "User",

--- a/acquisitions/src/test/java/org/folio/FinanceApiTest.java
+++ b/acquisitions/src/test/java/org/folio/FinanceApiTest.java
@@ -57,8 +57,9 @@ public class FinanceApiTest extends TestBaseEureka implements AcquisitionsTest {
     FEATURE_29("unopen-order-after-rollover-MODORDERS-542", false),
     FEATURE_30("unrelease-encumbrance", true),
     FEATURE_31("update-encumbrance-transactions", true),
-    FEATURE_32("acq-units/verify-get-funds-without-query-where-user-has-units-and-filter-only-by-units", true),
-    FEATURE_33("acq-units/verify-get-funds-with-query-where-user-has-units", true);
+    FEATURE_32("recalculate-budget", true),
+    FEATURE_33("acq-units/verify-get-funds-without-query-where-user-has-units-and-filter-only-by-units", true),
+    FEATURE_34("acq-units/verify-get-funds-with-query-where-user-has-units", true);
 
     private final String fileName;
     private final boolean isEnabled;
@@ -293,13 +294,19 @@ public class FinanceApiTest extends TestBaseEureka implements AcquisitionsTest {
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void verifyGetFundsWithoutQueryWhereUserHasUnitsAndFilterOnlyByUnits() {
+  void recalculateBudget() {
     runFeatureTest(Feature.FEATURE_32.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void verifyGetFundsWithQueryWhereUserHasUnits() {
+  void verifyGetFundsWithoutQueryWhereUserHasUnitsAndFilterOnlyByUnits() {
     runFeatureTest(Feature.FEATURE_33.getFileName());
+  }
+
+  @Test
+  @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
+  void verifyGetFundsWithQueryWhereUserHasUnits() {
+    runFeatureTest(Feature.FEATURE_34.getFileName());
   }
 }


### PR DESCRIPTION
## Purpose
[FAT-21157](https://folio-org.atlassian.net/browse/FAT-21157) - Thunderjet - Create Karate test - Budget summary for Net Transfers includes Rollover transfer amounts after budget total recalculation

## Approach
Instead of implementing [C627392](https://foliotest.testrail.io/index.php?/cases/view/627392), this PR adds a new test to check recalcutating budgets, for which no test existed previously. It will cover what was meant to be tested in C627392 (that rollover transfers are taken into account when recalculating, see [MODFIN-394](https://folio-org.atlassian.net/browse/MODFIN-394)).
The test is added to core finance tests, not as an extended test.
`createTransaction` is improved to avoid using both `fromFundId` and `toFundId` with the same id.