### PR TITLE
MODORDERS-1462. Use cache value as in mod-orders-storage

### DIFF
--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-instance-link.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-instance-link.feature
@@ -72,7 +72,7 @@ Feature: Check opening an order links to the right instance based on the identif
     And request { "id": "#(settingId)", "key": "disableInstanceMatching", "value": "{\"isInstanceMatchingDisabled\":true}" }
     When method POST
     Then status 201
-    * def v = call pause 31000
+    * def v = call pause 61000
     * configure headers = headersUser
 
     # Create Second Order With Disabled Instance Matching
@@ -105,7 +105,7 @@ Feature: Check opening an order links to the right instance based on the identif
     And request setting
     When method PUT
     Then status 204
-    * def v = call pause 31000
+    * def v = call pause 61000
     * configure headers = headersUser
 
     # Create Third Order And Verify Instance Matching Re-Enabled

--- a/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-instance-link.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-orders/features/open-order-instance-link.feature
@@ -10,6 +10,7 @@ Feature: Check opening an order links to the right instance based on the identif
     * callonce login testUser
     * def okapitokenUser = okapitoken
     * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)' }
+    * def headersUserBypassCache = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenUser)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)', 'x-okapi-bypass-cache': 'true' }
     * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitokenAdmin)', 'Accept': '*/*', 'x-okapi-tenant': '#(testTenant)' }
     * configure headers = headersUser
 
@@ -72,8 +73,7 @@ Feature: Check opening an order links to the right instance based on the identif
     And request { "id": "#(settingId)", "key": "disableInstanceMatching", "value": "{\"isInstanceMatchingDisabled\":true}" }
     When method POST
     Then status 201
-    * def v = call pause 61000
-    * configure headers = headersUser
+    * configure headers = headersUserBypassCache
 
     # Create Second Order With Disabled Instance Matching
     * def v = call createOrder { 'id': '#(orderId2)' }
@@ -105,8 +105,7 @@ Feature: Check opening an order links to the right instance based on the identif
     And request setting
     When method PUT
     Then status 204
-    * def v = call pause 61000
-    * configure headers = headersUser
+    * configure headers = headersUserBypassCache
 
     # Create Third Order And Verify Instance Matching Re-Enabled
     * def v = call createOrder { 'id': '#(orderId3)' }


### PR DESCRIPTION
## Purpose
Use bypath cache feature

Use cache TTL the same as in mod-orders-storage
https://folio-org.atlassian.net/browse/MODORDERS-1462 
Related PR: https://github.com/folio-org/mod-orders/pull/1337

<img width="1508" height="433" alt="image" src="https://github.com/user-attachments/assets/51d7d19a-4ece-4535-9b73-6048889aa5e7" />

## Approach
_How does this change fulfill the purpose?_

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
