### PR TITLE
[MODORDERS-1462] Reduced pause after changing order settings

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-instance-link.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-instance-link.feature
@@ -72,7 +72,7 @@ Feature: Check opening an order links to the right instance based on the identif
     And request { "id": "#(settingId)", "key": "disableInstanceMatching", "value": "{\"isInstanceMatchingDisabled\":true}" }
     When method POST
     Then status 201
-    * def v = call pause 65000
+    * def v = call pause 31000
     * configure headers = headersUser
 
     # Create Second Order With Disabled Instance Matching
@@ -105,7 +105,7 @@ Feature: Check opening an order links to the right instance based on the identif
     And request setting
     When method PUT
     Then status 204
-    * def v = call pause 65000
+    * def v = call pause 31000
     * configure headers = headersUser
 
     # Create Third Order And Verify Instance Matching Re-Enabled

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/orders.feature
@@ -23,6 +23,9 @@ Feature: mod-orders integration tests
 
   Scenario: Order status automatic change caused by a po line update
     * call read('features/order-status-automatic-change.feature')
+
+  Scenario: Update PO lines when an order is cancelled
+    * call read('features/update-po-lines-when-order-cancelled.feature')
   # END OF SLOW FEATURES
 
   Scenario: Add piece to cancelled order
@@ -331,9 +334,6 @@ Feature: mod-orders integration tests
 
   Scenario: Unopen order with synchronized and independent POLs deletes only empty holding
     * call read('features/unopen-order-delete-empty-holding-mixed-pols.feature')
-
-  Scenario: Update PO lines when an order is cancelled
-    * call read('features/update-po-lines-when-order-cancelled.feature')
 
   Scenario: P/E Mix change instance connection create new holdings and delete abandoned holdings
     * call read('features/pe-mix-change-instance-connection-create-new-delete-holdings.feature')


### PR DESCRIPTION
## Purpose
[MODORDERS-1462](https://folio-org.atlassian.net/browse/MODORDERS-1462) - Changing settings takes a long time to be effective

## Approach
- Reduced pause to from 65s to 31s after changing order settings
- Moved `update-po-lines-when-order-cancelled` to the list of slow features to speed up overall execution

## Related PRs
- [mod-orders](https://github.com/folio-org/mod-orders/pull/1336)