### PR TITLE
MODCONSKC-118 - self endpoint test

### DIFF
--- a/mod-consortia/src/main/resources/thunderjet/mod-consortia/consortia-junit.feature
+++ b/mod-consortia/src/main/resources/thunderjet/mod-consortia/consortia-junit.feature
@@ -137,11 +137,8 @@ Feature: mod-consortia-keycloak integration tests
   Scenario: User-Tenant associations api tests
     * call read('features/user-tenant-associations.feature')
 
-  Scenario: verify users with shadow or patron types not processed by consortia pipeline
-    * call read('features/consortia-skip-not-required-user-types.feature')
-
-  Scenario: verify user update scenarios
-    * call read('features/consortia-user-update.feature')
+  Scenario: Consortia _self endpoint access control tests
+    * call read('features/consortia-self.feature')
 
   Scenario: verify user type update scenarios
     * call read('features/consortia-user-type-update.feature')

--- a/mod-consortia/src/main/resources/thunderjet/mod-consortia/consortia-junit.feature
+++ b/mod-consortia/src/main/resources/thunderjet/mod-consortia/consortia-junit.feature
@@ -140,6 +140,12 @@ Feature: mod-consortia-keycloak integration tests
   Scenario: Consortia _self endpoint access control tests
     * call read('features/consortia-self.feature')
 
+  Scenario: verify users with shadow or patron types not processed by consortia pipeline
+    * call read('features/consortia-skip-not-required-user-types.feature')
+
+  Scenario: verify user update scenarios
+    * call read('features/consortia-user-update.feature')
+
   Scenario: verify user type update scenarios
     * call read('features/consortia-user-type-update.feature')
 

--- a/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/consortia-self.feature
+++ b/mod-consortia/src/main/resources/thunderjet/mod-consortia/features/consortia-self.feature
@@ -1,0 +1,23 @@
+Feature: Consortia _self endpoint access control tests
+
+  Background:
+    * url baseUrl
+    * call login consortiaAdmin
+    * def selfHeaders = { 'Content-Type': 'application/json', 'x-okapi-token': '#(okapitoken)', 'Accept': 'application/json' }
+
+  @Negative
+  Scenario: unauthenticated request to consortia _self returns 401
+    Given path 'consortia', consortiumId, '_self'
+    And header x-okapi-tenant = centralTenant
+    And header x-okapi-user-id = centralUser1.id
+    When method GET
+    Then status 401
+
+  @Positive
+  Scenario: authenticated request to consortia _self returns current user consortium context
+    * configure headers = selfHeaders
+    Given path 'consortia', consortiumId, '_self'
+    And header x-okapi-tenant = centralTenant
+    When method GET
+    Then status 200
+    And match response.userTenants != null


### PR DESCRIPTION
## Purpose

  The GET /consortia/{consortiumId}/_self endpoint in mod-consortia-keycloak is being updated to declare permissionsRequired: ["*"] in its module descriptor, requiring a valid access token from all callers. This PR adds integration test coverage to verify that unauthenticated requests are rejected with 401, and that authenticated requests continue to return the caller's consortium context.

  Jira: https://folio-org.atlassian.net/browse/MODCONSKC-118

## Approach

  A new consortia-self.feature is added with a @Negative scenario that sends a request with only x-okapi-tenant and x-okapi-user-id headers (no token) and asserts status 401, and a @Positive scenario that uses a valid consortiaAdmin token and asserts status 200 with a non-null userTenants collection in the response.
 The feature is registered in consortia-junit.feature immediately after the user-tenant-associations  block so full consortium context is established before the positive scenario runs.
### TODOS and Open Questions
- [ ] Use GitHub checklists. When solved, check the box and explain the answer.

### Learning
_Describe the research stage. Add links to blog posts, patterns, libraries or addons used to solve this problem._
