### PR TITLE
FAT-27514: increase retry interval for data import get job execution

### DIFF
--- a/data-import/src/main/resources/folijet/data-import/global/get-completed-job-execution-for-key.feature
+++ b/data-import/src/main/resources/folijet/data-import/global/get-completed-job-execution-for-key.feature
@@ -4,7 +4,7 @@ Feature: Get job execution by S3 key with retries (maps to job execution)
     * call login testUser
     * def headersUser = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'x-okapi-tenant': '#(testTenant)', 'Accept': '*/*'  }
     * url baseUrl
-    * configure retry = { interval: 3000, count: 30 }
+    * configure retry = { interval: 10000, count: 30 }
 
   @getJobWhenJobStatusCompleted
   Scenario: wait until job status will be 'completed'


### PR DESCRIPTION
## Purpose
Fix timeout in FAT-21038 scenario
[FAT-27514](https://folio-org.atlassian.net/browse/FAT-27514)

## Approach
Since tests in master and release branch are the same, seams like slower environment is used for release tests.
Increase retry interval for data import get job execution