### PR TITLE
Bump thymeleaf from 3.1.4 to 3.1.5 fixing CVE-2026-41901

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
     <dependency>
       <groupId>org.thymeleaf</groupId>
       <artifactId>thymeleaf</artifactId>
-      <version>3.1.4.RELEASE</version>
+      <version>3.1.5.RELEASE</version>
     </dependency>
     <dependency>
       <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
## Purpose
Fix CVE-2026-41901 https://github.com/thymeleaf/thymeleaf/security/advisories/GHSA-c9ph-gxww-7744 Improper recognition of unauthorized syntax patterns in sandboxed Thymeleaf expressions

## Approach
Bump thymeleaf version in pom.xml.