### PR TITLE
FAT-28505: Update profile settings tests to match latest implementation

### DIFF
--- a/mod-linked-data/src/main/resources/citation/mod-linked-data/features/profiles/profile-settings.feature
+++ b/mod-linked-data/src/main/resources/citation/mod-linked-data/features/profiles/profile-settings.feature
@@ -8,33 +8,35 @@ Feature: Get and set profile settings
     * configure headers = testUserHeaders
 
   @Positive
-  Scenario: Get default profile settings returns inactive response when no settings stored
-    Given path 'linked-data/profile/settings/3'
+  Scenario: Get default profile settings returns empty array when no settings stored
+    Given path 'linked-data/profile/3/settings'
     When method GET
     Then status 200
 
-    * match response.profileId == 3
-    * match response.active == false
-    * match response.children == '#notpresent'
+    * match response == []
 
   @Positive
   Scenario: Set profile settings and verify they are returned on get
     * def monographProfileId = 3
-    * def settingsRequest = { "active": true, "children": [{ "id": "ld:Instance:Title", "visible": true, "order": 1 }] }
+    * def settingsRequest = { "active": true, "name": "my settings name", "children": [{ "id": "ld:Instance:Title", "visible": true, "order": 1 }] }
 
     # Set profile settings
-    Given path 'linked-data/profile/settings/' + monographProfileId
+    Given path 'linked-data/profile/' + monographProfileId + '/settings'
     And request settingsRequest
     When method POST
-    Then status 204
+    Then status 201
+    And match $.id == '#present'
+    * def profileSettingsId = $.id
 
     # Get profile settings and verify they are returned
-    Given path 'linked-data/profile/settings/' + monographProfileId
+    Given path 'linked-data/profile/' + monographProfileId + '/settings/' + profileSettingsId
     When method GET
     Then status 200
 
+    * match response.id == profileSettingsId
     * match response.profileId == monographProfileId
     * match response.active == true
+    * match response.name == 'my settings name'
 
     * def titleChild = karate.filter(response.children, function(x){ return x.id == 'ld:Instance:Title' })[0]
     * match titleChild.visible == true


### PR DESCRIPTION
## Purpose

After releasing v2.0.5 of app-linked-data, Trillium tests for mod-linked-data need to be updated in order to avoid failures from running old tests against an old API.

https://folio-org.atlassian.net/browse/FAT-28505

## Approach

Cherry pick FAT-27181 changes, see #2490
