### PR TITLE
[MODORDERS-1439] Increase pause further for slow execution

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/helpers/helper-order-status-automatic-change.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/helpers/helper-order-status-automatic-change.feature
@@ -16,7 +16,7 @@ Feature: Helper for "close-order-when-fully-paid-and-received"
     * def v = call updateOrderLine { id: '#(poLineId)', paymentStatus: '#(newPaymentStatus)', receiptStatus: '#(newReceiptStatus)' }
 
     # 10. Wait for a potential order status update
-    * call pause 500
+    * call pause 1000
 
     # 11. Check order's expected workflow status
     Given path 'orders/composite-orders', orderId
@@ -35,7 +35,7 @@ Feature: Helper for "close-order-when-fully-paid-and-received"
     * if (newReceiptStatus == 'Awaiting Receipt') karate.call('classpath:thunderjet/mod-orders/reusable/unreceive-piece-like-ui.feature', { pieceId: pieceId, poLineId: poLineId })
 
     # 10. Wait for a potential order status update
-    * call pause 500
+    * call pause 1000
 
     # 11. Check order's expected workflow status
     Given path 'orders/composite-orders', orderId


### PR DESCRIPTION
## Purpose
Increase pause for slow execution (nightly run)

## Approach
Pause 1000ms instead of 500ms (was 100ms initially).
Waiting for the right status would not be a better solution, because the status changes during that time.

### TODOS and Open Questions
- Improve mod-orders performance when opening orders !
- Also, nightly runs seem to be very slow compared to local ones (possibly 10x). This should be improved as well.