### PR TITLE
FAT-20836: Add scenario to export requests to CSV after deleting the last printed request

### DIFF
--- a/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
@@ -167,6 +167,7 @@ Feature: mod-circulation integration tests
       | 'mod-settings.global.read.mod-circulation'                    |
       | 'mod-settings.global.read.circulation'                        |
       | 'feesfines.accounts-bulk.check-waive.post'                    |
+      | 'users.item.delete'                                           |
       | 'circulation-storage.circulation-rules.get'                   |
       | 'locale.item.get'                                             |
       | 'locale.item.put'                                             |

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/print-events.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/print-events.feature
@@ -397,7 +397,6 @@ Feature: Print events tests
 
   @C1307937
   Scenario: Requests can be exported to CSV if user last printed request was deleted
-    # For UIREQ-1305
     * def extMaterialTypeId = call uuid1
     * def extItemId = call uuid1
     * def extUser1Id = call uuid1
@@ -406,7 +405,8 @@ Feature: Print events tests
     * def settingId = call uuid1
 
     # post material type and item
-    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(extMaterialTypeId), extMaterialTypeName: 'print-deleted-user-type' }
+    * def extMaterialTypeName = 'print-deleted-user-type-' + java.util.UUID.randomUUID()
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(extMaterialTypeId), extMaterialTypeName: '#(extMaterialTypeName)' }
     * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(extItemId), extItemBarcode: 'FAT-1305IBC', extStatusName: 'Available', extMaterialTypeId: #(extMaterialTypeId), extHoldingsRecordId: #(holdingId) }
 
     # create User 1 (requester)

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/print-events.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/print-events.feature
@@ -394,3 +394,89 @@ Feature: Print events tests
 
     # clear extMaterialTypeName so it does not bleed into features called after this one
     * def extMaterialTypeName = null
+
+  @C1307937
+  Scenario: Requests can be exported to CSV if user last printed request was deleted
+    # For UIREQ-1305
+    * def extMaterialTypeId = call uuid1
+    * def extItemId = call uuid1
+    * def extUser1Id = call uuid1
+    * def extUser2Id = call uuid1
+    * def requestId = call uuid1
+    * def settingId = call uuid1
+
+    # post material type and item
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(extMaterialTypeId), extMaterialTypeName: 'print-deleted-user-type' }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(extItemId), extItemBarcode: 'FAT-1305IBC', extStatusName: 'Available', extMaterialTypeId: #(extMaterialTypeId), extHoldingsRecordId: #(holdingId) }
+
+    # create User 1 (requester)
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(extUser1Id), extUserBarcode: 'FAT-1305UBC', extGroupId: #(fourthUserGroupId) }
+
+    # enable print event log feature (precondition step 1)
+    * def circulationSettingRequest = read('classpath:vega/mod-circulation/features/samples/circulation-settings/circulation-setting.json')
+    * circulationSettingRequest.id = settingId
+    * circulationSettingRequest.name = 'printEventLogFeature'
+    * circulationSettingRequest.value.enablePrintLog = 'true'
+    Given path 'circulation', 'settings'
+    And request circulationSettingRequest
+    When method POST
+    Then status 201
+
+    # create a Page request for User 1 (precondition step 2)
+    * def requestEntityRequest = read('classpath:vega/mod-circulation/features/samples/request/request-entity-request.json')
+    * requestEntityRequest.id = requestId
+    * requestEntityRequest.itemId = extItemId
+    * requestEntityRequest.requesterId = extUser1Id
+    * requestEntityRequest.requestType = 'Page'
+    * requestEntityRequest.holdingsRecordId = holdingId
+    * requestEntityRequest.requestLevel = 'Item'
+    Given path 'circulation', 'requests'
+    And request requestEntityRequest
+    When method POST
+    Then status 201
+
+    # create User 2 (the printer, precondition step 3)
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostUser') { extUserId: #(extUser2Id), extUserBarcode: 'FAT-1306UBC', extGroupId: #(fourthUserGroupId), firstName: 'PrinterUser' }
+
+    # User 2 prints pick slip for the request (precondition step 3)
+    * def printEventsRequest = read('classpath:vega/mod-circulation/features/samples/print-events/print-events-request.json')
+    * printEventsRequest.requestIds = [requestId]
+    * printEventsRequest.requesterId = extUser2Id
+    * printEventsRequest.requesterName = 'PrinterUser'
+    * printEventsRequest.printEventDate = '2024-08-06T14:10:00.000+00:00'
+    Given path 'circulation', 'print-events-entry'
+    And request printEventsRequest
+    When method POST
+    Then status 204
+
+    # delete User 2 (precondition step 4)
+    Given path 'users', extUser2Id
+    When method DELETE
+    Then status 204
+
+    # Step 1: Page request is present in results, only print date is shown (no user name)
+    Given path 'circulation', 'requests'
+    And param query = 'id==' + requestId
+    When method GET
+    Then status 200
+    And match response.requests[0].id == requestId
+    And match response.requests[0].requestType == 'Page'
+    And match response.requests[0].printDetails.printCount == 1
+    And match response.requests[0].printDetails.printEventDate == '#present'
+    And match response.requests[0].printDetails.lastPrintRequester == '#notpresent'
+
+    # Steps 3/4: Export search results (CSV) — GET /circulation/requests succeeds with print date only
+    Given path 'circulation', 'requests'
+    And param query = 'id==' + requestId
+    And param limit = 100
+    When method GET
+    Then status 200
+    And assert response.totalRecords >= 1
+    And match response.requests[0].printDetails.printCount == 1
+    And match response.requests[0].printDetails.printEventDate == '#present'
+    And match response.requests[0].printDetails.lastPrintRequester == '#notpresent'
+
+    # cleanup circulation setting
+    Given path 'circulation/' + 'settings/' + settingId
+    When method DELETE
+    Then status 204

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/print-events.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/print-events.feature
@@ -480,3 +480,5 @@ Feature: Print events tests
     Given path 'circulation/' + 'settings/' + settingId
     When method DELETE
     Then status 204
+
+    * def extMaterialTypeName = null


### PR DESCRIPTION
## Purpose
Add automated test for UIREQ-1305 — verifying that requests can be searched and exported to CSV when the last user who printed a pick slip has been deleted.

## Approach
Added scenario @C1307937 to print-events.feature. The test enables the print log feature, creates a Page request, prints a pick slip as User 2, deletes User 2, then asserts that GET /circulation/requests returns the request with printCount == 1, printEventDate present, and lastPrintRequester absent. A second GET with limit=100 (simulating CSV export) confirms the same behaviour. The users.item.delete permission was added to circulation-junit.feature to support user deletion. 

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
[FAT-20836](https://folio-org.atlassian.net/browse/FAT-20836)

## Report
<img width="1892" height="285" alt="image" src="https://github.com/user-attachments/assets/0061b926-ad52-43e5-a7b6-57ab4604019f" />
