### PR TITLE
THUN-116. Fix in-reach tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
       <dependency>
         <groupId>io.netty</groupId>
         <artifactId>netty-bom</artifactId>
-        <version>4.1.135.Final</version>
+        <version>4.2.6.Final</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
 ### Problem                                 
  `mod-inn-reach` and `edge-inn-reach` karate tests fail on `karate.start(...)` with:                                                                                                                                              
  Could not initialize class com.linecorp.armeria.server.ServerBuilder                                                                                                                                                             
    at com.linecorp.armeria.server.Server.builder(Server.java:117)                                                                                                                                                                 
    at com.intuit.karate.core.MockServer$Builder.build(MockServer.java:127)
  These are the only two modules that spin up an in-process Armeria mock server, so no other module is affected.                                                                                                                   
                  
  ### Root cause
  `karate 1.5.2` pulls in `armeria 1.33.4`, which is built against **Netty 4.2.6.Final**. The parent `pom.xml` was pinning `netty-bom` to `4.1.135.Final`, downgrading every Netty artifact on the classpath. Armeria 1.33.4's
  `ServerBuilder` references symbols that only exist in Netty 4.2, so its static initializer throws at class-load time.

  ### Fix
  Bump `netty-bom` from `4.1.135.Final` → `4.2.6.Final` in `pom.xml` so the Netty version on the classpath matches what Armeria 1.33.4 expects. Netty 4.2 is the current release line and carries every security fix that was in
  4.1.135.

  ### Verification
  - `mvn dependency:tree -pl mod-inn-reach -Dincludes=io.netty` — every artifact resolves to `4.2.6.Final`.
  - Class-load smoke test via jshell:
    Class.forName("com.linecorp.armeria.server.ServerBuilder")
  Returns `STATIC INIT OK`; Armeria logs `Using Netty 4.2.6.Final`.

  ### Scope
  Single-file change: `pom.xml`.
