### PR TITLE
FAT-26740: Wait longer for mod-scheduler kafka events to arrive

### DIFF
--- a/mod-scheduler/src/main/resources/eureka/mod-scheduler/features/system-timers.feature
+++ b/mod-scheduler/src/main/resources/eureka/mod-scheduler/features/system-timers.feature
@@ -72,7 +72,7 @@ Feature: scheduler system timers
 
   @Positive
   Scenario: verify mod-users scheduled system timers are created during entitlement
-    * configure retry = { count: 100, interval: 5000 }
+    * configure retry = { count: 40, interval: 20000 }
     Given path 'scheduler/timers'
     And param limit = 500
     And retry until responseStatus == 200 && karate.filter(response.timerDescriptors, timer => timer.moduleName == 'mod-users').length >= 3


### PR DESCRIPTION
## Purpose
_Describe the purpose of the pull request._

## Approach
_How does this change fulfill the purpose?_

### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
