### PR TITLE
FAT-26697, FAT-26698 Karate test fail: [thunderjet/mod-data-export-spring] DataExportSpringExtendedApiTest {2} thunderjet/mod-data-export-spring/features/*.feature

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/features/automatic-export-flag-triggers-edifact-export.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/features/automatic-export-flag-triggers-edifact-export.feature
@@ -11,6 +11,8 @@ Feature: Verify, if Saved flag "automaticExport" in the POL supports EDIFACT ord
     * configure headers = headersUser
     * configure retry = { count: 12, interval: 5000 }
 
+    * call read('classpath:thunderjet/mod-data-export-spring/features/util/initHelpers.feature')
+
     * def expCreateOrg = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@CreateOrganization')
     * def expSetupOrgAcc = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@SetAccountToOrganization')
     * def expCreateOrgOrder = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@CreateOrderForOrganization')

--- a/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/features/edifact-orders-export.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/features/edifact-orders-export.feature
@@ -11,6 +11,8 @@ Feature: EDIFACT orders export tests
     * configure headers = headersUser
     * configure retry = { count: 12, interval: 5000 }
 
+    * call read('classpath:thunderjet/mod-data-export-spring/features/util/initHelpers.feature')
+
   Scenario: If there is an open order for organization and organization has integration method with the same acquisition method as order THEN export job should be triggered and be 'SUCCESSFUL' (ediSchedulePeriod = 'DAY')
     # Create an organization
     * def extOrganizationId = call uuid1

--- a/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/features/exported-order-not-repeated-in-next-exports.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/features/exported-order-not-repeated-in-next-exports.feature
@@ -11,6 +11,8 @@ Feature: Already exported order is not included repeatedly in next exports AND t
     * configure headers = headersUser
     * configure retry = { count: 12, interval: 5000 }
 
+    * call read('classpath:thunderjet/mod-data-export-spring/features/util/initHelpers.feature')
+
     * def expCreateOrg = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@CreateOrganization')
     * def expSetupOrgAcc = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@SetAccountToOrganization')
     * def expCreateOrgOrder = read('classpath:thunderjet/mod-data-export-spring/features/util/initData.feature@CreateOrderForOrganization')

--- a/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/features/util/initHelpers.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/features/util/initHelpers.feature
@@ -1,0 +1,10 @@
+Feature: Shared init for mod-data-export-spring test features
+  Loads global variables used across data-export-spring scenarios.
+
+  Scenario: init
+    * callonce variables
+
+    * def nextZonedTimeAsLocaleSettings = read('classpath:thunderjet/mod-data-export-spring/features/util/get-next-time-function.js')
+    * def currentDayOfWeek = read('classpath:thunderjet/mod-data-export-spring/features/util/get-day-of-week-function.js')
+    * def waitIfNecessary = read('classpath:thunderjet/mod-data-export-spring/features/util/determine-if-wait-necessary-function.js')
+

--- a/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/init-data-export-spring.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-data-export-spring/init-data-export-spring.feature
@@ -83,11 +83,6 @@ Feature: Initialize mod-data-export-spring integration tests
       | 'inventory-storage.service-points.item.post'                  |
       | 'organizations.organizations.item.post'                       |
 
-    * callonce variables
-
-    * def nextZonedTimeAsLocaleSettings = read('features/util/get-next-time-function.js')
-    * def currentDayOfWeek = read('features/util/get-day-of-week-function.js')
-    * def waitIfNecessary = read('features/util/determine-if-wait-necessary-function.js')
 
 
   Scenario: Create tenant and test user


### PR DESCRIPTION
## Purpose
Fix issues like that: 

https://jenkins.ci.folio.org/job/folioScheduledTesting/job/runNightlyKarateEurekaTests/833/testReport/junit/thunderjet.mod-data-export-spring.features/automatic-export-flag-triggers-edifact-export/PO_line_with_automaticExport_true_triggers_EDIFACT_orders_export_at_scheduled_WEEK_time_including_today_s_day/

https://jenkins.ci.folio.org/job/folioScheduledTesting/job/runNightlyKarateEurekaTests/833/testReport/junit/thunderjet.mod-data-export-spring.features/exported-order-not-repeated-in-next-exports/Already_exported_order_is_not_included_repeatedly_in_next_exports_AND_title_special_characters_are_escaped_in_EDI__ediSchedulePeriod____DAY__/

## Summary
Fixed ReferenceError: globalVendorId/waitIfNecessary is not defined in DataExportSpringExtendedApiTest extracting shared variable and JS helper definitions into a reusable initHelpers.feature and removing the dead definitions from init-data-export-spring.feature.


## Root cause
Karate feature scopes are isolated - variables defined in init-data-export-spring.feature (via callonce variables and JS helper defs) were only available when features ran as called sub-features through the data-export-spring.feature wrapper (which merges parent scope into children). When DataExportSpringExtendedApiTest runs each feature standalone via runFeatures(), every feature starts with a fresh empty scope, so globalVendorId, waitIfNecessary, and other helpers were never defined, causing the ReferenceError at JS evaluation.

## Evaluation

Tests before the fix:
<img width="1428" height="427" alt="image" src="https://github.com/user-attachments/assets/a73b6b5d-ae04-4c38-94ef-c5dd5fde6214" />

After:
<img width="1097" height="311" alt="image" src="https://github.com/user-attachments/assets/28cb5747-92a6-4173-8e0e-a22c3aa52358" />




