### PR TITLE
[FAT-21205] Encumbrance remains released after another credited invoice was paid

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/cross-modules.feature
@@ -56,8 +56,8 @@ Feature: cross-module integration tests
   Scenario: Check encumbrance status after moving expended value
     * call read('features/check-encumbrance-status-after-moving-expended-value.feature')
 
-  Scenario: Check the encumbrances after issuing credit when the order is fully paid
-    * call read('features/check-encumbrances-after-issuing-credit-for-paid-order.feature')
+  Scenario: Encumbrance remains released after another credited invoice was paid
+    * call read('features/encumbrance-remains-released-after-another-credited-invoice-was-paid.feature')
 
   Scenario: Check encumbrances after order is reopened
     * call read('features/check-encumbrances-after-order-is-reopened.feature')

--- a/acquisitions/src/main/resources/thunderjet/cross-modules/features/encumbrance-remains-released-after-another-credited-invoice-was-paid.feature
+++ b/acquisitions/src/main/resources/thunderjet/cross-modules/features/encumbrance-remains-released-after-another-credited-invoice-was-paid.feature
@@ -1,5 +1,5 @@
-  # https://folio-org.atlassian.net/browse/MODFISTO-512
-  Feature: Check the encumbrances after issuing credit when the order is fully paid
+  # For MODFISTO-512, FAT-21205
+  Feature: Encumbrance remains released after another credited invoice was paid
 
     Background:
       * print karate.info.scenarioName
@@ -20,14 +20,16 @@
       * def invoiceLineId2 = callonce uuid8
 
 
-    Scenario: Check the encumbrances after issuing credit when the order is fully paid
+    @C624240
+    @Positive
+    Scenario: Encumbrance remains released after another credited invoice was paid
       # 1. Create a fund and a budget
-      * def v = call createFund { 'id': '#(fundId)', 'ledgerId': '#(globalLedgerWithRestrictionsId)' }
-      * def v = call createBudget { 'id': '#(budgetId)', 'fundId': '#(fundId)', 'allocated': 1000 }
+      * def v = call createFund { id: '#(fundId)', ledgerId: '#(globalLedgerWithRestrictionsId)' }
+      * def v = call createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 100 }
 
       # 2. Create an order, order line and open the order
       * def v = call createOrder { id: '#(orderId)' }
-      * def v = call createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', fundId: '#(fundId)', listUnitPrice: 100, quantity: 1 }
+      * def v = call createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', fundId: '#(fundId)', listUnitPrice: 10, quantity: 1 }
       * def v = call openOrder { orderId: '#(orderId)' }
 
       # 3. Get encumbrance transaction and check the amount
@@ -36,14 +38,14 @@
       When method GET
       Then status 200
       And match response.transactions[0].encumbrance.status == 'Unreleased'
-      And match response.transactions[0].amount == 100
+      And match response.transactions[0].amount == 10
       * def encumbranceId = response.transactions[0].id
 
       # 4. Create an invoice and invoice line
       * def v = call createInvoice { id: '#(invoiceId1)' }
       * table invoiceLineData
         | invoiceLineId  | invoiceId  | poLineId | total | releaseEncumbrance | fundId | encumbranceId |
-        | invoiceLineId1 | invoiceId1 | poLineId | 100   | true               | fundId | encumbranceId |
+        | invoiceLineId1 | invoiceId1 | poLineId | 10    | true               | fundId | encumbranceId |
       * def v = call createInvoiceLine invoiceLineData
 
       # 5. Approve invoice and check the encumbrance transaction amount
@@ -58,7 +60,7 @@
       * def v = call createInvoice { id: '#(invoiceId2)' }
       * table invoiceLineData
         | invoiceLineId  | invoiceId  | poLineId | total | releaseEncumbrance | fundId | encumbranceId |
-        | invoiceLineId2 | invoiceId2 | poLineId | -100  | true               | fundId | encumbranceId |
+        | invoiceLineId2 | invoiceId2 | poLineId | -10   | false              | fundId | encumbranceId |
       * def v = call createInvoiceLine invoiceLineData
 
       # 8. Approve second invoice and check the encumbrance transaction amount

--- a/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
+++ b/acquisitions/src/test/java/org/folio/CrossModulesApiTest.java
@@ -36,53 +36,52 @@ public class CrossModulesApiTest extends TestBaseEureka implements AcquisitionsT
     FEATURE_10("change-poline-fd-and-pay-invoice", true),
     FEATURE_11("check-approve-and-pay-invoice-with-invoice-references-same-po-line", true),
     FEATURE_12("check-encumbrance-status-after-moving-expended-value", true),
-    FEATURE_13("check-encumbrances-after-issuing-credit-for-paid-order", true),
-    FEATURE_14("check-encumbrances-after-order-is-reopened", true),
-    FEATURE_15("check-encumbrances-after-order-is-reopened-2", true),
-    FEATURE_16("check-encumbrances-after-order-line-exchange-rate-update", true),
-    FEATURE_17("check-order-re-encumber-after-preview-rollover", true),
-    FEATURE_18("check-order-re-encumber-work-correctly", true),
-    FEATURE_19("check-order-total-fields-calculated-correctly", true),
-    FEATURE_20("check-payment-status-after-cancelling-paid-invoice", true),
-    FEATURE_21("check-paymentstatus-after-reopen", true),
-    FEATURE_22("check-po-numbers-updates", true),
-    FEATURE_23("check-po-numbers-updates-when-invoice-line-deleted", true),
-    FEATURE_24("create-order-and-approve-invoice-were-pol-without-fund-distributions", true),
-    FEATURE_25("create-order-and-invoice-with-odd-penny", true),
-    FEATURE_26("create-order-with-invoice-that-has-enough-money", true),
-    FEATURE_27("delete-encumbrance", true),
-    FEATURE_28("ledger-fiscal-year-rollover", true),
-    FEATURE_29("ledger-fiscal-year-rollover-cash-balance", true),
-    FEATURE_30("link-invoice-line-to-po-line", true),
-    FEATURE_31("MODFISTO-270-delete-planned-budget-without-transactions", true),
-    FEATURE_32("moving_encumbered_value_to_different_budget", true),
-    FEATURE_33("moving_expended_value_to_newly_created_encumbrance", true),
-    FEATURE_34("open-approve-and-pay-order-with-50-lines", true),
-    FEATURE_35("open-order-after-approving-invoice", true),
-    FEATURE_36("order-invoice-relation", true),
-    FEATURE_37("order-invoice-relation-can-be-changed", true),
-    FEATURE_38("order-invoice-relation-can-be-deleted", true),
-    FEATURE_39("order-invoice-relation-must-be-deleted-if-invoice-deleted", true),
-    FEATURE_40("partial-rollover", true),
-    FEATURE_41("pay-invoice-and-delete-piece", true),
-    FEATURE_42("pay-invoice-with-new-expense-class", true),
-    FEATURE_43("pay-invoice-without-order-acq-unit-permission", true),
-    FEATURE_44("pending-payment-update-after-encumbrance-deletion", true),
-    FEATURE_45("remove-fund-distribution-after-rollover-when-re-encumber-false", true),
-    FEATURE_46("remove_linked_invoice_lines_fund_distribution_encumbrance_reference", true),
-    FEATURE_47("rollover-and-pay-invoice-using-past-fiscal-year", true),
-    FEATURE_48("rollover-with-closed-order", true),
-    FEATURE_49("rollover-with-no-settings", true),
-    FEATURE_50("rollover-with-pending-order", true),
-    FEATURE_51("unopen-approve-invoice-reopen", true),
-    FEATURE_52("unopen-order-and-add-addition-pol-and-check-encumbrances", true),
-    FEATURE_53("unopen-order-simple-case", true),
-    FEATURE_54("update-encumbrance-links-with-fiscal-year", true),
-    FEATURE_55("update_fund_in_poline_when_invoice_approved", true),
-    FEATURE_56("rollover-multi-ledger", true),
-    FEATURE_57("rollover-many-orders-and-lines", false),
-    FEATURE_58("approve-invoice-with-different-fund-than-order", false),
-    FEATURE_59("rollover-one-order-type", false);
+    FEATURE_13("check-encumbrances-after-order-is-reopened", true),
+    FEATURE_14("check-encumbrances-after-order-is-reopened-2", true),
+    FEATURE_15("check-encumbrances-after-order-line-exchange-rate-update", true),
+    FEATURE_16("check-order-re-encumber-after-preview-rollover", true),
+    FEATURE_17("check-order-re-encumber-work-correctly", true),
+    FEATURE_18("check-order-total-fields-calculated-correctly", true),
+    FEATURE_19("check-payment-status-after-cancelling-paid-invoice", true),
+    FEATURE_20("check-paymentstatus-after-reopen", true),
+    FEATURE_21("check-po-numbers-updates", true),
+    FEATURE_22("check-po-numbers-updates-when-invoice-line-deleted", true),
+    FEATURE_23("create-order-and-approve-invoice-were-pol-without-fund-distributions", true),
+    FEATURE_24("create-order-and-invoice-with-odd-penny", true),
+    FEATURE_25("create-order-with-invoice-that-has-enough-money", true),
+    FEATURE_26("delete-encumbrance", true),
+    FEATURE_27("ledger-fiscal-year-rollover", true),
+    FEATURE_28("ledger-fiscal-year-rollover-cash-balance", true),
+    FEATURE_29("link-invoice-line-to-po-line", true),
+    FEATURE_30("MODFISTO-270-delete-planned-budget-without-transactions", true),
+    FEATURE_31("moving_encumbered_value_to_different_budget", true),
+    FEATURE_32("moving_expended_value_to_newly_created_encumbrance", true),
+    FEATURE_33("open-approve-and-pay-order-with-50-lines", true),
+    FEATURE_34("open-order-after-approving-invoice", true),
+    FEATURE_35("order-invoice-relation", true),
+    FEATURE_36("order-invoice-relation-can-be-changed", true),
+    FEATURE_37("order-invoice-relation-can-be-deleted", true),
+    FEATURE_38("order-invoice-relation-must-be-deleted-if-invoice-deleted", true),
+    FEATURE_39("partial-rollover", true),
+    FEATURE_40("pay-invoice-and-delete-piece", true),
+    FEATURE_41("pay-invoice-with-new-expense-class", true),
+    FEATURE_42("pay-invoice-without-order-acq-unit-permission", true),
+    FEATURE_43("pending-payment-update-after-encumbrance-deletion", true),
+    FEATURE_44("remove-fund-distribution-after-rollover-when-re-encumber-false", true),
+    FEATURE_45("remove_linked_invoice_lines_fund_distribution_encumbrance_reference", true),
+    FEATURE_46("rollover-and-pay-invoice-using-past-fiscal-year", true),
+    FEATURE_47("rollover-with-closed-order", true),
+    FEATURE_48("rollover-with-no-settings", true),
+    FEATURE_49("rollover-with-pending-order", true),
+    FEATURE_50("unopen-approve-invoice-reopen", true),
+    FEATURE_51("unopen-order-and-add-addition-pol-and-check-encumbrances", true),
+    FEATURE_52("unopen-order-simple-case", true),
+    FEATURE_53("update-encumbrance-links-with-fiscal-year", true),
+    FEATURE_54("update_fund_in_poline_when_invoice_approved", true),
+    FEATURE_55("rollover-multi-ledger", true),
+    FEATURE_56("rollover-many-orders-and-lines", false),
+    FEATURE_57("approve-invoice-with-different-fund-than-order", false),
+    FEATURE_58("rollover-one-order-type", false);
 
     private final String fileName;
     private final boolean isEnabled;
@@ -199,266 +198,260 @@ public class CrossModulesApiTest extends TestBaseEureka implements AcquisitionsT
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void checkEncumbrancesAfterIssuingCreditForPaidOrder() {
+  void checkEncumbrancesAfterOrderIsReopened() {
     runFeatureTest(Feature.FEATURE_13.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void checkEncumbrancesAfterOrderIsReopened() {
+  void checkEncumbrancesAfterOrderIsReopened2() {
     runFeatureTest(Feature.FEATURE_14.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void checkEncumbrancesAfterOrderIsReopened2() {
+  void checkEncumbrancesAfterOrderLineExchangeRateUpdate() {
     runFeatureTest(Feature.FEATURE_15.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void checkEncumbrancesAfterOrderLineExchangeRateUpdate() {
+  void checkOrderReEncumberAfterPreviewRollover() {
     runFeatureTest(Feature.FEATURE_16.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void checkOrderReEncumberAfterPreviewRollover() {
+  void checkOrderReEncumberWorksCorrectly() {
     runFeatureTest(Feature.FEATURE_17.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void checkOrderReEncumberWorksCorrectly() {
+  void checkOrderTotalFieldsCalculatedCorrectly() {
     runFeatureTest(Feature.FEATURE_18.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void checkOrderTotalFieldsCalculatedCorrectly() {
+  void checkPaymentStatusAfterCancellingPaidInvoice() {
     runFeatureTest(Feature.FEATURE_19.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void checkPaymentStatusAfterCancellingPaidInvoice() {
+  void checkPaymentStatusAfterReopen() {
     runFeatureTest(Feature.FEATURE_20.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void checkPaymentStatusAfterReopen() {
+  void checkPoNumbersUpdates() {
     runFeatureTest(Feature.FEATURE_21.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void checkPoNumbersUpdates() {
+  void checkPoNumbersUpdatesWhenIinvoiceLineDeleted() {
     runFeatureTest(Feature.FEATURE_22.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void checkPoNumbersUpdatesWhenIinvoiceLineDeleted() {
+  void createOrderAndApproveInvoiceWerePolWithoutFundDistributions() {
     runFeatureTest(Feature.FEATURE_23.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void createOrderAndApproveInvoiceWerePolWithoutFundDistributions() {
+  void createOrderAndInvoiceWithOddPenny() {
     runFeatureTest(Feature.FEATURE_24.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void createOrderAndInvoiceWithOddPenny() {
+  void createOrderWithInvoiceWithEnoughMoney() {
     runFeatureTest(Feature.FEATURE_25.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void createOrderWithInvoiceWithEnoughMoney() {
+  void deleteEncumbrance() {
     runFeatureTest(Feature.FEATURE_26.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void deleteEncumbrance() {
+  void ledgerRollover() {
     runFeatureTest(Feature.FEATURE_27.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void ledgerRollover() {
+  void ledgerFiscalYearRolloverCashBalance() {
     runFeatureTest(Feature.FEATURE_28.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void ledgerFiscalYearRolloverCashBalance() {
+  void linkInvoiceLineToPoLine() {
     runFeatureTest(Feature.FEATURE_29.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void linkInvoiceLineToPoLine() {
+  void deletePlannedBudgetWithoutTransactions() {
     runFeatureTest(Feature.FEATURE_30.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void deletePlannedBudgetWithoutTransactions() {
+  void movingEncumberedValueToDifferentBudget() {
     runFeatureTest(Feature.FEATURE_31.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void movingEncumberedValueToDifferentBudget() {
+  void movingExpendedValueToNewlyCreatedEncumbrance() {
     runFeatureTest(Feature.FEATURE_32.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void movingExpendedValueToNewlyCreatedEncumbrance() {
+  void openApproveAndPayOrderWith50Lines() {
     runFeatureTest(Feature.FEATURE_33.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void openApproveAndPayOrderWith50Lines() {
+  void openOrderAfterApprovingInvoice() {
     runFeatureTest(Feature.FEATURE_34.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void openOrderAfterApprovingInvoice() {
+  void orderInvoiceRelation() {
     runFeatureTest(Feature.FEATURE_35.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void orderInvoiceRelation() {
+  void orderInvoiceRelationCanBeChanged() {
     runFeatureTest(Feature.FEATURE_36.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void orderInvoiceRelationCanBeChanged() {
+  void orderInvoiceRelationCanBeDeleted() {
     runFeatureTest(Feature.FEATURE_37.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void orderInvoiceRelationCanBeDeleted() {
+  void order_invoice_relation_must_be_deleted_if_invoice_deleted() {
     runFeatureTest(Feature.FEATURE_38.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void order_invoice_relation_must_be_deleted_if_invoice_deleted() {
+  void partialRollover() {
     runFeatureTest(Feature.FEATURE_39.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void partialRollover() {
+  void payInvoiceAndDeletePiece() {
     runFeatureTest(Feature.FEATURE_40.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void payInvoiceAndDeletePiece() {
+  void payInvoiceWithNewExpenseClass() {
     runFeatureTest(Feature.FEATURE_41.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void payInvoiceWithNewExpenseClass() {
+  void payInvoiceWithoutOrderAcqUnitPermission() {
     runFeatureTest(Feature.FEATURE_42.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void payInvoiceWithoutOrderAcqUnitPermission() {
+  void pendingPaymentUpdateAfterEncumbranceDeletion() {
     runFeatureTest(Feature.FEATURE_43.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void pendingPaymentUpdateAfterEncumbranceDeletion() {
+  void removeFundDistributionAfterRolloverWhenReEncumberFalse() {
     runFeatureTest(Feature.FEATURE_44.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void removeFundDistributionAfterRolloverWhenReEncumberFalse() {
+  void removeLinkedInvoiceLinesFundDistributionEncumbranceReference() {
     runFeatureTest(Feature.FEATURE_45.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void removeLinkedInvoiceLinesFundDistributionEncumbranceReference() {
+  void rolloverAndPayInvoiceUsingPastFiscalYear() {
     runFeatureTest(Feature.FEATURE_46.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void rolloverAndPayInvoiceUsingPastFiscalYear() {
+  void rolloverWithClosedOrder() {
     runFeatureTest(Feature.FEATURE_47.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void rolloverWithClosedOrder() {
+  void rolloverWithNoSettings() {
     runFeatureTest(Feature.FEATURE_48.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void rolloverWithNoSettings() {
+  void rolloverWithPendingOrder() {
     runFeatureTest(Feature.FEATURE_49.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void rolloverWithPendingOrder() {
+  void unopenApproveInvoiceReopen() {
     runFeatureTest(Feature.FEATURE_50.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void unopenApproveInvoiceReopen() {
+  void unopen_order_and_add_addition_pol_and_check_encumbrances() {
     runFeatureTest(Feature.FEATURE_51.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void unopen_order_and_add_addition_pol_and_check_encumbrances() {
+  void unopen_order_simple_case() {
     runFeatureTest(Feature.FEATURE_52.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void unopen_order_simple_case() {
+  void updateEncumbranceLinksWithFiscalYear() {
     runFeatureTest(Feature.FEATURE_53.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void updateEncumbranceLinksWithFiscalYear() {
+  void updateFundInPoLineWhenInvoiceApproved() {
     runFeatureTest(Feature.FEATURE_54.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
-  void updateFundInPoLineWhenInvoiceApproved() {
-    runFeatureTest(Feature.FEATURE_55.getFileName());
-  }
-
-  @Test
-  @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void rolloverMultiLedger() {
-    runFeatureTest(Feature.FEATURE_56.getFileName());
+    runFeatureTest(Feature.FEATURE_55.getFileName());
   }
 
   @Test
@@ -466,18 +459,18 @@ public class CrossModulesApiTest extends TestBaseEureka implements AcquisitionsT
   @Disabled
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void rolloverManyOrdersAndLines() {
-    runFeatureTest(Feature.FEATURE_57.getFileName());
+    runFeatureTest(Feature.FEATURE_56.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void approveInvoiceWithDifferentFundThanOrder() {
-    runFeatureTest(Feature.FEATURE_58.getFileName());
+    runFeatureTest(Feature.FEATURE_57.getFileName());
   }
 
   @Test
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void rolloverOneOrderTypeFeature() {
-    runFeatureTest(Feature.FEATURE_59.getFileName());
+    runFeatureTest(Feature.FEATURE_58.getFileName());
   }
 }

--- a/acquisitions/src/test/java/org/folio/CrossModulesExtendedApiTest.java
+++ b/acquisitions/src/test/java/org/folio/CrossModulesExtendedApiTest.java
@@ -53,7 +53,8 @@ public class CrossModulesExtendedApiTest extends TestBaseEureka implements Acqui
     FEATURE_25("expense-class-percent-expended-when-budget-over-expended", true),
     FEATURE_26("rollover-settings-no-encumbrances", true),
     FEATURE_27("unreleased-encumbrance-rolled-over-to-next-fiscal-year", true),
-    FEATURE_28("invoice-encumbrance-update-without-acquisition-unit", true);
+    FEATURE_28("invoice-encumbrance-update-without-acquisition-unit", true),
+    FEATURE_29("encumbrance-remains-released-after-another-credited-invoice-was-paid", true);
 
     private final String fileName;
     private final boolean isEnabled;
@@ -298,6 +299,13 @@ public class CrossModulesExtendedApiTest extends TestBaseEureka implements Acqui
   @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
   void invoiceEncumbranceUpdateWithoutAcquisitionUnit() {
     runFeatureTest(Feature.FEATURE_28.getFileName());
+  }
+
+  @Test
+  @DisplayName("(Thunderjet) (C624240) Encumbrance remains released after another credited invoice was paid")
+  @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
+  void encumbranceRemainsReleasedAfterAnotherCreditedInvoiceWasPaid() {
+    runFeatureTest(Feature.FEATURE_29.getFileName());
   }
 
 }


### PR DESCRIPTION
## Purpose
[FAT-21205](https://folio-org.atlassian.net/browse/FAT-21205) - Thunderjet - Create Karate test - Encumbrance remains released after another credited invoice was paid

## Approach
Modified `check-encumbrances-after-issuing-credit-for-paid-order.feature` a little bit so it matches [C624240](https://foliotest.testrail.io/index.php?/cases/view/624240). Moved to extended tests.
