### PR TITLE
FAT-26453. Karate test fail: [thunderjet/mod-data-export-spring] DataExportSpringExtendedApiTest

### DIFF
--- a/acquisitions/ai/ACQ_ORDERS_SYSTEM_PROMPT.md
+++ b/acquisitions/ai/ACQ_ORDERS_SYSTEM_PROMPT.md
@@ -431,7 +431,7 @@ And match response.paymentStatus == 'Payment Not Required'
 
 ### Dynamic Test Data
 - Use `call uuid` for unique IDs
-- Generate unique tenant names: `"testorders" + RandomUtils.nextLong()`
+- Generate unique tenant names: `SharedTenantOptions.generateTenantName("testorders")` (do NOT use `+ RandomUtils.nextLong()` — its unbounded 19-digit suffix can overflow FOLIO's 31-char tenant name limit)
 - Create test-specific resources to avoid conflicts
 
 ## Error Handling & Debugging

--- a/acquisitions/src/test/java/org/folio/ConsortiaOrdersApiTest.java
+++ b/acquisitions/src/test/java/org/folio/ConsortiaOrdersApiTest.java
@@ -1,7 +1,7 @@
 package org.folio;
 
-import org.apache.commons.lang3.RandomUtils;
 import org.folio.shared.AcquisitionsTest;
+import org.folio.shared.SharedTenantOptions;
 import org.folio.test.TestBaseEureka;
 import org.folio.test.annotation.FolioTest;
 import org.folio.test.config.TestModuleConfiguration;
@@ -43,7 +43,7 @@ class ConsortiaOrdersApiTest extends TestBaseEureka implements AcquisitionsTest 
   @BeforeAll
   @Override
   public void beforeAll() {
-    System.setProperty("testTenant", TENANT + RandomUtils.nextLong());
+    System.setProperty("testTenant", SharedTenantOptions.generateTenantName(TENANT));
     System.setProperty("testTenantId", UUID.randomUUID().toString());
     runFeature("classpath:thunderjet/consortia/init-consortia-orders.feature");
   }

--- a/acquisitions/src/test/java/org/folio/DataExportSpringExtendedApiTest.java
+++ b/acquisitions/src/test/java/org/folio/DataExportSpringExtendedApiTest.java
@@ -1,7 +1,7 @@
 package org.folio;
 
-import org.apache.commons.lang3.RandomUtils;
 import org.folio.shared.AcquisitionsTest;
+import org.folio.shared.SharedTenantOptions;
 import org.folio.test.TestBaseEureka;
 import org.folio.test.annotation.FolioTest;
 import org.folio.test.config.TestModuleConfiguration;
@@ -45,7 +45,7 @@ class DataExportSpringExtendedApiTest extends TestBaseEureka implements Acquisit
   @BeforeAll
   @Override
   public void beforeAll() {
-    System.setProperty("testTenant", TEST_TENANT + RandomUtils.nextLong());
+    System.setProperty("testTenant", SharedTenantOptions.generateTenantName(TEST_TENANT));
     System.setProperty("testTenantId", UUID.randomUUID().toString());
     runFeature("classpath:thunderjet/mod-data-export-spring/init-data-export-spring.feature");
   }

--- a/acquisitions/src/test/java/org/folio/EbsconetApiTest.java
+++ b/acquisitions/src/test/java/org/folio/EbsconetApiTest.java
@@ -1,7 +1,7 @@
 package org.folio;
 
-import org.apache.commons.lang3.RandomUtils;
 import org.folio.shared.AcquisitionsTest;
+import org.folio.shared.SharedTenantOptions;
 import org.folio.test.TestBaseEureka;
 import org.folio.test.annotation.FolioTest;
 import org.folio.test.config.TestModuleConfiguration;
@@ -48,7 +48,7 @@ public class EbsconetApiTest extends TestBaseEureka implements AcquisitionsTest 
   @BeforeAll
   @Override
   public void beforeAll() {
-    System.setProperty("testTenant", TEST_TENANT + RandomUtils.nextLong());
+    System.setProperty("testTenant", SharedTenantOptions.generateTenantName(TEST_TENANT));
     System.setProperty("testTenantId", UUID.randomUUID().toString());
     runFeature("classpath:thunderjet/mod-ebsconet/init-ebsconet.feature");
   }

--- a/acquisitions/src/test/java/org/folio/FinanceApiTest.java
+++ b/acquisitions/src/test/java/org/folio/FinanceApiTest.java
@@ -1,7 +1,7 @@
 package org.folio;
 
-import org.apache.commons.lang3.RandomUtils;
 import org.folio.shared.AcquisitionsTest;
+import org.folio.shared.SharedTenantOptions;
 import org.folio.test.TestBaseEureka;
 import org.folio.test.annotation.FolioTest;
 import org.folio.test.config.TestModuleConfiguration;
@@ -76,7 +76,7 @@ public class FinanceApiTest extends TestBaseEureka implements AcquisitionsTest {
   @BeforeAll
   @Override
   public void beforeAll() {
-    System.setProperty("testTenant", TEST_TENANT + RandomUtils.nextLong());
+    System.setProperty("testTenant", SharedTenantOptions.generateTenantName(TEST_TENANT));
     System.setProperty("testTenantId", UUID.randomUUID().toString());
     runFeature("classpath:thunderjet/mod-finance/init-finance.feature");
   }

--- a/acquisitions/src/test/java/org/folio/GobiApiTest.java
+++ b/acquisitions/src/test/java/org/folio/GobiApiTest.java
@@ -1,7 +1,7 @@
 package org.folio;
 
-import org.apache.commons.lang3.RandomUtils;
 import org.folio.shared.AcquisitionsTest;
+import org.folio.shared.SharedTenantOptions;
 import org.folio.test.TestBaseEureka;
 import org.folio.test.annotation.FolioTest;
 import org.folio.test.config.TestModuleConfiguration;
@@ -47,7 +47,7 @@ class GobiApiTest extends TestBaseEureka implements AcquisitionsTest {
   @BeforeAll
   @Override
   public void beforeAll() {
-    System.setProperty("testTenant", TEST_TENANT + RandomUtils.nextLong());
+    System.setProperty("testTenant", SharedTenantOptions.generateTenantName(TEST_TENANT));
     System.setProperty("testTenantId", UUID.randomUUID().toString());
     runFeature("classpath:thunderjet/mod-gobi/init-gobi.feature");
   }

--- a/acquisitions/src/test/java/org/folio/GobiExtendedApiTest.java
+++ b/acquisitions/src/test/java/org/folio/GobiExtendedApiTest.java
@@ -1,7 +1,7 @@
 package org.folio;
 
-import org.apache.commons.lang3.RandomUtils;
 import org.folio.shared.AcquisitionsTest;
+import org.folio.shared.SharedTenantOptions;
 import org.folio.test.TestBaseEureka;
 import org.folio.test.annotation.FolioTest;
 import org.folio.test.config.TestModuleConfiguration;
@@ -48,7 +48,7 @@ class GobiExtendedApiTest extends TestBaseEureka implements AcquisitionsTest {
   @BeforeAll
   @Override
   public void beforeAll() {
-    System.setProperty("testTenant", TEST_TENANT + RandomUtils.nextLong());
+    System.setProperty("testTenant", SharedTenantOptions.generateTenantName(TEST_TENANT));
     System.setProperty("testTenantId", UUID.randomUUID().toString());
     runFeature("classpath:thunderjet/mod-gobi/init-gobi.feature");
   }

--- a/acquisitions/src/test/java/org/folio/MosaicApiTest.java
+++ b/acquisitions/src/test/java/org/folio/MosaicApiTest.java
@@ -1,7 +1,7 @@
 package org.folio;
 
-import org.apache.commons.lang3.RandomUtils;
 import org.folio.shared.AcquisitionsTest;
+import org.folio.shared.SharedTenantOptions;
 import org.folio.test.TestBaseEureka;
 import org.folio.test.annotation.FolioTest;
 import org.folio.test.config.TestModuleConfiguration;
@@ -52,7 +52,7 @@ class MosaicApiTest extends TestBaseEureka implements AcquisitionsTest {
   @BeforeAll
   @Override
   public void beforeAll() {
-    System.setProperty("testTenant", TEST_TENANT + RandomUtils.nextLong());
+    System.setProperty("testTenant", SharedTenantOptions.generateTenantName(TEST_TENANT));
     System.setProperty("testTenantId", UUID.randomUUID().toString());
     runFeature("classpath:thunderjet/mod-mosaic/init-mosaic.feature");
   }

--- a/acquisitions/src/test/java/org/folio/OrganizationsApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrganizationsApiTest.java
@@ -1,7 +1,7 @@
 package org.folio;
 
-import org.apache.commons.lang3.RandomUtils;
 import org.folio.shared.AcquisitionsTest;
+import org.folio.shared.SharedTenantOptions;
 import org.folio.test.TestBaseEureka;
 import org.folio.test.annotation.FolioTest;
 import org.folio.test.config.TestModuleConfiguration;
@@ -43,7 +43,7 @@ public class OrganizationsApiTest extends TestBaseEureka implements Acquisitions
   @BeforeAll
   @Override
   public void beforeAll() {
-    System.setProperty("testTenant", TEST_TENANT + RandomUtils.nextLong());
+    System.setProperty("testTenant", SharedTenantOptions.generateTenantName(TEST_TENANT));
     System.setProperty("testTenantId", UUID.randomUUID().toString());
     runFeature("classpath:thunderjet/mod-organizations/init-organizations.feature");
   }

--- a/acquisitions/src/test/java/org/folio/shared/SharedTenantOptions.java
+++ b/acquisitions/src/test/java/org/folio/shared/SharedTenantOptions.java
@@ -6,6 +6,19 @@ import java.util.UUID;
 
 public class SharedTenantOptions {
 
+  private static final long TENANT_SUFFIX_BOUND = 1_000_000_000L;
+
+  /**
+   * Generates a tenant name as {@code prefix + bounded-random-suffix} that complies with the
+   * FOLIO tenant name regex {@code [a-z][a-z0-9_]{0,29}[a-z0-9]} (max 31 chars).
+   *
+   * @param prefix Lowercase tenant prefix (must be ≤ 22 chars to stay within the 31-char limit)
+   * @return tenant name with a numeric suffix of at most 9 digits
+   */
+  public static String generateTenantName(String prefix) {
+    return prefix + RandomUtils.insecure().randomLong(0, TENANT_SUFFIX_BOUND);
+  }
+
   /**
    *  Returns a property object containing tenant name, tenant id and the destroy option, which are
    *  needed for {@code AcquisitionsTest.beforeAll() and AcquisitionsTest.afterAll()} operation.
@@ -22,7 +35,7 @@ public class SharedTenantOptions {
     var tenantId = System.getProperty("tenant-id");
     var destroy = Boolean.parseBoolean(System.getProperty("destroy"));
     if (tenantName == null || tenantId == null) {
-      tenantName = tenantPrefix + RandomUtils.nextLong();
+      tenantName = generateTenantName(tenantPrefix);
       tenantId = UUID.randomUUID().toString();
     }
     return new TenantData(tenantName, tenantId, destroy);


### PR DESCRIPTION
## Purpose
Fix issues like that: https://jenkins.ci.folio.org/job/folioScheduledTesting/job/runNightlyKarateEurekaTests/831/testReport/junit/thunderjet.mod-data-export-spring/init-data-export-spring/Create_tenant_and_test_user/

### Summary                                                                                                                                                                                                                        
                                                                                                                                                                                                                                 
Fixes intermittent CI failures where tenant creation returned 400 validation_error because the generated tenant name exceeded FOLIO's 31-character limit.                                                                      
   
### Root cause                                                                                                                                                                                                                     
                                                            
  TEST_TENANT + RandomUtils.nextLong() produced suffixes up to 19 digits long. With prefixes like testexportext (13) or testconsortia (13), the resulting name was 32 chars — one over the limit — failing the regex
  [a-z][a-z0-9_]{0,29}[a-z0-9].

### Changes

  - Added SharedTenantOptions.generateTenantName(prefix) helper that bounds the suffix to 9 digits, keeping total length within 31 chars.
  - Migrated 8 test classes to use the helper instead of inline + RandomUtils.nextLong().
  - Updated ACQ_ORDERS_SYSTEM_PROMPT.md so AI-generated tests follow the same pattern.
