### PR TITLE
FAT-28505: Align mod-linked-data userPermissions with module permissions

### DIFF
--- a/mod-linked-data/src/main/resources/citation/mod-linked-data/linked-data-junit.feature
+++ b/mod-linked-data/src/main/resources/citation/mod-linked-data/linked-data-junit.feature
@@ -45,6 +45,9 @@ Feature: mod-linked-data integration tests
       | 'linked-data.profiles.preferred.delete'                        |
       | 'linked-data.profiles.settings.get'                            |
       | 'linked-data.profiles.settings.post'                           |
+      | 'linked-data.profiles.settings.put'                            |
+      | 'linked-data.profiles.settings.delete'                         |
+      | 'linked-data.profiles.settings.list.get'                       |
       | 'linked-data.authority-assignment-check.post'                  |
       | 'linked-data.vocabularies.item.get'                            |
       | 'linked-data.batch.graph.cleaning.post'                        |


### PR DESCRIPTION
## Purpose

Permissions clean up following #2543.

## Approach

Adds permissions introduced in latest mod-linked-data release and present in folio-integration-tests master branch.
