### PR TITLE
Wait for locations index before running mod-gobi tests

### DIFF
--- a/acquisitions/src/main/resources/global/variables.feature
+++ b/acquisitions/src/main/resources/global/variables.feature
@@ -42,6 +42,7 @@ Feature: Global variables
     * def globalLocationsId = 'b32c5ce2-6738-42db-a291-2796b1c3c4c6'
     * def globalLocationsId2 = 'b32c5ce2-6738-42db-a291-2796b1c3c4c8'
     * def globalLocationsId3 = 'b32c5ce2-6738-42db-a291-2796b1c3c4c9'
+    * def globalLocationCodes = ['LOC1', 'LOC2', 'LOC3', 'LOC4']
     * def globalInstanceId1 = "d6635cf1-b775-46ac-94e5-adaffee111cd"
     * def globalHoldingId1 = "59e2c91d-d1dd-4e1a-bbeb-67e8b4dcd111"
     * def globalHoldingId2 = "59e2c91d-d1dd-4e1a-bbeb-67e8b4dcd222"

--- a/acquisitions/src/main/resources/thunderjet/mod-gobi/init-gobi.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-gobi/init-gobi.feature
@@ -95,11 +95,11 @@ Feature: Initialize mod-gobi integration tests
   Scenario: Wait for consortium-locations index to catch up with seeded locations
     * call login testAdmin
     * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
-    * def seededCodes = ['LOC1', 'LOC2', 'LOC3', 'LOC4']
+    * callonce variables
     * configure retry = { count: 10, interval: 2000 }
     Given path 'search/consortium/locations'
     And param limit = 10000
     And headers headersAdmin
-    And retry until karate.filter(response.locations || [], function(x){ return seededCodes.indexOf(x.code) != -1 }).length == seededCodes.length
+    And retry until karate.filter(response.locations || [], function(x){ return globalLocationCodes.indexOf(x.code) != -1 }).length == globalLocationCodes.length
     When method GET
     Then status 200

--- a/acquisitions/src/main/resources/thunderjet/mod-gobi/init-gobi.feature
+++ b/acquisitions/src/main/resources/thunderjet/mod-gobi/init-gobi.feature
@@ -78,6 +78,7 @@ Feature: Initialize mod-gobi integration tests
       | 'orders-storage.settings.item.put'                            |
       | 'tenant-addresses.item.post'                                  |
       | 'tenant-addresses.item.delete'                                |
+      | 'consortium-search.locations.collection.get'                  |
 
   Scenario: Create tenant and test user
     * call read('classpath:common/eureka/setup-users.feature')
@@ -90,3 +91,15 @@ Feature: Initialize mod-gobi integration tests
     * callonce read('classpath:global/finances.feature')
     * callonce read('classpath:global/inventory.feature')
     * callonce read('classpath:global/organizations.feature')
+
+  Scenario: Wait for consortium-locations index to catch up with seeded locations
+    * call login testAdmin
+    * def headersAdmin = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json, text/plain', 'x-okapi-tenant': '#(testTenant)' }
+    * def seededCodes = ['LOC1', 'LOC2', 'LOC3', 'LOC4']
+    * configure retry = { count: 10, interval: 2000 }
+    Given path 'search/consortium/locations'
+    And param limit = 10000
+    And headers headersAdmin
+    And retry until karate.filter(response.locations || [], function(x){ return seededCodes.indexOf(x.code) != -1 }).length == seededCodes.length
+    When method GET
+    Then status 200


### PR DESCRIPTION
## Purpose
The recent Karate run was failing with: https://jenkins.ci.folio.org/job/folioScheduledTesting/job/runNightlyKarateEurekaTests/892/testReport/thunderjet.mod-gobi.features/receipt-not-required-open-order-independent-workflow/Receipt_Not_Required_Forces_Independent_Receiving_Workflow_For_Open_Order/

It seems to be flaky rather than consistently failing. Based on the history, it fails approximately once every ~10-15 runs.
<img width="1365" height="541" alt="image" src="https://github.com/user-attachments/assets/472067d2-21ba-41b6-8307-db8f38337b43" />


## Approach
Wait for the locations index to be ready before running the mod-gobi tests. This ensures that the locations lookup does not return null and prevents the validation failure from being raised.

<img width="1895" height="328" alt="image" src="https://github.com/user-attachments/assets/b6813bc0-c0f9-458e-ba79-838fe1ed661a" />


### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
