### PR TITLE
[FAT-21313] Expense classes of transactions are updated correctly when Expense classes of Fund were switched in one POL

### DIFF
--- a/acquisitions/ai/ACQ_CROSS_MODULES_SYSTEM_PROMPT.md
+++ b/acquisitions/ai/ACQ_CROSS_MODULES_SYSTEM_PROMPT.md
@@ -30,6 +30,7 @@ You are an expert in FOLIO library system cross-module integration testing using
 `headersUser` is used to query `mod-orders`, `mod-invoice`, `mod-finance` and `mod-organizations` APIs (this user has permission to use these APIs).
 For any other module (such as the storage modules), `headersAdmin` should be used.
 `configure` is used to change the header. It is initialized to `headersUser` in `Background` and can be changed in a feature. It applies to all requests until changed again, so if a block needs one header, there is no need to use `configure` within. Typically, `headersUser` is used by default, and when `headersAdmin` is needed, it is set before and reset to `headersUser` afterward.
+**Never add `* configure headers = headersUser` at the very end of a scenario** — it has no effect because the scenario is already finishing, and the `Background` resets headers for the next scenario anyway.
 Permissions are defined for the 2 users in `init-cross-modules.feature`.
 
 ### Parallel Execution Control

--- a/acquisitions/ai/ACQ_ORDERS_SYSTEM_PROMPT.md
+++ b/acquisitions/ai/ACQ_ORDERS_SYSTEM_PROMPT.md
@@ -29,6 +29,7 @@ You are an expert in FOLIO library system integration testing using Karate frame
 `headersUser` is used to query `mod-orders`, `mod-orders-storage` and `inventory` APIs (this user has permission to use these APIs).
 For any other module (such as `mod-finance` when creating budgets and funds), `headersAdmin` should be used.
 `configure` is used to change the header. It is initialized to `headersUser` in `Background` and can be changed in a feature. It applies to all requests until changed again, so if a block needs one header, there is no need to use `configure` within. Typically, `headersUser` is used by default, and when `headersAdmin` is needed, it is set before and reset to `headersUser` afterward.
+**Never add `* configure headers = headersUser` at the very end of a scenario** — it has no effect because the scenario is already finishing, and the `Background` resets headers for the next scenario anyway.
 Permissions are defined for the 2 users in `init-orders.feature`.
 
 ### Parallel Execution Control

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/encumbrance-expense-class-switch-two-distributions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/encumbrance-expense-class-switch-two-distributions.feature
@@ -42,15 +42,15 @@ Feature: Encumbrance Expense Class Switch In Two Fund Distributions
     * def v = call openOrder { orderId: '#(orderId)' }
 
     # 5. Switch Expense Classes In Both Fund Distribution Records (Electronic -> Print And Print -> Electronic)
-    * def orderLineResponse = call getOrderLine { poLineId: '#(poLineId)' }
-    * def updatedFundDistribution = orderLineResponse.poLine.fundDistribution
+    * call getOrderLine { poLineId: '#(poLineId)' }
+    * def updatedFundDistribution = poLine.fundDistribution
     * set updatedFundDistribution[0].expenseClassId = globalPrnExpenseClassId
     * set updatedFundDistribution[1].expenseClassId = globalElecExpenseClassId
     * def v = call updateOrderLine { id: '#(poLineId)', fundDistribution: '#(updatedFundDistribution)' }
 
     # 6. Verify That Both Fund Distribution Records Have The Switched Expense Classes
-    * def orderLineResponse = call getOrderLine { poLineId: '#(poLineId)' }
-    * def fundDistribution = orderLineResponse.poLine.fundDistribution
+    * call getOrderLine { poLineId: '#(poLineId)' }
+    * def fundDistribution = poLine.fundDistribution
     And match fundDistribution[0].expenseClassId == globalPrnExpenseClassId
     And match fundDistribution[1].expenseClassId == globalElecExpenseClassId
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/encumbrance-expense-class-switch-two-distributions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/encumbrance-expense-class-switch-two-distributions.feature
@@ -1,0 +1,77 @@
+# For MODORDERS-1039, https://foliotest.testrail.io/index.php?/cases/view/451477
+Feature: Encumbrance Expense Class Switch In Two Fund Distributions
+
+  Background:
+    * print karate.info.scenarioName
+    * url baseUrl
+
+    * callonce login testAdmin
+    * def okapitokenAdmin = okapitoken
+    * callonce login testUser
+    * def okapitokenUser = okapitoken
+    * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': 'application/json', 'x-okapi-tenant': '#(testTenant)' }
+    * configure headers = headersUser
+    * configure retry = { count: 10, interval: 500 }
+
+    * callonce variables
+
+
+  @C451477
+  @Positive
+  Scenario: Encumbrance Expense Classes Are Updated After Switching Expense Classes In Two Fund Distributions Of One POL
+    # 1. Generate Unique Identifiers For This Test Scenario
+    * def fundId = call uuid
+    * def budgetId = call uuid
+    * def orderId = call uuid
+    * def poLineId = call uuid
+
+    # 2. Create Fund And Budget With Print And Electronic Expense Classes
+    * configure headers = headersAdmin
+    * def statusExpenseClasses = [ { expenseClassId: '#(globalPrnExpenseClassId)', status: 'Active' }, { expenseClassId: '#(globalElecExpenseClassId)', status: 'Active' } ]
+    * def v = call createFund { id: '#(fundId)' }
+    * def v = call createBudget { id: '#(budgetId)', fundId: '#(fundId)', allocated: 1000, statusExpenseClasses: '#(statusExpenseClasses)' }
+
+    # 3. Create Order With One POL Having Two Fund Distributions (Same Fund, 50% Electronic + 50% Print)
+    * configure headers = headersUser
+    * def v = call createOrder { id: '#(orderId)' }
+    * def fundDistribution = [ { fundId: '#(fundId)', code: '#(fundId)', distributionType: 'percentage', value: 50.0, expenseClassId: '#(globalElecExpenseClassId)' }, { fundId: '#(fundId)', code: '#(fundId)', distributionType: 'percentage', value: 50.0, expenseClassId: '#(globalPrnExpenseClassId)' } ]
+    * def v = call createOrderLine { id: '#(poLineId)', orderId: '#(orderId)', listUnitPrice: 10, fundDistribution: '#(fundDistribution)' }
+
+    # 4. Open The Order
+    * def v = call openOrder { orderId: '#(orderId)' }
+
+    # 5. Switch Expense Classes In Both Fund Distribution Records (Electronic -> Print And Print -> Electronic)
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+    * def poLine = $
+    * set poLine.fundDistribution[0].expenseClassId = globalPrnExpenseClassId
+    * set poLine.fundDistribution[1].expenseClassId = globalElecExpenseClassId
+
+    Given path 'orders/order-lines', poLineId
+    And request poLine
+    When method PUT
+    Then status 204
+
+    # 6. Verify That Both Fund Distribution Records Have The Switched Expense Classes
+    Given path 'orders/order-lines', poLineId
+    When method GET
+    Then status 200
+    * def fundDistribution = $.fundDistribution
+    And match fundDistribution[0].expenseClassId == globalPrnExpenseClassId
+    And match fundDistribution[1].expenseClassId == globalElecExpenseClassId
+
+    # 7. Verify That Both Encumbrance Transactions Have The Updated Expense Classes
+    * configure headers = headersAdmin
+    Given path 'finance/transactions'
+    And param query = 'transactionType==Encumbrance and encumbrance.sourcePurchaseOrderId==' + orderId
+    When method GET
+    Then status 200
+    And match $.totalRecords == 2
+    * def transaction1 = karate.jsonPath(response, "$.transactions[?(@.id=='" + fundDistribution[0].encumbrance + "')]")[0]
+    * def transaction2 = karate.jsonPath(response, "$.transactions[?(@.id=='" + fundDistribution[1].encumbrance + "')]")[0]
+    And match transaction1.expenseClassId == globalPrnExpenseClassId
+    And match transaction2.expenseClassId == globalElecExpenseClassId
+    * configure headers = headersUser
+

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/encumbrance-expense-class-switch-two-distributions.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/encumbrance-expense-class-switch-two-distributions.feature
@@ -42,23 +42,15 @@ Feature: Encumbrance Expense Class Switch In Two Fund Distributions
     * def v = call openOrder { orderId: '#(orderId)' }
 
     # 5. Switch Expense Classes In Both Fund Distribution Records (Electronic -> Print And Print -> Electronic)
-    Given path 'orders/order-lines', poLineId
-    When method GET
-    Then status 200
-    * def poLine = $
-    * set poLine.fundDistribution[0].expenseClassId = globalPrnExpenseClassId
-    * set poLine.fundDistribution[1].expenseClassId = globalElecExpenseClassId
-
-    Given path 'orders/order-lines', poLineId
-    And request poLine
-    When method PUT
-    Then status 204
+    * def orderLineResponse = call getOrderLine { poLineId: '#(poLineId)' }
+    * def updatedFundDistribution = orderLineResponse.poLine.fundDistribution
+    * set updatedFundDistribution[0].expenseClassId = globalPrnExpenseClassId
+    * set updatedFundDistribution[1].expenseClassId = globalElecExpenseClassId
+    * def v = call updateOrderLine { id: '#(poLineId)', fundDistribution: '#(updatedFundDistribution)' }
 
     # 6. Verify That Both Fund Distribution Records Have The Switched Expense Classes
-    Given path 'orders/order-lines', poLineId
-    When method GET
-    Then status 200
-    * def fundDistribution = $.fundDistribution
+    * def orderLineResponse = call getOrderLine { poLineId: '#(poLineId)' }
+    * def fundDistribution = orderLineResponse.poLine.fundDistribution
     And match fundDistribution[0].expenseClassId == globalPrnExpenseClassId
     And match fundDistribution[1].expenseClassId == globalElecExpenseClassId
 
@@ -73,5 +65,4 @@ Feature: Encumbrance Expense Class Switch In Two Fund Distributions
     * def transaction2 = karate.jsonPath(response, "$.transactions[?(@.id=='" + fundDistribution[1].encumbrance + "')]")[0]
     And match transaction1.expenseClassId == globalPrnExpenseClassId
     And match transaction2.expenseClassId == globalElecExpenseClassId
-    * configure headers = headersUser
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
@@ -111,6 +111,9 @@ Feature: mod-orders integration tests
   Scenario: Encumbrance update after expense class change
     * call read('features/encumbrance-update-after-expense-class-change.feature')
 
+  Scenario: Encumbrance expense class switch in two fund distributions
+    * call read('features/encumbrance-expense-class-switch-two-distributions.feature')
+
   Scenario: Handling of expense classes for order and lines
     * call read('features/expense-class-handling-for-order-and-lines.feature')
 

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/update-order-line.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/reusable/update-order-line.feature
@@ -1,6 +1,6 @@
 @ignore
 Feature: Update order line
-  # parameters: id, titleOrPackage?, paymentStatus?, receiptStatus?, listUnitPrice?
+  # parameters: id, titleOrPackage?, paymentStatus?, receiptStatus?, listUnitPrice?, fundDistribution?
 
   Background:
     * print karate.info.scenarioName
@@ -17,6 +17,7 @@ Feature: Update order line
     * set poLine.receiptStatus = karate.get('receiptStatus', poLine.receiptStatus)
     * set poLine.cost.listUnitPrice = karate.get('listUnitPrice', poLine.cost.listUnitPrice)
     * set poLine.cost.poLineEstimatedPrice = karate.get('listUnitPrice', poLine.cost.listUnitPrice)
+    * set poLine.fundDistribution = karate.get('fundDistribution', poLine.fundDistribution)
 
     Given path 'orders/order-lines', id
     And request poLine

--- a/acquisitions/src/test/java/org/folio/OrdersApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersApiTest.java
@@ -54,7 +54,6 @@ class OrdersApiTest extends TestBaseEureka implements AcquisitionsTest {
     "encumbrance-released-when-order-closes",
     "encumbrance-tags-inheritance",
     "encumbrance-update-after-expense-class-change",
-    "encumbrance-expense-class-switch-two-distributions",
     "expense-class-handling-for-order-and-lines",
     "find-holdings-by-location-and-instance-for-mixed-pol",
     "fund-codes-in-open-order-error",

--- a/acquisitions/src/test/java/org/folio/OrdersApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersApiTest.java
@@ -54,6 +54,7 @@ class OrdersApiTest extends TestBaseEureka implements AcquisitionsTest {
     "encumbrance-released-when-order-closes",
     "encumbrance-tags-inheritance",
     "encumbrance-update-after-expense-class-change",
+    "encumbrance-expense-class-switch-two-distributions",
     "expense-class-handling-for-order-and-lines",
     "find-holdings-by-location-and-instance-for-mixed-pol",
     "fund-codes-in-open-order-error",

--- a/acquisitions/src/test/java/org/folio/OrdersExtendedApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersExtendedApiTest.java
@@ -58,7 +58,8 @@ class OrdersExtendedApiTest extends TestBaseEureka implements AcquisitionsTest {
     "item-under-holdings-after-instance-connection-change-create-new",
     "pe-mix-change-instance-connection-find-create-delete-holdings",
     "unopen-open-order-with-pol-and-fund-distribution",
-    "open-order-with-resolution-statuses"
+    "open-order-with-resolution-statuses",
+    "encumbrance-expense-class-switch-two-distributions"
 };
 
   public OrdersExtendedApiTest() {


### PR DESCRIPTION
## Purpose
[FAT-21313](https://folio-org.atlassian.net/browse/FAT-21313)  Expense classes of transactions are updated correctly when Expense classes of Fund were switched in one POL

## Approach
Implements karate test
<img width="1912" height="453" alt="image" src="https://github.com/user-attachments/assets/1a22994d-e48f-41ef-a8b8-2fb6eb3dadf5" />


### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
