### PR TITLE
FAT-20839: Add feature to verify requester departments in pick slips

### DIFF
--- a/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/circulation-junit.feature
@@ -170,4 +170,5 @@ Feature: mod-circulation integration tests
       | 'circulation-storage.circulation-rules.get'                   |
       | 'locale.item.get'                                             |
       | 'locale.item.put'                                             |
+      | 'departments.item.post'                                       |
     Given call read('classpath:common/eureka/setup-users.feature@addUserCapabilities')

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
@@ -2064,3 +2064,55 @@ Feature: Requests tests
     When method GET
     Then status 200
     And match $.id == requestUuid
+
+  @C396391
+  Scenario: Verify requester.departments is populated in pick slip
+    * def extItemId = call uuid1
+    * def extUserId = call uuid1
+    * def extDepartmentId = call uuid1
+    * def extMaterialTypeId = call uuid1
+    * def extLocationId = call uuid1
+    * def extServicePointId = call uuid1
+    * def extHoldingId = call uuid1
+    * def extHoldingSourceId = call uuid1
+    * def extHoldingSourceName = random_string()
+    * def extItemBarcode = 'FAT-396391IBC'
+    * def extUserBarcode = 'FAT-396391UBC'
+    * def extDepartmentName = 'dept-' + java.util.UUID.randomUUID()
+    * def extMaterialTypeName = 'pick-slip-dept-mat-' + java.util.UUID.randomUUID()
+
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostServicePoint') { extServicePointId: #(extServicePointId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostLocation') { extLocationId: #(extLocationId) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostHoldings') { extHoldingSourceId: #(extHoldingSourceId), extHoldingSourceName: #(extHoldingSourceName), extLocationId: #(extLocationId), extHoldingsRecordId: #(extHoldingId) }
+
+    # post a material type and item
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostMaterialType') { extMaterialTypeId: #(extMaterialTypeId), extMaterialTypeName: #(extMaterialTypeName) }
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostItem') { extItemId: #(extItemId), extItemBarcode: #(extItemBarcode), extMaterialTypeId: #(extMaterialTypeId), extHoldingsRecordId: #(extHoldingId) }
+
+    # post a department
+    Given path 'departments'
+    And request { id: '#(extDepartmentId)', name: '#(extDepartmentName)', code: '#(extDepartmentName)' }
+    When method POST
+    Then status 201
+
+    # post a user with the department assigned
+    * def userEntityRequest = read('classpath:vega/mod-circulation/features/samples/user/user-entity-request.json')
+    * userEntityRequest.id = extUserId
+    * userEntityRequest.barcode = extUserBarcode
+    * userEntityRequest.patronGroup = fourthUserGroupId
+    * userEntityRequest.departments = [extDepartmentId]
+    Given path 'users'
+    And request userEntityRequest
+    When method POST
+    Then status 201
+
+    # post a Page request
+    * def extRequestId = call uuid1
+    * call read('classpath:vega/mod-circulation/features/util/initData.feature@PostRequest') { requestId: #(extRequestId), itemId: #(extItemId), requesterId: #(extUserId), extRequestType: 'Page', extRequestLevel: 'Item', extInstanceId: #(instanceId), extHoldingsRecordId: #(extHoldingId), extServicePointId: #(extServicePointId) }
+
+    # get pick slips and verify requester.departments is populated
+    Given path 'circulation', 'pick-slips', extServicePointId
+    When method GET
+    Then status 200
+    And match $.pickSlips[0].requester.barcode == extUserBarcode
+    And match $.pickSlips[0].requester.departments == extDepartmentName

--- a/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
+++ b/mod-circulation/src/main/resources/vega/mod-circulation/features/requests.feature
@@ -2159,3 +2159,5 @@ Feature: Requests tests
     Then status 200
     And match $.pickSlips[0].requester.barcode == extUserBarcode
     And match $.pickSlips[0].requester.departments == extDepartmentName
+
+    * def extMaterialTypeName = null


### PR DESCRIPTION
## Purpose
Verify that {{requester.departments}} token is populated in the pick slip (TestRail C396391).

## Approach
Added @C396391 scenario to requests.feature (alongside the existing pick slip test). The scenario creates a department via POST /departments, assigns it to a requester user, places a Page request, then calls GET /circulation/pick-slips/{servicePointId} and asserts requester.departments is populated
Added departments.item.post permission to circulation-junit.feature to support the new API call.

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
[FAT-20839](https://folio-org.atlassian.net/browse/FAT-20839)

## Report
<img width="1557" height="874" alt="image" src="https://github.com/user-attachments/assets/83c465a4-fcc6-4418-8989-b231fb0a4628" />
