### PR TITLE
[FAT-21138] Already exported order is not included repeatedly in next exports

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/data-export-spring.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/data-export-spring.feature
@@ -22,3 +22,9 @@ Feature: mod-data-export-spring integration tests
 
   Scenario: Claims Export
     * call read('features/claims-export.feature')
+
+  Scenario: Already exported order is not included repeatedly in next exports AND title special characters are escaped in EDI
+    * call read('features/exported-order-not-repeated-in-next-exports.feature')
+
+  Scenario: Automatic export flag triggers EDIFACT orders export
+    * call read('features/automatic-export-flag-triggers-edifact-export.feature')

--- a/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/features/automatic-export-flag-triggers-edifact-export.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/features/automatic-export-flag-triggers-edifact-export.feature
@@ -1,0 +1,95 @@
+# For FAT-21136, https://foliotest.testrail.io/index.php?/cases/view/350543
+Feature: Verify, if Saved flag "automaticExport" in the POL supports EDIFACT orders export
+
+  Background:
+    * print karate.info.scenarioName
+    * url baseUrl
+
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+    * configure retry = { count: 12, interval: 5000 }
+
+    * def expCreateOrg = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@CreateOrganization')
+    * def expSetupOrgAcc = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@SetAccountToOrganization')
+    * def expCreateOrgOrder = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@CreateOrderForOrganization')
+    * def expCreateOrderLines = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@CreateOrderLines')
+    * def expOpenOrder = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@OpenOrder')
+    * def expAddOrgIntegration = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@AddIntegrationToOrganization')
+    * def expGetJobs = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@GetDataExportSpringJobsByType')
+
+
+  @C350543
+  @Positive
+  Scenario: PO line with automaticExport=true triggers EDIFACT orders export at scheduled WEEK time including today's day
+
+    #========================================================================================================
+    # Preconditions
+    #========================================================================================================
+
+    # 1. Create an organization
+    * def organizationId = call uuid1
+    * def organizationName = 'OrgName-C350543'
+    * def organizationCode = 'OrgCode-C350543'
+    * call expCreateOrg { extOrganizationId: #(organizationId), extOrganizationName: #(organizationName), extOrganizationCode: #(organizationCode) }
+
+    # 2. Create an Active account and attach it to the organization
+    * def account = read('classpath:thunderjet/mod-data-export-spring/features/samples/account-for-organization.json')
+    * def accountName = 'OrgAccountName-C350543'
+    * def accountNo = 'OrgAccountNo-C350543'
+    * account.name = accountName
+    * account.accountNo = accountNo
+
+    * call expSetupOrgAcc { extOrganizationId: #(organizationId), extAccounts: [#(account)] }
+
+    # 3. Create a One-time order in Pending status for the vendor (Manual option = disabled is the default)
+    * def orderId = call uuid1
+    * def poNumber = 'PoNumberC350543'
+    * call expCreateOrgOrder { extOrderId: #(orderId), extOrganizationId: #(organizationId), extPoNumber: #(poNumber) }
+
+    #========================================================================================================
+    # TestRail Case Steps
+    #========================================================================================================
+
+    # 4. Add a PO line with acquisitionMethod=Purchase, automaticExport=true (saved flag under test), valid vendor account number
+    * def poLineId = call uuid1
+    * call expCreateOrderLines { extPoLineId: #(poLineId), extOrderId: #(orderId), extOrganizationId: #(organizationId), extAccountNumber: #(accountNo) }
+
+    # 5. Open the order
+    * call expOpenOrder { extOrderId: #(orderId)}
+
+    # Pause if necessary so the integration scheduleTime lands on a clean minute boundary
+    * call pause waitIfNecessary('UTC')
+
+    # 6. Add integration to the organization: Ordering type, Purchase acquisition method, FTP, WEEKLY schedule with today's day included, scheduleTime = current time + 1 min
+    * def exportConfigId = call uuid1
+
+    * def ediScheduleFrequency = 1
+    * def ediSchedulePeriod = 'WEEK'
+    * def ediScheduleTime = nextZonedTimeAsLocaleSettings('UTC', 1)
+    * def ediScheduleWeekDays = ['SATURDAY', 'FRIDAY', 'THURSDAY', 'WEDNESDAY', 'TUESDAY', 'MONDAY', 'SUNDAY']
+    * def ediScheduleTimeZone = 'UTC'
+    * call expAddOrgIntegration { extExportConfigId: #(exportConfigId), extOrganizationId: #(organizationId), extAccountNoList: [#(accountNo)], extEdiScheduleFrequency: #(ediScheduleFrequency), extEdiSchedulePeriod: #(ediSchedulePeriod), extEdiScheduleTime: #(ediScheduleTime), extEdiScheduleWeekDays: #(ediScheduleWeekDays), extEdiScheduleTimeZone: #(ediScheduleTimeZone)}
+
+    # Pause 70 seconds so the scheduled export executes
+    * call pause 70000
+
+    # 7. Search created job - verify it was successfully ran and a file was exported
+    * def dataExportSpringJobsByType = call expGetJobs
+    * def fun = function(job) {return job.isSystemSource && job.exportTypeSpecificParameters.vendorEdiOrdersExportConfig.exportConfigId == exportConfigId}
+    * def jobs = karate.filter(dataExportSpringJobsByType.response.jobRecords, fun)
+
+    And assert karate.sizeOf(jobs) == 1
+    * def job = jobs[0]
+    And retry until job.status == 'SUCCESSFUL'
+
+    # 8. Download the EDI file and verify it contains expected EDIFACT order segments (UNH/UNB header for ORDERS message + UNT/UNZ trailers)
+    Given path 'data-export-spring/jobs', job.id, 'download'
+    When method GET
+    Then status 200
+    And string actualEdiFile = response
+    And match actualEdiFile contains 'UNB+UNOC'
+    And match actualEdiFile contains 'BGM+220'
+    And match actualEdiFile contains 'UNZ+1'
+

--- a/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/features/exported-order-not-repeated-in-next-exports.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/features/exported-order-not-repeated-in-next-exports.feature
@@ -1,0 +1,112 @@
+# For FAT-21138, https://foliotest.testrail.io/index.php?/cases/view/358971
+Feature: Already exported order is not included repeatedly in next exports AND title special characters are escaped in EDI
+
+  Background:
+    * print karate.info.scenarioName
+    * url baseUrl
+
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+    * configure retry = { count: 12, interval: 5000 }
+
+    * def expCreateOrg = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@CreateOrganization')
+    * def expSetupOrgAcc = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@SetAccountToOrganization')
+    * def expCreateOrgOrder = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@CreateOrderForOrganization')
+    * def expCreateOrderLines = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@CreateOrderLines')
+    * def expOpenOrder = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@OpenOrder')
+    * def expAddOrgIntegration = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@AddIntegrationToOrganization')
+    * def expUpdateOrgIntegration = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@UpdateIntegrationOfOrganization')
+    * def expGetJobs = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@GetDataExportSpringJobsByType')
+
+
+  @C358971
+  @Positive
+  Scenario: Already exported order is not included repeatedly in next exports AND title special characters are escaped in EDI (ediSchedulePeriod = 'DAY')
+
+    #========================================================================================================
+    # Preconditions
+    #========================================================================================================
+
+    # 1. Create an organization (vendor)
+    * def organizationId = call uuid1
+    * def organizationName = 'OrgName-6'
+    * def organizationCode = 'OrgCode-6'
+    * call expCreateOrg { extOrganizationId: #(organizationId), extOrganizationName: #(organizationName), extOrganizationCode: #(organizationCode) }
+
+    # 2. Create an active account, and set it to the organization
+    * def account = read('classpath:thunderjet/mod-data-export-spring/features/samples/account-for-organization.json')
+    * def accountName = 'OrgAccountName-6'
+    * def accountNo = 'OrgAccountNo-6'
+    * account.name = accountName
+    * account.accountNo = accountNo
+
+    * call expSetupOrgAcc { extOrganizationId: #(organizationId), extAccounts: [#(account)] }
+
+    # 3. Create purchase order for the organization
+    * def orderId = call uuid1
+    * def poNumber = 'PoNumber6'
+    * call expCreateOrgOrder { extOrderId: #(orderId), extOrganizationId: #(organizationId), extPoNumber: #(poNumber) }
+
+    # 4. Create PO Line for the order with title containing single quote, question mark and colon (Purchase acquisition method + automatic export are already defaults in the sample)
+    * def poLineId = call uuid1
+    * def titleOrPackage = "Test's example: title?"
+    * call expCreateOrderLines { extPoLineId: #(poLineId), extOrderId: #(orderId), extOrganizationId: #(organizationId), extAccountNumber: #(accountNo), extTitleOrPackage: #(titleOrPackage) }
+
+    # 5. Open the order
+    * call expOpenOrder { extOrderId: #(orderId)}
+
+    # Pause if necessary
+    * call pause waitIfNecessary('UTC')
+
+    # 6. Add integration to the organization (1st scheduled export)
+    * def exportConfigId = call uuid1
+
+    * def ediScheduleFrequency = 1
+    * def ediSchedulePeriod = 'DAY'
+    * def ediScheduleTime = nextZonedTimeAsLocaleSettings('UTC', 1)
+    * def ediScheduleTimeZone = 'UTC'
+    * call expAddOrgIntegration { extExportConfigId: #(exportConfigId), extOrganizationId: #(organizationId), extAccountNoList: [#(accountNo)], extEdiScheduleFrequency: #(ediScheduleFrequency), extEdiSchedulePeriod: #(ediSchedulePeriod), extEdiScheduleTime: #(ediScheduleTime), extEdiScheduleTimeZone: #(ediScheduleTimeZone)}
+
+    # Pause for a minute ('delay' = 1 minute) so the first scheduled run executes - this represents "Preconditions item #4 (One order export was performed after opening order)"
+    * call pause 65000
+
+    #========================================================================================================
+    # TestRail Case Steps
+    #========================================================================================================
+    
+    # 7. Locate the last successful export job for the integration
+    * def dataExportSpringJobsByType = call expGetJobs
+    * def fun = function(job) {return job.isSystemSource && job.exportTypeSpecificParameters.vendorEdiOrdersExportConfig.exportConfigId == exportConfigId}
+    * def jobs = karate.filter(dataExportSpringJobsByType.response.jobRecords, fun)
+
+    And assert karate.sizeOf(jobs) == 1
+    * def firstJob = jobs[0]
+    And retry until firstJob.status == 'SUCCESSFUL'
+
+    # 8. Download exported .edi file and verify title section escapes '?', single-quote, ':' with leading '?' (UN/EDIFACT release character)
+    Given path 'data-export-spring/jobs', firstJob.id, 'download'
+    When method GET
+    Then status 200
+    And string actualEdiFile = response
+    And match actualEdiFile contains "IMD+L+050+:::Test?'s example?: title??'"
+
+    # 9. "Rerun" - re-schedule the same export config to fire again
+    * call pause waitIfNecessary('UTC')
+    * def ediScheduleTimeRerun = nextZonedTimeAsLocaleSettings('UTC', 1)
+    * call expUpdateOrgIntegration { extExportConfigId: #(exportConfigId), extEdiScheduleTime: #(ediScheduleTimeRerun) }
+
+    # Pause for a minute so the second scheduled run executes
+    * call pause 65000
+
+    # 10. Verify rerun job has FAILED status because the already-exported order is NOT included again, and "Entities not found: PurchaseOrder" error is reported
+    * def dataExportSpringJobsAfterRerun = call expGetJobs
+    * def allJobs = karate.filter(dataExportSpringJobsAfterRerun.response.jobRecords, fun)
+
+    And assert karate.sizeOf(allJobs) == 2
+    * def sortedJobs = karate.sort(allJobs, function(j){ return j.metadata.createdDate })
+    * def lastIndex = karate.sizeOf(sortedJobs) - 1
+    * def rerunJob = sortedJobs[lastIndex]
+    And retry until rerunJob.status == 'FAILED'
+    And retry until rerunJob.errorDetails == 'Entities not found: PurchaseOrder (NotFoundException)'

--- a/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/features/util/initData.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/features/util/initData.feature
@@ -74,6 +74,7 @@ Feature: Init data for mod-data-export-spring
     * poLineEntityRequest.physical.materialSupplier = karate.get('extMaterialSupplier', globalVendorId)
     * poLineEntityRequest.eresource.materialType = karate.get('extMaterialTypeId', globalMaterialTypeIdElec)
     * poLineEntityRequest.vendorDetail.vendorAccount = karate.get('extAccountNumber', 'default account number')
+    * poLineEntityRequest.titleOrPackage = karate.get('extTitleOrPackage', poLineEntityRequest.titleOrPackage)
 
     Given path 'orders/order-lines'
     And request poLineEntityRequest
@@ -127,3 +128,27 @@ Feature: Init data for mod-data-export-spring
     And param query = '(type==' + exportType + ')'
     When method GET
     Then status 200
+
+  @UpdateIntegrationOfOrganization
+  Scenario: Re-schedule existing integration (export config) of organization
+    # parameters: extExportConfigId, extEdiScheduleTime (optional: extEdiScheduleFrequency, extEdiSchedulePeriod, extEdiScheduleWeekDays, extEdiScheduleTimeZone)
+    * def configId = karate.get('extExportConfigId')
+
+    # Get current export config
+    Given path 'data-export-spring/configs', configId
+    When method GET
+    Then status 200
+    * json exportConfig = response
+
+    # Update schedule parameters
+    * set exportConfig.exportTypeSpecificParameters.vendorEdiOrdersExportConfig.ediSchedule.scheduleParameters.scheduleFrequency = karate.get('extEdiScheduleFrequency', exportConfig.exportTypeSpecificParameters.vendorEdiOrdersExportConfig.ediSchedule.scheduleParameters.scheduleFrequency)
+    * set exportConfig.exportTypeSpecificParameters.vendorEdiOrdersExportConfig.ediSchedule.scheduleParameters.schedulePeriod = karate.get('extEdiSchedulePeriod', exportConfig.exportTypeSpecificParameters.vendorEdiOrdersExportConfig.ediSchedule.scheduleParameters.schedulePeriod)
+    * set exportConfig.exportTypeSpecificParameters.vendorEdiOrdersExportConfig.ediSchedule.scheduleParameters.scheduleTime = karate.get('extEdiScheduleTime', exportConfig.exportTypeSpecificParameters.vendorEdiOrdersExportConfig.ediSchedule.scheduleParameters.scheduleTime)
+    * set exportConfig.exportTypeSpecificParameters.vendorEdiOrdersExportConfig.ediSchedule.scheduleParameters.weekDays = karate.get('extEdiScheduleWeekDays', exportConfig.exportTypeSpecificParameters.vendorEdiOrdersExportConfig.ediSchedule.scheduleParameters.weekDays)
+    * set exportConfig.exportTypeSpecificParameters.vendorEdiOrdersExportConfig.ediSchedule.scheduleParameters.timeZone = karate.get('extEdiScheduleTimeZone', exportConfig.exportTypeSpecificParameters.vendorEdiOrdersExportConfig.ediSchedule.scheduleParameters.timeZone)
+
+    # Put updated export config
+    Given path 'data-export-spring/configs', configId
+    And request exportConfig
+    When method PUT
+    Then status 204

--- a/acquisitions/src/test/java/org/folio/DataExportSpringExtendedApiTest.java
+++ b/acquisitions/src/test/java/org/folio/DataExportSpringExtendedApiTest.java
@@ -1,0 +1,94 @@
+package org.folio;
+
+import org.apache.commons.lang3.RandomUtils;
+import org.folio.shared.AcquisitionsTest;
+import org.folio.test.TestBaseEureka;
+import org.folio.test.annotation.FolioTest;
+import org.folio.test.config.CommonFeature;
+import org.folio.test.config.TestModuleConfiguration;
+import org.folio.test.services.TestIntegrationService;
+import org.folio.test.services.TestRailService;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledIfSystemProperty;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+import java.util.UUID;
+
+@Order(18)
+@FolioTest(team = "thunderjet", module = "mod-data-export-spring")
+class DataExportSpringExtendedApiTest extends TestBaseEureka implements AcquisitionsTest {
+
+  private static final String TEST_BASE_PATH = "classpath:thunderjet/mod-data-export-spring/features/";
+  private static final String TEST_TENANT = "testexportext";
+  private static final int THREAD_COUNT = 1; // Scheduled EDI export tests must run sequentially (shared quartz scheduler / minute-boundary timing)
+
+  private enum Feature implements CommonFeature {
+    FEATURE_1("exported-order-not-repeated-in-next-exports", true),
+    FEATURE_2("automatic-export-flag-triggers-edifact-export", true);
+
+    private final String fileName;
+    private final boolean isEnabled;
+
+    Feature(String fileName, boolean isEnabled) {
+      this.fileName = fileName;
+      this.isEnabled = isEnabled;
+    }
+
+    public boolean isEnabled() {
+      return isEnabled;
+    }
+
+    public String getFileName() {
+      return fileName;
+    }
+  }
+
+  public DataExportSpringExtendedApiTest() {
+    super(new TestIntegrationService(new TestModuleConfiguration(TEST_BASE_PATH)), new TestRailService());
+  }
+
+  @BeforeAll
+  @Override
+  public void beforeAll() {
+    System.setProperty("testTenant", TEST_TENANT + RandomUtils.nextLong());
+    System.setProperty("testTenantId", UUID.randomUUID().toString());
+    runFeature("classpath:thunderjet/mod-data-export-spring/init-data-export-spring.feature");
+  }
+
+  @AfterAll
+  @Override
+  public void afterAll() {
+    try {
+      runFeature("classpath:common/eureka/destroy-data.feature");
+    } finally {
+      super.afterAll();
+    }
+  }
+
+  @Test
+  @Override
+  @DisplayName("(Thunderjet) Run features")
+  @DisabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
+  public void runFeatures() {
+    runFeatures(Feature.values(), THREAD_COUNT, null);
+  }
+
+  @Test
+  @DisplayName("(Thunderjet) (C358971) Already exported order is not included repeatedly in next exports")
+  @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
+  void alreadyExportedOrderNotRepeated() {
+    runFeatureTest(Feature.FEATURE_1.getFileName());
+  }
+
+  @Test
+  @DisplayName("(Thunderjet) (C350543) Saved automaticExport flag in PO line supports EDIFACT orders export")
+  @EnabledIfSystemProperty(named = "test.mode", matches = "no-shared-pool")
+  void automaticExportFlagTriggersEdifactExport() {
+    runFeatureTest(Feature.FEATURE_2.getFileName());
+  }
+}
+


### PR DESCRIPTION
## Purpose
[[FAT-21138](https://folio-org.atlassian.net/browse/FAT-21138)] Already exported order is not included repeatedly in next exports
[[FAT-21136](https://folio-org.atlassian.net/browse/FAT-21136)] Verify, if Saved flag "automaticExport" in the POL supports EDIFACT orders export

## Approach
Implement tests
<img width="739" height="218" alt="image" src="https://github.com/user-attachments/assets/995ab1a7-17c9-4d04-836f-d27544da45ee" />
