### PR TITLE
[MODORDERS-1439] Added a sleep and optimized parallel execution

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/helpers/helper-order-status-automatic-change.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/helpers/helper-order-status-automatic-change.feature
@@ -68,19 +68,22 @@ Feature: Helper for "close-order-when-fully-paid-and-received"
     # 4. Receive the piece if initialReceiptStatus is Fully Received
     * if (initialReceiptStatus == 'Fully Received' && !checkinItems) karate.call('classpath:thunderjet/mod-orders/reusable/receive-piece-with-holding.feature', { pieceId: pieceId, poLineId: poLineId })
 
-    # 5. Set po line initial statuses
+    # 5. Wait for a potential order status update
+    * if (initialReceiptStatus == 'Fully Received' && !checkinItems) java.lang.Thread.sleep(1000)
+
+    # 6. Set po line initial statuses
     * def v = call updateOrderLine { id: '#(poLineId)', paymentStatus: '#(initialPaymentStatus)', receiptStatus: '#(initialReceiptStatus)' }
 
-    # 6. Close order if initialWorkflowStatus is Closed
+    # 7. Close order if initialWorkflowStatus is Closed
     * if (initialWorkflowStatus == 'Closed') karate.call('classpath:thunderjet/mod-orders/reusable/close-order.feature', { orderId: orderId })
 
-    # 7. Wait for order's initial workflow status
+    # 8. Wait for order's initial workflow status
     Given path 'orders/composite-orders', orderId
     And retry until response.workflowStatus == initialWorkflowStatus
     When method GET
     Then status 200
 
-    # 8. Check po line initial statuses have not changed
+    # 9. Check po line initial statuses have not changed
     Given path '/orders/order-lines', poLineId
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
@@ -17,6 +17,14 @@ Feature: mod-orders integration tests
     * configure afterFeature = function() { karate.call('classpath:common/eureka/destroy-data.feature'); }
 
 
+  # SLOW FEATURES - moved to the top so that a complete execution with threads finishes earlier
+  Scenario: Check opening an order links to the right instance
+    * call read('features/open-order-instance-link.feature')
+
+  Scenario: Order status automatic change caused by a po line update
+    * call read('features/order-status-automatic-change.feature')
+  # END OF SLOW FEATURES
+
   Scenario: Add piece to cancelled order
     * call read('features/add-piece-to-cancelled-order.feature')
 
@@ -165,9 +173,6 @@ Feature: mod-orders integration tests
   Scenario: Open order failure side effects
     * call read('features/open-order-failure-side-effects.feature')
 
-  Scenario: Check opening an order links to the right instance
-    * call read('features/open-order-instance-link.feature')
-
   Scenario: Open order success with expenditure restrictions
     * call read('features/open-order-success-with-expenditure-restrictions.feature')
 
@@ -191,9 +196,6 @@ Feature: mod-orders integration tests
 
   Scenario: Open order with restricted locations
     * call read('features/open-order-with-restricted-locations.feature')
-
-  Scenario: Order status automatic change caused by a po line update
-    * call read('features/order-status-automatic-change.feature')
 
   Scenario: Should open order with polines having the same fund distributions
     * call read('features/open-order-with-the-same-fund-distributions.feature')

--- a/acquisitions/src/test/java/org/folio/OrdersApiTest.java
+++ b/acquisitions/src/test/java/org/folio/OrdersApiTest.java
@@ -32,6 +32,10 @@ class OrdersApiTest extends TestBaseEureka implements AcquisitionsTest {
   private static final int THREAD_COUNT = 4;
 
   private static final String[] FEATURES = {
+    // SLOW FEATURES - moved to the top so that a complete execution with threads finishes earlier
+    "open-order-instance-link",
+    "order-status-automatic-change",
+    // END OF SLOW FEATURES
     "bind-piece",
     "cancel-and-delete-order",
     "cancel-item-after-canceling-poline-in-multi-line-orders",
@@ -45,7 +49,6 @@ class OrdersApiTest extends TestBaseEureka implements AcquisitionsTest {
     "check-re-encumber-property",
     "close-order-and-release-encumbrances",
     "close-order-including-lines",
-    "order-status-automatic-change",
     "create-five-pieces",
     "create-open-composite-order",
     "create-order-that-has-not-enough-money",
@@ -70,7 +73,6 @@ class OrdersApiTest extends TestBaseEureka implements AcquisitionsTest {
     "open-ongoing-order",
     "open-ongoing-order-if-interval-or-renewaldate-notset",
     "open-order-failure-side-effects",
-    "open-order-instance-link",
     "open-order-success-with-expenditure-restrictions",
     "open-orders-with-poLines",
     "open-order-with-different-po-line-currency",


### PR DESCRIPTION
## Purpose
Fixed one particular case in order-status-automatic-change.feature, which required waiting after receiving a piece.
Also optimized parallel execution for mod-orders tests by moving the slow ones to the top of the list.
